### PR TITLE
feat(auth): show brand logo next to wordmark in marketing header

### DIFF
--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
@@ -10,6 +11,22 @@ export function MarketingHeader() {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between">
         <Link href="/sign-in" className="flex items-center gap-2">
+          <Image
+            src="/logo_light.svg"
+            alt=""
+            width={28}
+            height={28}
+            className="h-7 w-7 shrink-0 dark:hidden"
+            priority
+          />
+          <Image
+            src="/logo_dark.svg"
+            alt=""
+            width={28}
+            height={28}
+            className="hidden h-7 w-7 shrink-0 dark:block"
+            priority
+          />
           <span className="text-xl font-bold tracking-tight">
             {siteConfig.name}
           </span>


### PR DESCRIPTION
Sign-in / sign-up / pricing pages share a single header that previously
showed only the "Ansvisor" wordmark. Adds the SVG logo (theme-aware via
two images + Tailwind dark: visibility classes — same pattern used by
the dashboard sidebar) so the auth surface looks branded instead of
text-only. Logo files come straight from public/ — no asset pipeline
changes.
