### PR TITLE
chore(seo): block search indexing on the app subdomain

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -30,6 +30,16 @@ export const metadata: Metadata = {
   },
   description:
     "Monitor, analyze, and optimize your brand's visibility in AI-powered search engines.",
+  // The product app at app.ansvisor.com should not appear in search results;
+  // ansvisor.com (the Webflow marketing site) is the indexable surface.
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
 };
 
 export default function RootLayout({

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * Block search engines from indexing the application subdomain.
+ *
+ * The marketing site at `ansvisor.com` is hosted separately (Webflow) and
+ * is the surface that should be indexed. The Next.js app at `app.ansvisor.com`
+ * is purely the authenticated product UI and provides no value in search.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        disallow: '/',
+      },
+    ],
+  };
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -4,5 +4,16 @@
       "path": "/api/cron/daily-tracking",
       "schedule": "45 15 * * *"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow, noarchive, nosnippet"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
The product app is moving to app.ansvisor.com while the marketing site
is hosted separately on Webflow at ansvisor.com. Authenticated dashboard
pages should never appear in search results, both because they leak
nothing useful to crawlers and because surfacing /sign-in / /dashboard
URLs in SERPs hurts the marketing funnel.

Three layers of opt-out, applied together so any one is enough:

  1. Next.js robots.ts emits a Disallow: / robots.txt for *all bots
  2. Root layout metadata sets robots.index/follow = false (and the
     same for googleBot specifically), which renders
     <meta name="robots" content="noindex, nofollow"> on every page
  3. Vercel.json adds X-Robots-Tag: noindex, nofollow, noarchive,
     nosnippet as a response header, the strongest signal because it
     also covers non-HTML resources

Marketing site at ansvisor.com is unaffected — it's served from a
different origin (Webflow) and keeps default indexing behavior.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
