### PR TITLE
chore(cron): move daily-tracking schedule to 06:00 UTC

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/daily-tracking",
-      "schedule": "45 15 * * *"
+      "schedule": "0 6 * * *"
     }
   ],
   "headers": [


### PR DESCRIPTION
Previously the cron ran at 15:45 UTC (18:45 Europe/Istanbul), which
overlapped with peak European traffic and meant fresh data didn't land
until the evening. Move it to 06:00 UTC so tracking results are ready
by the start of the business day across most regions.
