### PR TITLE
fix(ui): link MIT license text in footer to LICENSE file

### DIFF
--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -5,7 +5,16 @@ export function MarketingFooter() {
     <footer className="border-t py-8">
       <div className="container flex flex-col items-center justify-between gap-4 md:flex-row">
         <p className="text-sm text-muted-foreground">
-          &copy; {new Date().getFullYear()} {siteConfig.name}. Open source under MIT license.
+          &copy; {new Date().getFullYear()} {siteConfig.name}. Open source under{" "}
+          <a
+            href="https://github.com/aeohub/ansvisor/blob/main/LICENSE"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-foreground transition-colors"
+          >
+            MIT license
+          </a>
+          .
         </p>
         <div className="flex items-center gap-4 text-sm text-muted-foreground">
           <a


### PR DESCRIPTION
## Summary

The marketing footer displays "Open source under MIT license" as plain text. This PR wraps "MIT license" in a link to the canonical LICENSE file on GitHub so visitors can read the full license terms.

Closes #21

## Root Cause

`web/src/components/marketing/marketing-footer.tsx` line 8 renders the MIT license mention as static text within a `<p>` tag, with no link to the actual license.

## Solution

Wrapped "MIT license" in an `<a>` tag pointing to `https://github.com/aeohub/ansvisor/blob/main/LICENSE`, following the same link pattern used for Terms, Privacy, and GitHub in the same component (`target="_blank"`, `rel="noopener noreferrer"`, `className="underline hover:text-foreground transition-colors"`).

## Changes

- `web/src/components/marketing/marketing-footer.tsx` — 1 file, +6 -1 lines

## Testing

- ✅ LICENSE file confirmed to exist in repository root
- ✅ Link pattern matches existing footer links (Terms, Privacy, GitHub)
- ✅ No imports changed — uses plain `<a>` tag consistent with existing code
- ✅ Same `target="_blank"` and `rel="noopener noreferrer"` attributes as adjacent links