### PR TITLE
fix(auth): point Terms / Privacy links at the marketing site

### DIFF
--- a/web/src/components/auth/sign-up-form.tsx
+++ b/web/src/components/auth/sign-up-form.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 import { OAuthButtons } from "@/components/auth/oauth-buttons";
 import { Separator } from "@/components/ui/separator";
+import { siteConfig } from "@/config/site";
 
 export function SignUpForm() {
   const t = useTranslations("auth");
@@ -127,13 +128,23 @@ export function SignUpForm() {
 
       <p className="text-center text-xs text-muted-foreground">
         {t("termsAgreement")}{" "}
-        <Link href="/terms" className="underline underline-offset-4 hover:text-primary">
+        <a
+          href={siteConfig.legal.terms}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-4 hover:text-primary"
+        >
           {t("termsOfService")}
-        </Link>{" "}
+        </a>{" "}
         {t("and")}{" "}
-        <Link href="/privacy" className="underline underline-offset-4 hover:text-primary">
+        <a
+          href={siteConfig.legal.privacy}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-4 hover:text-primary"
+        >
           {t("privacyPolicy")}
-        </Link>
+        </a>
         .
       </p>
     </form>

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@/i18n/navigation";
 import { siteConfig } from "@/config/site";
 
 export function MarketingFooter() {
@@ -9,12 +8,22 @@ export function MarketingFooter() {
           &copy; {new Date().getFullYear()} {siteConfig.name}. Open source under MIT license.
         </p>
         <div className="flex items-center gap-4 text-sm text-muted-foreground">
-          <Link href="/terms" className="hover:text-foreground transition-colors">
+          <a
+            href={siteConfig.legal.terms}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
             Terms
-          </Link>
-          <Link href="/privacy" className="hover:text-foreground transition-colors">
+          </a>
+          <a
+            href={siteConfig.legal.privacy}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
             Privacy
-          </Link>
+          </a>
           <a
             href={siteConfig.links.github}
             target="_blank"

--- a/web/src/config/site.ts
+++ b/web/src/config/site.ts
@@ -3,10 +3,14 @@ export const siteConfig = {
   description:
     "Monitor, analyze, and optimize your brand's visibility in AI-powered search engines like ChatGPT, Perplexity, Gemini, and more.",
   url: "https://ansvisor.com",
-  ogImage: "https://ansvisor.com/og.jpg",
+  ogImage: "https://app.ansvisor.com/opengraph-image",
   links: {
-    github: "https://github.com/your-org/ansvisor",
+    github: "https://github.com/aeohub/ansvisor",
     docs: "https://docs.ansvisor.com",
+  },
+  legal: {
+    privacy: "https://www.ansvisor.com/privacy-policy",
+    terms: "https://www.ansvisor.com/terms-of-service",
   },
 } as const;
 


### PR DESCRIPTION
The sign-up form and marketing footer linked Terms and Privacy to
internal `/terms` and `/privacy` routes that have no page on the app —
clicking either 404'd. Both legal documents live on the Webflow
marketing site at www.ansvisor.com.

  - siteConfig now exposes a `legal.privacy` / `legal.terms` block
    pointing at the canonical www.ansvisor.com URLs, so the two
    targets are owned in one place.
  - sign-up-form.tsx and marketing-footer.tsx swap the i18n <Link>
    components for plain external <a target="_blank"> anchors that
    read from siteConfig.legal.
  - Bonus cleanup: siteConfig.links.github was still the
    your-org/ansvisor placeholder — corrected to aeohub/ansvisor.
