### PR TITLE
fix(ui): change competitor avatar background from muted to white

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -494,10 +494,10 @@ function CompetitorsTab({ brandId }: { brandId: string }) {
                       <img
                         src={getFaviconUrl(c.domain, 64)}
                         alt={c.name}
-                        className="h-8 w-8 shrink-0 rounded-full bg-muted object-contain"
+                        className="h-8 w-8 shrink-0 rounded-full bg-white object-contain"
                       />
                     ) : (
-                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-bold">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-xs font-bold">
                         {c.name.charAt(0).toUpperCase()}
                       </div>
                     )}

--- a/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
@@ -254,7 +254,7 @@ function NoBrandSelected() {
       </div>
       <Card>
         <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted mb-4">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white mb-4">
             <AlertCircle className="h-7 w-7 text-muted-foreground" />
           </div>
           <h3 className="text-lg font-semibold">{t("noBrandTitle")}</h3>
@@ -274,7 +274,7 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
   return (
     <Card>
       <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted mb-4">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white mb-4">
           <Users className="h-7 w-7 text-muted-foreground" />
         </div>
         <h3 className="text-lg font-semibold">{t("emptyTitle")}</h3>


### PR DESCRIPTION
## Summary
Fixes #18 — Competitor avatars with transparent dark logos become invisible against the dark `bg-muted` background.

## Root Cause
The competitor avatar elements in brand settings and competitors page use Tailwind's `bg-muted` class, which renders as a dark gray. Favicons are conventionally designed for white backgrounds, so transparent dark logos (common for monochrome brand marks like Vercel, Linear, GitHub) blend into the background and appear invisible.

## Fix
Changed `bg-muted` → `bg-white` on avatar-related elements in two files:
- `settings/page.tsx` (+2 -2): Competitor favicon `<img>` and fallback `<div>` (lines 497, 500)
- `competitors/page.tsx` (+2 -2): Empty-state placeholder avatar containers (lines 257, 277)

Intentionally preserved `bg-muted` on non-avatar elements (code tags, progress bars, hover states).

## Changes
| File | + | - |
|------|---|---|
| `web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx` | 2 | 2 |
| `web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx` | 2 | 2 |

## Testing
1. Verified the exact class strings exist in source before patching
2. Confirmed no remaining avatar-related `bg-muted` in the modified components
3. Other `bg-muted` uses (progress bars `h-1.5`, code tags, hover states) are untouched