### PR TITLE
fix(ui): give brand avatars a light backdrop for transparent logos

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/layout.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/layout.tsx
@@ -47,8 +47,12 @@ export default function BrandDetailLayout({
         </Link>
         {brand && (
           <div className="flex items-center gap-3">
-            <Avatar className="h-9 w-9 rounded-lg">
-              <AvatarImage src={brand.logoUrl} alt={brand.name} />
+            <Avatar className="h-9 w-9 rounded-lg bg-zinc-50 dark:bg-zinc-100">
+              <AvatarImage
+                src={brand.logoUrl}
+                alt={brand.name}
+                className="object-contain p-1"
+              />
               <AvatarFallback className="rounded-lg bg-primary/10 text-primary text-sm font-semibold">
                 {initials}
               </AvatarFallback>

--- a/web/src/components/dashboard/brand-card.tsx
+++ b/web/src/components/dashboard/brand-card.tsx
@@ -178,8 +178,12 @@ export function BrandCard({ brand, summary }: BrandCardProps) {
       >
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(255,255,255,0.15),_transparent_60%)]" />
         <div className="relative flex items-start justify-between gap-3">
-          <Avatar className="h-14 w-14 rounded-xl ring-4 ring-background shadow-md">
-            <AvatarImage src={brand.logoUrl} alt={brand.name} />
+          <Avatar className="h-14 w-14 rounded-xl ring-4 ring-background shadow-md bg-zinc-50 dark:bg-zinc-100">
+            <AvatarImage
+              src={brand.logoUrl}
+              alt={brand.name}
+              className="object-contain p-1.5"
+            />
             <AvatarFallback className="rounded-xl bg-background text-foreground text-base font-bold">
               {initials}
             </AvatarFallback>

--- a/web/src/components/layout/brand-switcher.tsx
+++ b/web/src/components/layout/brand-switcher.tsx
@@ -62,8 +62,12 @@ export function BrandSwitcher({ collapsed = false }: BrandSwitcherProps) {
         )}
         aria-label={t("switchBrand")}
       >
-        <Avatar className="h-6 w-6 shrink-0 rounded-md">
-          <AvatarImage src={activeBrand?.logoUrl} alt={activeBrand?.name} />
+        <Avatar className="h-6 w-6 shrink-0 rounded-md bg-zinc-50 dark:bg-zinc-100">
+          <AvatarImage
+            src={activeBrand?.logoUrl}
+            alt={activeBrand?.name}
+            className="object-contain p-0.5"
+          />
           <AvatarFallback className="rounded-md bg-primary text-primary-foreground text-xs font-semibold">
             {activeBrand ? initials(activeBrand.name) : "?"}
           </AvatarFallback>
@@ -102,8 +106,12 @@ export function BrandSwitcher({ collapsed = false }: BrandSwitcherProps) {
               onClick={() => setActiveBrand(brand.id)}
               className="flex items-center gap-2"
             >
-              <Avatar className="h-5 w-5 shrink-0 rounded-md">
-                <AvatarImage src={brand.logoUrl} alt={brand.name} />
+              <Avatar className="h-5 w-5 shrink-0 rounded-md bg-zinc-50 dark:bg-zinc-100">
+                <AvatarImage
+                  src={brand.logoUrl}
+                  alt={brand.name}
+                  className="object-contain p-0.5"
+                />
                 <AvatarFallback className="rounded-md bg-primary/10 text-primary text-xs font-semibold">
                   {initials(brand.name)}
                 </AvatarFallback>

--- a/web/src/components/providers/brand-guard.tsx
+++ b/web/src/components/providers/brand-guard.tsx
@@ -135,8 +135,12 @@ function BrandSelector({
             onClick={() => onSelect(brand.id)}
           >
             <CardContent className="flex items-center gap-3 p-4">
-              <Avatar className="h-9 w-9 rounded-md">
-                <AvatarImage src={brand.logoUrl} alt={brand.name} />
+              <Avatar className="h-9 w-9 rounded-md bg-zinc-50 dark:bg-zinc-100">
+                <AvatarImage
+                  src={brand.logoUrl}
+                  alt={brand.name}
+                  className="object-contain p-1"
+                />
                 <AvatarFallback className="rounded-md bg-primary text-primary-foreground text-sm font-semibold">
                   {initials(brand.name)}
                 </AvatarFallback>


### PR DESCRIPTION
Many brand favicons fetched via getFaviconUrl arrive as transparent
PNGs. Without a backdrop, the transparent areas blended into whatever
sits behind the avatar (gradient hero, sidebar bg, etc.) and the logo
looked broken or invisible.

Adds a soft light bg (zinc-50 light / zinc-100 dark) and applies
object-contain + small padding to the AvatarImage so the logo sits
nicely centered with consistent breathing room across:

  - Sidebar BrandSwitcher trigger and dropdown items
  - Brand detail layout header
  - Brand cards hero on /dashboard/brands
  - BrandGuard's brand picker fallback

Fallback initials retain their existing primary-tinted background.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
