### PR TITLE
docs: point sign-up links at the app subdomain

### DIFF
--- a/docs/guides/add-your-first-brand.mdx
+++ b/docs/guides/add-your-first-brand.mdx
@@ -5,7 +5,7 @@ description: 'Step-by-step walkthrough of brand onboarding.'
 
 ## Prerequisites
 
-- A logged-in Ansvisor account ([cloud](https://ansvisor.com/sign-up) or [self-hosted](/self-host/docker-compose))
+- A logged-in Ansvisor account ([cloud](https://app.ansvisor.com/sign-up) or [self-hosted](/self-host/docker-compose))
 - 5–10 minutes
 - The website URL of the brand you want to track
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -11,8 +11,8 @@ description: "Track your first brand in under 10 minutes — cloud or self-hoste
 The fastest way to start. No infrastructure, no env files.
 
 <Steps>
-  <Step title="Sign up at ansvisor.com">
-    Create an account at [ansvisor.com/sign-up](https://ansvisor.com/sign-up). All paid plans include a 7-day free trial.
+  <Step title="Sign up for the cloud">
+    Create an account at [app.ansvisor.com/sign-up](https://app.ansvisor.com/sign-up). All paid plans include a 7-day free trial.
   </Step>
   <Step title="Add your first brand">
     On the onboarding screen, enter your brand name, primary domain, and industry. Ansvisor auto-suggests starter prompts based on your industry — you can edit them or accept all.


### PR DESCRIPTION
The product app moved to app.ansvisor.com while ansvisor.com is the
Webflow marketing site. Existing docs linked sign-up at ansvisor.com,
which would 404 once the marketing site is published. Two affected
spots:

  - docs/quickstart.mdx — step title + body
  - docs/guides/add-your-first-brand.mdx — prerequisites bullet

Other ansvisor.com mentions (Try the Cloud card, footer link, FAQ
"powers ansvisor.com") still point at the marketing root on purpose.
