### PR TITLE
fix(insights): collapse duplicate provider entries in the AI Model filter

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -769,7 +769,17 @@ function FilterBar({
           onValueChange={(v) => set({ model: !v || v === '__all__' ? '' : v })}
         >
           <SelectTrigger className="h-8 w-44 text-xs">
-            <SelectValue placeholder="All Platforms" />
+            <SelectValue placeholder="All Platforms">
+              {(value) => {
+                if (!value || value === '__all__') return 'All Platforms';
+                const firstSlug = String(value).split(',')[0];
+                return (
+                  MODEL_DISPLAY_NAME[firstSlug] ??
+                  PLATFORM_LABELS[firstSlug] ??
+                  getAIProviderDisplayName(resolveAIProvider(firstSlug))
+                );
+              }}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="__all__">All Platforms</SelectItem>

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -773,13 +773,17 @@ function FilterBar({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="__all__">All Platforms</SelectItem>
-            {availableModels.map((m) => (
-              <SelectItem key={m} value={m}>
-                {MODEL_DISPLAY_NAME[m] ??
-                  PLATFORM_LABELS[m] ??
-                  getAIProviderDisplayName(resolveAIProvider(m))}
-              </SelectItem>
-            ))}
+            {availableModels.map((m) => {
+              // m is a comma-separated slug list representing a provider family
+              const firstSlug = m.split(',')[0];
+              return (
+                <SelectItem key={m} value={m}>
+                  {MODEL_DISPLAY_NAME[firstSlug] ??
+                    PLATFORM_LABELS[firstSlug] ??
+                    getAIProviderDisplayName(resolveAIProvider(firstSlug))}
+                </SelectItem>
+              );
+            })}
           </SelectContent>
         </Select>
       </div>
@@ -1423,13 +1427,29 @@ export default function InsightsPage() {
               .filter(Boolean) as string[],
           ),
         ].sort();
-        const models = [
-          ...new Set(
-            resultsData.results
-              .map((r) => r.modelUsed)
-              .filter(Boolean) as string[],
-          ),
-        ].sort();
+        // Group raw model slugs by their resolved display name so different
+        // ChatGPT versions ("gpt-5-3-mini" + "gpt-5-5") collapse into one
+        // "ChatGPT" filter option. Stored as `slugA,slugB` so the server can
+        // filter the whole family with .in() via applyModelFilter().
+        const slugToLabel = new Map<string, string>();
+        for (const r of resultsData.results) {
+          const slug = r.modelUsed;
+          if (!slug || slugToLabel.has(slug)) continue;
+          const label =
+            MODEL_DISPLAY_NAME[slug] ??
+            PLATFORM_LABELS[slug] ??
+            getAIProviderDisplayName(resolveAIProvider(slug));
+          slugToLabel.set(slug, label);
+        }
+        const familyToSlugs = new Map<string, string[]>();
+        for (const [slug, label] of slugToLabel) {
+          const arr = familyToSlugs.get(label) ?? [];
+          arr.push(slug);
+          familyToSlugs.set(label, arr);
+        }
+        const models = Array.from(familyToSlugs.values())
+          .map((slugs) => slugs.sort().join(','))
+          .sort();
         setAvailableRegions((prev) =>
           [...new Set([...prev, ...regions])].sort((a, b) =>
             a.localeCompare(b),

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -9,6 +9,28 @@ import type {
   CompetitorMention,
 } from '@/types';
 
+/**
+ * Apply the `model` filter to a Supabase query against `prompt_results.model_used`.
+ *
+ * Accepts either a single slug ("gpt-5-5") or a comma-separated list
+ * ("gpt-5-5,gpt-5-3-mini,chatgpt-web") so callers can filter by a provider
+ * family without the UI having to enumerate every per-model row in the
+ * filter dropdown.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applyModelFilter<T extends { eq: any; in: any }>(
+  query: T,
+  model: string | undefined,
+): T {
+  if (!model) return query;
+  const list = model
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (list.length <= 1) return query.eq('model_used', list[0] ?? model);
+  return query.in('model_used', list);
+}
+
 function mapResultRow(row: Record<string, unknown>): PromptResult {
   return {
     id: row.id as string,
@@ -97,7 +119,7 @@ async function buildResultsQuery(
     .eq('brand_id', brandId);
 
   if (opts?.platform) query = query.eq('platform', opts.platform);
-  if (opts?.model) query = query.eq('model_used', opts.model);
+  query = applyModelFilter(query, opts?.model);
   if (opts?.region) query = query.eq('region', opts.region);
   if (opts?.dateFrom) query = query.gte('created_at', opts.dateFrom);
   if (opts?.dateTo) query = query.lte('created_at', opts.dateTo);
@@ -1309,7 +1331,7 @@ export async function getVisibilityTrend(
     .eq('brand_id', brandId)
     .order('created_at', { ascending: true });
 
-  if (opts?.model) query = query.eq('model_used', opts.model);
+  query = applyModelFilter(query, opts?.model);
   if (opts?.region) query = query.eq('region', opts.region);
   if (opts?.dateFrom) query = query.gte('created_at', opts.dateFrom);
   if (opts?.dateTo) query = query.lte('created_at', opts.dateTo);


### PR DESCRIPTION
AI engine vendors swap underlying model slugs between runs.
Each slug was landing in prompt_results.model_used as a distinct value,
and the Insights filter built its dropdown from a deduped Set of raw
slugs — so two "ChatGPT" rows showed up, and a third would appear the
moment gpt-5-6 ships.

Group the dropdown by resolved provider display name. Each option's
value is now a comma-separated list of every raw slug that maps to the
same family (e.g. "gpt-5-3-mini,gpt-5-5"). The label uses the family
display name once.

Server side, applyModelFilter() detects the comma list and switches
from .eq() to .in() on prompt_results.model_used so a single "ChatGPT"
selection still pulls runs from every underlying slug. Single-slug
callers stay on .eq() — backwards compatible.
