### PR TITLE
fix(stripe): read current_period_end from subscription item, not subscription

### DIFF
--- a/web/src/app/api/stripe/subscription/route.ts
+++ b/web/src/app/api/stripe/subscription/route.ts
@@ -3,14 +3,44 @@ import { createClient } from '@/lib/supabase/server';
 import { stripe, PRICE_IDS } from '@/lib/stripe';
 import { SUBSCRIBABLE_PLANS } from '@/config/plans';
 
+type SubscriptionItem = {
+  id: string;
+  current_period_end?: number;
+  price: {
+    unit_amount: number | null;
+    recurring: { interval: string } | null;
+  };
+};
+
 type SubscriptionRaw = {
   id: string;
   status: string;
-  current_period_end: number;
   cancel_at_period_end: boolean;
   metadata: Record<string, string>;
-  items: { data: Array<{ id: string; price: { unit_amount: number | null; recurring: { interval: string } | null } }> };
+  items: { data: SubscriptionItem[] };
+  // Some older API versions still return this on the subscription itself.
+  // Newer versions (2025-03-31+) moved it to subscription items.
+  current_period_end?: number;
 };
+
+/**
+ * Stripe API 2025-03-31 moved `current_period_end` from the subscription
+ * onto each subscription item. Read item-level first, fall back to the
+ * subscription-level for older API versions, and return null if neither is
+ * present (so callers can skip emitting an Invalid Date).
+ */
+function getCurrentPeriodEndIso(sub: SubscriptionRaw): string | null {
+  const itemEnd = sub.items?.data?.[0]?.current_period_end;
+  const subEnd = sub.current_period_end;
+  const epochSeconds =
+    typeof itemEnd === 'number'
+      ? itemEnd
+      : typeof subEnd === 'number'
+        ? subEnd
+        : null;
+  if (epochSeconds == null) return null;
+  return new Date(epochSeconds * 1000).toISOString();
+}
 
 async function getOrgStripeIds() {
   const supabase = await createClient();
@@ -66,7 +96,7 @@ export async function GET() {
     return NextResponse.json({
       planId: org.plan ?? 'starter',
       status: sub.status,
-      currentPeriodEnd: new Date(sub.current_period_end * 1000).toISOString(),
+      currentPeriodEnd: getCurrentPeriodEndIso(sub),
       cancelAtPeriodEnd: sub.cancel_at_period_end,
       priceAmount: price?.unit_amount ? price.unit_amount / 100 : null,
       interval: price?.recurring?.interval ?? null,
@@ -108,7 +138,7 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({
         status: updated.status,
         cancelAtPeriodEnd: false,
-        currentPeriodEnd: new Date(updated.current_period_end * 1000).toISOString(),
+        currentPeriodEnd: getCurrentPeriodEndIso(updated),
       });
     }
 
@@ -151,7 +181,7 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({
       planId: newPlanId,
       status: updated.status,
-      currentPeriodEnd: new Date(updated.current_period_end * 1000).toISOString(),
+      currentPeriodEnd: getCurrentPeriodEndIso(updated),
       cancelAtPeriodEnd: updated.cancel_at_period_end,
       priceAmount: newPrice?.unit_amount ? newPrice.unit_amount / 100 : null,
       interval: newPrice?.recurring?.interval ?? null,
@@ -184,7 +214,7 @@ export async function DELETE() {
 
     return NextResponse.json({
       cancelAtPeriodEnd: true,
-      currentPeriodEnd: new Date(updated.current_period_end * 1000).toISOString(),
+      currentPeriodEnd: getCurrentPeriodEndIso(updated),
     });
   } catch (err) {
     console.error('[stripe/subscription] DELETE error:', err);

--- a/web/src/app/api/stripe/webhook/route.ts
+++ b/web/src/app/api/stripe/webhook/route.ts
@@ -71,12 +71,27 @@ export async function POST(req: NextRequest) {
             : subscription.customer?.id;
 
         if (customerId) {
+          // Stripe API 2025-03-31 moved current_period_end to the item level.
+          // Read item-level first, fall back to subscription-level for older
+          // API versions, and skip the field entirely if neither is present.
+          const subItems = (
+            subscription as unknown as {
+              items?: { data?: Array<{ current_period_end?: number }> };
+              current_period_end?: number;
+            }
+          );
+          const epochSeconds =
+            subItems.items?.data?.[0]?.current_period_end ??
+            subItems.current_period_end;
+
           const updates: Record<string, unknown> = {
             subscription_status: subscription.status,
-            subscription_ends_at: new Date(
-              (subscription as unknown as { current_period_end: number }).current_period_end * 1000,
-            ).toISOString(),
           };
+          if (typeof epochSeconds === 'number') {
+            updates.subscription_ends_at = new Date(
+              epochSeconds * 1000,
+            ).toISOString();
+          }
 
           // Update plan if metadata has plan_id
           if (subscription.metadata.plan_id) {


### PR DESCRIPTION
Stripe API 2025-03-31 (and the matching SDK 22.x) removed
current_period_end from the Subscription object and moved it onto each
SubscriptionItem so subscriptions with multi-billing-cycle items make
sense. Our code still read sub.current_period_end, which is undefined
under the new shape — `new Date(undefined * 1000).toISOString()` then
threw RangeError: Invalid time value, surfacing as a 500 on
GET /api/stripe/subscription and breaking the Settings → Billing page.

Adds a getCurrentPeriodEndIso() helper that reads item-level first and
falls back to the subscription-level field for older API versions.
Returns null when neither is present so the response stays valid JSON
instead of crashing the request. The webhook handler for
customer.subscription.updated gets the same treatment.
