### PR TITLE
fix(insights): suppress error toasts on silent background refresh

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -1471,9 +1471,16 @@ export default function InsightsPage() {
           ),
         );
       } catch (err) {
-        toast.error(
-          err instanceof Error ? err.message : 'Failed to load insights',
-        );
+        // Silent refreshes fire every ~10s while a tracking job runs; a transient
+        // 5xx or network blip there shouldn't pop a red toast — the next poll
+        // will retry and the user sees nothing.
+        if (!silent) {
+          toast.error(
+            err instanceof Error ? err.message : 'Failed to load insights',
+          );
+        } else {
+          console.warn('[insights] silent refresh failed', err);
+        }
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
## Summary
- The insights page polls every ~10s while a tracking job is running so new results appear progressively.
- A transient 5xx / network blip during a silent background refresh was popping a red error toast even though the next poll would retry and the user would never have noticed the failure.
- Silent refreshes now log to console only; toasts still fire for foreground calls (initial load, filter change, post-stop refresh's user-triggered path).

## Test plan
- [x] Start a tracking job, confirm no red toasts appear while it runs.
- [x] Trigger a real foreground failure (offline + filter change) and confirm the toast still appears.