### PR TITLE
feat(skills): ship Ansvisor AEO Coach in MCP + standalone flavours

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ ansvisor/
 What we're planning to build next. React with 👍 on the linked issue (or open a new one) to push something up the list. PRs welcome on any of these.
 
 - [x] **Ansvisor MCP server** — expose insights through a Model Context Protocol server so Claude Desktop, Claude Code, Cursor, Zed, and any other MCP client can query your brand visibility directly. Remote (Streamable HTTP) endpoint at `/api/mcp` — zero install, paste a URL + API key into your client and you're done. Ships with `list_brands` and `get_visibility_summary` today; more tools landing as we go.
-- [ ] **Claude Code skills** — opinionated workflows on top of the MCP server (page-audit, rewrite-for-aeo, check-mentions) plus a freeform `/ansvisor:ask` for conversational queries
+- [x] **Anthropic Skills** — opinionated AEO knowledge that turns Claude into an analyst on your account. Ships in two flavours: an MCP-tool flavour for Claude Desktop / Claude Code / Cursor / Zed, and a standalone REST flavour for claude.ai web (no MCP required). First skill (`ansvisor-aeo-coach`) is live — see [`skills/`](./skills). More (page-audit, rewrite-for-aeo, content-brief) on the way.
 - [ ] **In-product conversational AI assistant** — chat with your dashboard about visibility trends, competitor moves, and content gaps without leaving the page
 - [ ] **ScrapeLLM integration** — add ScrapeLLM as an alternative scraping backend alongside Cloro for users who prefer it or need a fallback
 - [ ] **PostHog integration** — pipe AI-referred sessions and tracking events into PostHog for users already running it as their product analytics layer

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,126 @@
+# Ansvisor Skills
+
+A collection of opinionated [Anthropic Skills](https://docs.anthropic.com/claude/docs/skills)
+that turn Claude into an AEO analyst with live access to your Ansvisor
+account.
+
+Most skills come in **two flavours**: one that talks to the
+[Ansvisor MCP server](../docs/guides/mcp-server.mdx) (cleaner UX in
+clients that support it) and one that calls the REST API directly with
+code execution (works anywhere). Pick the flavour that matches your
+Claude client — see the table below.
+
+Without a skill, Claude can still hit our tools/API if you tell it
+how — it'll just answer generically. With one of these installed, it
+behaves like an AEO analyst who's been on your account for six months.
+
+## Skills in this repo
+
+| Skill | Flavour | What it's for |
+| --- | --- | --- |
+| [`ansvisor-aeo-coach`](./ansvisor-aeo-coach) | **MCP (preferred)** | Brand snapshots, visibility deep-dives, competitor watch. Use this when your client (Claude Desktop, Claude Code, Cursor, Zed) is connected to the Ansvisor MCP server. |
+| [`ansvisor-aeo-coach-standalone`](./ansvisor-aeo-coach-standalone) | **REST (fallback)** | Same skill, no MCP needed. Use this when you're on claude.ai web without a Connector, or any surface where setting up MCP isn't an option. |
+
+## Which flavour should I install?
+
+| Your client | Recommended |
+| --- | --- |
+| Claude Desktop | **MCP** — install the [MCP server](../docs/guides/mcp-server.mdx) once, then `ansvisor-aeo-coach` |
+| Claude Code | **MCP** — same as above |
+| Cursor / Zed / other MCP-aware tools | **MCP** — it's their native primitive |
+| claude.ai web with the Ansvisor Connector configured | **MCP** |
+| claude.ai web without a Connector | **Standalone** — single install, no extra setup |
+| Anywhere else with Skills + code execution | **Standalone** |
+
+Both flavours hit the same data, format the same way, and share the
+same `references/` knowledge files. The difference is just _how_ Claude
+fetches numbers — typed tool calls vs. inline Python HTTP requests.
+
+## Prerequisites
+
+You need an **Ansvisor API key** in either flavour:
+
+1. Open your Ansvisor dashboard → **Settings → API Keys**
+2. Click **New key**, give it a memorable name (e.g. _Claude — laptop_)
+3. Copy the token (`ans_...`). It's shown **once** — store it in your
+   password manager
+
+If you self-host Ansvisor, both flavours work against your own instance
+— you'll just provide a different base URL when prompted (MCP: in your
+client config; standalone: when the skill asks).
+
+## Install
+
+Skills are just markdown files — they work in any Claude surface that
+supports the Skills feature.
+
+### Claude.ai (web)
+
+1. Open <https://claude.ai/skills>
+2. Click **New Skill** → **Paste from markdown**
+3. Paste the contents of your chosen flavour's `SKILL.md`
+4. Save
+
+The first time you use the MCP flavour, you also need the **Ansvisor
+Connector** added to your Claude.ai account (see the MCP guide). The
+standalone flavour will ask you for your API key in the conversation
+itself.
+
+### Claude Code / Claude Desktop
+
+```bash
+git clone https://github.com/aeohub/ansvisor.git
+cp -r ansvisor/skills/ansvisor-aeo-coach ~/.claude/skills/   # MCP flavour
+# or
+cp -r ansvisor/skills/ansvisor-aeo-coach-standalone ~/.claude/skills/
+```
+
+Restart your Claude client and the skill is live. If you chose the MCP
+flavour, also configure the
+[Ansvisor MCP server](../docs/guides/mcp-server.mdx) in your client.
+
+## Use
+
+Once installed, just ask in plain English:
+
+- _"How is my brand doing this week?"_
+- _"Why did visibility drop on ChatGPT?"_
+- _"Who are my biggest competitors right now?"_
+- _"Give me a 30-second standup on the Acme brand."_
+
+Claude picks the right tools / endpoints, fills in filters, interprets
+the numbers, and answers with action items.
+
+## Contributing
+
+Got an idea for another skill? Open a PR with a new folder under
+`skills/`:
+
+```
+skills/
+  your-skill-name/
+    SKILL.md           # frontmatter + body
+    references/        # optional supporting docs
+```
+
+A few principles we follow:
+
+- **Skills layer knowledge, not data.** Data comes from the MCP server
+  or the matching REST endpoint. A skill's job is to know _when_ and
+  _how_ to use it.
+- **Be opinionated about output.** Marketers don't want a CSV dump —
+  they want a 3-line summary, a delta, and a suggested next step.
+- **Ship MCP and standalone flavours together when it makes sense.**
+  Users on different surfaces shouldn't have to fork the skill
+  themselves.
+- **Handle errors gracefully.** Missing tool / bad key / empty data →
+  tell the user, don't fabricate.
+- **Don't echo API keys.** In the standalone flavour, hold tokens in
+  execution memory and redact them in any output.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for branch naming, commit
+conventions, and PR workflow.
+
+## License
+
+[MIT](../LICENSE) — part of [Ansvisor](https://github.com/aeohub/ansvisor).

--- a/skills/ansvisor-aeo-coach-standalone/SKILL.md
+++ b/skills/ansvisor-aeo-coach-standalone/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: ansvisor-aeo-coach-standalone
+description: |
+  Standalone (no-MCP) version of the Ansvisor AEO Coach. Use this only
+  when the user's Claude client cannot connect to the Ansvisor MCP
+  server (e.g. claude.ai web without a Connector configured). Fetches
+  live data from the Ansvisor REST API directly with the user's API
+  key via code execution. For clients that support MCP (Claude
+  Desktop, Claude Code, Cursor, Zed), prefer the `ansvisor-aeo-coach`
+  skill — it's a cleaner UX because tool calls are first-class instead
+  of inline Python.
+---
+
+# Ansvisor AEO Coach — Standalone
+
+You are an AEO (Answer Engine Optimization) analyst working on the user's
+brand visibility inside AI search products. You have direct HTTP access
+to the user's Ansvisor account through their REST API.
+
+Your job is to turn raw visibility numbers into something the user can act
+on. A marketer asking _"how are we doing?"_ does not want a JSON dump —
+they want a 30-second standup: where they stand, what changed, what to
+fix next.
+
+## When to activate
+
+Activate this skill when the user asks anything in the shape of:
+
+- _"How is my brand doing?" / "Show me a snapshot."_
+- _"What's my visibility on ChatGPT this week?"_
+- _"Did anything change recently?" / "Why did visibility drop?"_
+- _"Who are my competitors right now?" / "How do we compare?"_
+- _"Give me a daily / weekly standup on `<brand name>`."_
+
+## Setup (first use)
+
+You need two things from the user, in this order:
+
+1. **API key** — a token starting with `ans_`. Tell them to grab one
+   from their Ansvisor dashboard: **Settings → API Keys → New key**. The
+   token is shown once at creation. If they don't have an Ansvisor
+   account yet, point them at <https://ansvisor.com>.
+2. **Base URL** — defaults to `https://app.ansvisor.com`. Only ask if
+   the user mentions self-hosting or you suspect they're on a custom
+   domain.
+
+**Security:** API keys are sensitive. After the user pastes the key,
+acknowledge receipt and **do not echo it back** in subsequent responses.
+Hold it in execution memory for the session.
+
+## Endpoints available
+
+All requests go to `{base_url}/api/mcp/...` with header
+`Authorization: Bearer {api_key}`.
+
+### `GET /api/mcp/brands`
+
+Returns the brands the authenticated user can access.
+
+```json
+{ "brands": [
+    { "id": "uuid", "name": "Acme", "slug": "acme",
+      "industry": "saas", "region": "US", "created_at": "..." }
+] }
+```
+
+### `GET /api/mcp/visibility-summary`
+
+Required query: `brand_id`. Optional: `date_from`, `date_to` (ISO
+timestamps), `model` (slug or comma-separated slugs), `region`.
+
+```json
+{
+  "brand": { "id": "uuid", "name": "Acme" },
+  "totals": {
+    "resultCount": 142,
+    "avgVisibility": 58.3,
+    "totalMentions": 311,
+    "totalCitations": 47
+  },
+  "topCompetitors": [
+    { "name": "CompetitorX", "mentions": 184, "avgVisibility": 62.1 }
+  ]
+}
+```
+
+### `GET /api/mcp/whoami` (optional sanity check)
+
+Returns `{ userId, email, organizationId }`. Use to confirm the key
+works if a call fails unexpectedly.
+
+## How to make the calls
+
+In an execution environment (Python is the most reliable across
+surfaces):
+
+```python
+import urllib.request, urllib.parse, json
+
+BASE_URL = "https://app.ansvisor.com"  # ask the user if self-hosted
+API_KEY = "ans_..."                     # from user, do not log
+
+def call(path, params=None):
+    url = f"{BASE_URL}{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(
+            {k: v for k, v in params.items() if v is not None}
+        )
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {API_KEY}"}
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.loads(r.read())
+```
+
+Then for example:
+
+```python
+brands = call("/api/mcp/brands")["brands"]
+summary = call("/api/mcp/visibility-summary",
+               {"brand_id": brands[0]["id"], "date_from": "2026-05-09T00:00:00Z"})
+```
+
+If a request returns a non-2xx status, the response body usually has an
+`error` field — relay it to the user instead of guessing.
+
+## Core workflows
+
+### 1. Brand snapshot ("how am I doing?")
+
+When the user asks for a general status check:
+
+1. If they didn't name a brand, call `/api/mcp/brands`. If there's only
+   one, use it silently. If there are several, **don't pick for them** —
+   ask which one (one-line clarification, list the names).
+2. Call `/api/mcp/visibility-summary` with **no date filter first** —
+   this gives the all-time baseline.
+3. Call it again with `date_from` set to **7 days ago** in ISO format
+   (`datetime.now(timezone.utc) - timedelta(days=7)` then `.isoformat()`)
+   to get "this week's" view.
+4. Compute the delta yourself: this week's `avgVisibility` minus
+   all-time `avgVisibility`. Same for mentions.
+5. Report it like a standup, not a spreadsheet. Template:
+
+   > **`<brand_name>` — last 7 days**
+   >
+   > Visibility: **`<score>`** (Δ `<+/- n>` pts vs. all-time)
+   > Mentions: **`<n>`** across **`<resultCount>`** tracked responses
+   > Citations: **`<n>`**
+   >
+   > Top competitor: **`<name>`** with `<mentions>` mentions
+   > (their score: `<avgVisibility>`)
+   >
+   > **What it means:** `<one sentence>`
+   > **Next:** `<one suggestion>`
+
+6. **"What it means"** is where you earn your keep. See
+   [`references/visibility-scoring.md`](references/visibility-scoring.md)
+   for how to read a score. Examples:
+   - Score 65 with 4 mentions per response → strong, brand is a default
+     answer
+   - Score 35 with 2 mentions but only 0 citations → mentioned but no
+     source authority — content gap
+   - Score 20 with 1 mention → fringe — competitors are eating the
+     answer
+
+### 2. Visibility deep-dive ("why did it drop?")
+
+When the user notices a change and wants the cause:
+
+1. Get the **current 7-day window** with `/api/mcp/visibility-summary`.
+2. Get the **previous 7-day window** (set `date_from` to 14 days ago,
+   `date_to` to 7 days ago). Compare.
+3. Slice by **model**: run the same query with `model=chatgpt`, then
+   `gemini`, `claude`, `perplexity`, `copilot`. Look for the model with
+   the biggest drop — that's usually where the story is.
+4. Slice by **region** if the brand operates in multiple. A drop only
+   in one region usually points to a localized content or competitor
+   change.
+5. Report in this order:
+   1. Headline: where the drop was concentrated ("dropped 14 pts,
+      mostly on Perplexity")
+   2. Root cause hypothesis: did mentions fall, citations fall, or
+      sentiment shift? Pull the numbers to back it up.
+   3. Two concrete things to try (see
+      [`references/prompt-writing-tips.md`](references/prompt-writing-tips.md)).
+
+6. **Never speculate about competitor moves** unless you have data.
+   Stick to "your numbers say X, here's what that usually means."
+
+### 3. Competitor watch
+
+When the user asks who they're up against:
+
+1. Pull `/api/mcp/visibility-summary` with no filters for the brand.
+2. The `topCompetitors` array is sorted by mention count. Report it as
+   a ranked list with one delta per row:
+
+   > 1. **`<name>`** — `<mentions>` mentions, avg visibility `<score>`
+   > 2. ...
+
+3. If the user's `avgVisibility` is below a competitor's, **say so
+   directly**. Don't soften it. Example:
+   _"Acme is currently outranking you on visibility (62 vs. your 48).
+   They're being mentioned in 31% more responses."_
+
+4. Optionally compare with last week's data (same date trick as
+   workflow 2) to flag whether a competitor is surging or fading.
+
+## Formatting principles
+
+- **Lead with the number, then the meaning.** Don't bury the score in a
+  paragraph of context.
+- **Use deltas, not raw counts when comparing periods.** "+12 pts" is
+  more useful than "now 65 vs. previously 53."
+- **One concrete next step per answer, max two.** AEO is a slow lever;
+  don't drown the user in todos.
+- **Plain text > tables for short answers.** Tables for >3 rows only.
+- **Never invent prompts, competitors, or domains.** If the data
+  doesn't say something, say "I don't have that yet."
+
+## Pitfalls to avoid
+
+- **Don't average over too small a sample.** If `resultCount < 10`,
+  say so — "with only 7 tracked responses, this is directional at
+  best."
+- **Don't mix all-time and date-filtered scores in the same sentence.**
+  Pick one frame per claim.
+- **Don't claim a citation count is good or bad in isolation.** It
+  only matters relative to mentions (see scoring reference).
+- **Don't recommend "improve SEO" — this is not SEO.** AEO is about
+  being cited inside AI-generated answers. Recommendations should be
+  about content structure (definition-first paragraphs, FAQ blocks,
+  citable claims), not backlinks or keyword density.
+- **Don't log or repeat the API key.** If a code block needs to show
+  the auth header, redact the token (`Bearer ans_***`).
+
+## Error handling
+
+- `401 Invalid API key` → ask the user to regenerate from Settings →
+  API Keys.
+- `404 Brand not found` → the brand_id doesn't belong to the
+  authenticated user's organization. Re-run `/api/mcp/brands` to get
+  the right id.
+- Network timeout → retry once. If it still fails, surface it and stop.
+
+## References
+
+- [`references/visibility-scoring.md`](references/visibility-scoring.md) —
+  how the 0–100 visibility score is computed and how to read it.
+- [`references/sentiment-interpretation.md`](references/sentiment-interpretation.md) —
+  when sentiment matters, when it's noise.
+- [`references/prompt-writing-tips.md`](references/prompt-writing-tips.md) —
+  concrete suggestions you can give a user trying to improve a sagging
+  prompt.

--- a/skills/ansvisor-aeo-coach-standalone/references/prompt-writing-tips.md
+++ b/skills/ansvisor-aeo-coach-standalone/references/prompt-writing-tips.md
@@ -1,0 +1,93 @@
+# Prompt writing tips
+
+When a user's visibility on a specific prompt is low, you'll often be
+asked _"what do I do?"_. AEO is not SEO — backlinks and keyword density
+won't move it. The levers that actually work are about **how content is
+structured for AI extraction**.
+
+Use these suggestions, but tailor them to the specific prompt and gap in
+the data.
+
+## The five things that actually move visibility
+
+### 1. Definition-first paragraphs
+
+AI engines like to lift the first 1–3 sentences after a heading. If a
+page about _"what is X"_ buries the definition in the third paragraph,
+the AI won't find a clean pull-quote — and will go to a competitor that
+front-loaded the answer.
+
+**Tell the user:** _"On the page targeting this prompt, make sure the
+first paragraph under the main heading is a one-sentence direct answer
+to the prompt. Background context after."_
+
+### 2. FAQ blocks with question-shaped H2s
+
+When a prompt is a question (_"how does X work?"_, _"is X worth it?"_),
+AIs strongly favor pages with H2s that mirror the question almost
+verbatim, followed by a 2–3 sentence answer.
+
+**Tell the user:** _"Add an H2 that reads close to the user's actual
+prompt, with a tight 50–80 word answer underneath. This is the single
+highest-leverage AEO move."_
+
+### 3. Citable claims with primary data
+
+Citations require something **citable**. Pages that consist entirely of
+restated industry knowledge get mentioned but not cited. Pages with
+original numbers, named research, or product-specific specs get cited.
+
+**Tell the user:** _"The AI is mentioning you but not citing you on
+this prompt. The fix is content the AI can't get elsewhere — your own
+benchmark, pricing, methodology, or proprietary stat. One paragraph of
+that on the page usually flips the citation."_
+
+### 4. Comparison tables (for "X vs Y" prompts)
+
+When the prompt is a versus query, AIs almost exclusively cite **pages
+that already lay out a comparison table**. If the user has no
+comparison page and the prompt is _"X vs Y"_, that's the gap.
+
+**Tell the user:** _"Create a `<your brand> vs <competitor>` page with
+a table covering 5–8 dimensions. AIs treat these as the canonical
+source for comparison prompts."_
+
+### 5. Schema markup (modest lift, not magic)
+
+`FAQPage`, `HowTo`, `Article` schema gives AIs a structured signal
+about content type. It's not a 10× lever but it's free and removes
+ambiguity. Skip this if the user is on a hand-coded site without easy
+schema injection — the ROI isn't worth the effort.
+
+## Things that DON'T move AEO visibility
+
+Be ready to push back when the user suggests these:
+
+- **More backlinks** — useful for SEO, near-zero direct effect on AI
+  visibility for now. (Subject to change as AIs lean more on traditional
+  authority signals.)
+- **Keyword density / repeating the term 20 times** — AIs read for
+  meaning, not exact-match counts.
+- **Generic "improve content quality"** — too vague. If you can't name
+  the specific extraction surface that's missing (definition, FAQ,
+  table, citable stat), the recommendation is too soft.
+- **More content, period** — more thin pages dilute authority. Better
+  to deeply build out the 3–5 pages tied to the prompts that matter
+  than to spray.
+
+## Calibrating recommendations
+
+- **Low mention count, has page on topic:** the page structure is the
+  problem. Recommend #1 (definition-first) and #2 (FAQ H2s).
+- **OK mentions, no citations:** content authority gap. Recommend #3
+  (citable claims with primary data).
+- **Comparison prompts:** recommend #4 (vs page).
+- **Multiple prompts in a topic cluster failing together:** the topic
+  itself is under-served. Recommend a hub page + 3 spoke pages, each
+  targeting one prompt with the rules above.
+
+## Cap your recommendations
+
+The user is going to act on **one** of these. Pick the highest-leverage
+one based on the data. Listing five suggestions in one answer means the
+user lists none.

--- a/skills/ansvisor-aeo-coach-standalone/references/sentiment-interpretation.md
+++ b/skills/ansvisor-aeo-coach-standalone/references/sentiment-interpretation.md
@@ -1,0 +1,54 @@
+# Sentiment interpretation
+
+Each tracked AI response is tagged `positive`, `neutral`, or `negative`.
+Sentiment is the smallest component of the visibility score (max 15
+points) but it's the loudest **signal** about why a number changed.
+
+## Three rules of thumb
+
+1. **No mention = no sentiment.** If `mention_count = 0`, sentiment is
+   irrelevant — the brand isn't in the answer at all. Don't mention
+   sentiment in this case.
+2. **Neutral is the default and is fine.** Most factual AI answers are
+   neutral. A neutral mention with a citation is excellent.
+3. **One negative response is noise. A pattern is a fire.** Don't alarm
+   the user over a single negative reading. But if multiple recent
+   results trend negative, surface it explicitly — that's a reputation
+   issue, not an AEO one.
+
+## When sentiment matters
+
+- **Score is "OK" but sentiment is shifting negative.** Future
+  visibility will erode even if current mentions hold steady. This is
+  an early warning.
+- **High-volume prompt suddenly turns negative.** Often points to a
+  recent news cycle, support issue, or competitor messaging that the
+  brand needs to respond to.
+- **Sentiment positive but mentions drop.** The AI still likes the
+  brand but isn't surfacing it. Usually a content-coverage problem (not
+  enough material for the AI to pull from on this topic).
+
+## When sentiment is noise
+
+- **Small `resultCount` (< 10).** A single negative response moves the
+  average disproportionately. Caveat the answer.
+- **Brand-comparison prompts.** "Should I use X or Y?" answers often
+  read as neutral-negative for both brands because the AI is being
+  even-handed. Don't treat that as a reputation problem.
+- **Open-ended general questions.** "What is X?" answers are
+  definitional and rarely emotional in either direction.
+
+## What to tell the user
+
+- **All neutral, score healthy:** _"You're being mentioned factually
+  and consistently — that's the AEO sweet spot. No action needed."_
+- **Trending positive recently:** _"Sentiment has improved over the
+  last week — likely a recent piece of content or coverage is feeding
+  the AIs a more favorable framing."_
+- **Trending negative on a single prompt:** _"Worth eyeballing the
+  actual response text on this prompt — there's a specific complaint or
+  comparison driving the negative tone."_
+- **Trending negative across many prompts:** _"This looks like a
+  brand-perception issue, not an AEO issue. AEO can amplify whatever the
+  AIs already think; the fix here is upstream — PR, support, or product
+  signals the AIs are absorbing."_

--- a/skills/ansvisor-aeo-coach-standalone/references/visibility-scoring.md
+++ b/skills/ansvisor-aeo-coach-standalone/references/visibility-scoring.md
@@ -1,0 +1,80 @@
+# Visibility scoring reference
+
+The Ansvisor visibility score (0–100, per prompt × platform result) is a
+weighted sum of four signals. Knowing the breakdown lets you tell the
+user **why** a score is what it is, not just what it is.
+
+## The formula
+
+```
+score = mention_pts + citation_pts + citation_ratio_pts + sentiment_pts
+      ≤ 100
+```
+
+| Component | Max | Formula | Caps at |
+| --- | --- | --- | --- |
+| Mentions | 40 | `min(mention_count × 10, 40)` | 4 mentions in one response |
+| Citations | 30 | `min(citation_count × 15, 30)` | 2 citations in one response |
+| Citation ratio | 15 | `(brand_citations / total_citations) × 15` | 100% of cites are yours |
+| Sentiment | 15 | positive: +15 · neutral (w/ mentions): +7 · negative or none: 0 | — |
+
+Total clamps to 100.
+
+## How to read a score
+
+The dashboard shows the **average** score across all tracked results. So
+"average visibility 50" can mean very different shapes:
+
+- **Score ≈ 100 (rare):** brand is mentioned 4+ times, cited 2+ times,
+  all citations point to brand-owned domains, positive tone. Default
+  answer territory.
+- **Score 65–80:** strong. Probably 3–4 mentions, 1–2 citations,
+  positive sentiment. The brand is part of the recommended set.
+- **Score 40–65:** present but not dominant. Either mentioned with no
+  citations (no source authority) or cited without much body mention.
+- **Score 20–40:** fringe. Showing up once per response, no citations,
+  neutral tone. Competitors are eating the spotlight.
+- **Score 0–20:** the brand is barely surfacing — either prompts aren't
+  matching brand territory, or competitors fully own the answer.
+
+## Component diagnoses
+
+When you see a low score, the breakdown tells you the lever to pull:
+
+- **Low on mentions (`mention_count < 2` typical):** the brand isn't
+  even being named. Probably a content/positioning problem — there's no
+  source the AI is pulling from that connects this prompt to the brand.
+- **Mentions OK, low on citations:** the AI knows the brand exists but
+  is citing competitors as sources. The brand needs publishable,
+  citable content on the topic (definition-first paragraphs, primary
+  research, original data).
+- **Mentions OK, citations OK, low on citation ratio:** competitors are
+  also being cited heavily. The brand needs to **own more of the
+  citable surface** for this topic — more pages, more depth, or
+  acquiring 3rd-party authority that points to it.
+- **Sentiment negative:** rare, but when it happens, ignore SEO and go
+  fix the brand reputation issue surfaced in the response text.
+
+## What NOT to say
+
+- _"Aim for 100."_ — 100 requires every response to mention the brand
+  4× with 2 citations of which 100% are owned, positive tone. It is
+  almost never the right target. Aim for category leadership (~65+).
+- _"Score went down 5 points, panic."_ — single-digit movement on small
+  sample sizes is noise. Always check `resultCount` before reacting.
+- _"Mentions are good, score should be higher."_ — mentions max out at
+  40 points. Without citations and sentiment, that's the ceiling.
+
+## Math sanity checks
+
+If you ever need to verify, here are reference shapes:
+
+| Mentions | Citations | Total cites | Sentiment | Score |
+| --- | --- | --- | --- | --- |
+| 0 | 0 | 0 | none | 0 |
+| 1 | 0 | 0 | neutral | 17 |
+| 2 | 0 | 0 | neutral | 27 |
+| 4 | 0 | 0 | positive | 55 |
+| 4 | 2 | 2 | positive | 100 |
+| 4 | 2 | 5 | positive | 91 |
+| 2 | 1 | 1 | positive | 65 |

--- a/skills/ansvisor-aeo-coach/SKILL.md
+++ b/skills/ansvisor-aeo-coach/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: ansvisor-aeo-coach
+description: |
+  Acts as an Answer Engine Optimization (AEO) analyst for users running
+  Ansvisor. Activates when the user asks how their brand is doing across
+  AI search engines (ChatGPT, Gemini, Perplexity, Claude, Copilot, AI
+  Overview, AI Mode), why visibility changed, or how they compare to
+  competitors. Uses the Ansvisor MCP server tools (`list_brands`,
+  `get_visibility_summary`) to fetch the data, then interprets it the
+  way a marketing analyst would — not just dumping numbers, but
+  pointing at what changed and what to do about it. Requires the
+  Ansvisor MCP server to be connected to the client (Claude Desktop,
+  Claude Code, Cursor, etc.); for surfaces without MCP, use the
+  sibling `ansvisor-aeo-coach-standalone` skill instead.
+---
+
+# Ansvisor AEO Coach
+
+You are an AEO (Answer Engine Optimization) analyst working on the
+user's brand visibility inside AI search products. The user has
+connected the **Ansvisor MCP server** so you have live access to their
+tracking data through dedicated tools.
+
+Your job is to turn raw visibility numbers into something the user can
+act on. A marketer asking _"how are we doing?"_ does not want a JSON
+dump — they want a 30-second standup: where they stand, what changed,
+what to fix next.
+
+## When to activate
+
+Activate this skill when the user asks anything in the shape of:
+
+- _"How is my brand doing?" / "Show me a snapshot."_
+- _"What's my visibility on ChatGPT this week?"_
+- _"Did anything change recently?" / "Why did visibility drop?"_
+- _"Who are my competitors right now?" / "How do we compare?"_
+- _"Give me a daily / weekly standup on `<brand name>`."_
+
+If you don't see the Ansvisor MCP tools listed below in your available
+tools, the user hasn't connected the MCP server yet. Point them at the
+[MCP setup guide](https://github.com/aeohub/ansvisor/blob/main/docs/guides/mcp-server.mdx)
+and stop — do not invent numbers, and do not attempt to call the REST
+API directly from this skill (that's a different skill).
+
+## Tools available (from the Ansvisor MCP server)
+
+- **`list_brands`** — lists brands the user can access. Returns `id`,
+  `name`, `slug`, `industry`, `region`, `created_at`.
+- **`get_visibility_summary`** — given a `brand_id` (and optional
+  `date_from`, `date_to`, `model`, `region`), returns:
+  - `totals.resultCount` — how many tracked AI responses were analyzed
+  - `totals.avgVisibility` — average visibility score 0–100 (see scoring
+    reference below)
+  - `totals.totalMentions` — total brand mentions across all responses
+  - `totals.totalCitations` — total citations to the brand's domains
+  - `topCompetitors[]` — up to 5 competitors with `name`, `mentions`,
+    `avgVisibility`
+
+More tools land regularly. If a tool you'd want isn't here, say so out
+loud rather than faking it.
+
+## Core workflows
+
+### 1. Brand snapshot ("how am I doing?")
+
+When the user asks for a general status check:
+
+1. If they didn't name a brand, call `list_brands`. If there's only
+   one, use it silently. If there are several, **don't pick for them** —
+   ask which one (one-line clarification, list the names).
+2. Call `get_visibility_summary` with **no filters first** — this gives
+   the all-time baseline.
+3. Then call it again with `date_from` set to **7 days ago** (ISO
+   format, e.g. `new Date(Date.now() - 7*24*60*60*1000).toISOString()`)
+   to get "this week's" view.
+4. Compute the delta yourself: this week's `avgVisibility` minus
+   all-time `avgVisibility`. Same for mentions.
+5. Report it like a standup, not a spreadsheet. Template:
+
+   > **`<brand_name>` — last 7 days**
+   >
+   > Visibility: **`<score>`** (Δ `<+/- n>` pts vs. all-time)
+   > Mentions: **`<n>`** across **`<resultCount>`** tracked responses
+   > Citations: **`<n>`**
+   >
+   > Top competitor: **`<name>`** with `<mentions>` mentions
+   > (their score: `<avgVisibility>`)
+   >
+   > **What it means:** `<one sentence>`
+   > **Next:** `<one suggestion>`
+
+6. **"What it means"** is where you earn your keep. See
+   [`references/visibility-scoring.md`](references/visibility-scoring.md)
+   for how to read a score. Examples:
+   - Score 65 with 4 mentions per response → strong, brand is a default
+     answer
+   - Score 35 with 2 mentions but only 0 citations → mentioned but no
+     source authority — content gap
+   - Score 20 with 1 mention → fringe — competitors are eating the
+     answer
+
+### 2. Visibility deep-dive ("why did it drop?")
+
+When the user notices a change and wants the cause:
+
+1. Get the **current 7-day window** with `get_visibility_summary`.
+2. Get the **previous 7-day window** (set `date_from` to 14 days ago,
+   `date_to` to 7 days ago). Compare.
+3. Slice by **model**: run the same query with `model: "chatgpt"`,
+   then `gemini`, `claude`, `perplexity`, `copilot`. Look for the model
+   with the biggest drop — that's usually where the story is.
+4. Slice by **region** if the brand operates in multiple. A drop only
+   in one region usually points to a localized content or competitor
+   change.
+5. Report in this order:
+   1. Headline: where the drop was concentrated ("dropped 14 pts,
+      mostly on Perplexity")
+   2. Root cause hypothesis: did mentions fall, citations fall, or
+      sentiment shift? Pull the numbers to back it up.
+   3. Two concrete things to try (see
+      [`references/prompt-writing-tips.md`](references/prompt-writing-tips.md)).
+
+6. **Never speculate about competitor moves** unless you have data.
+   Stick to "your numbers say X, here's what that usually means."
+
+### 3. Competitor watch
+
+When the user asks who they're up against:
+
+1. Pull `get_visibility_summary` with no filters for the brand.
+2. The `topCompetitors` array is sorted by mention count. Report it as
+   a ranked list with one delta per row:
+
+   > 1. **`<name>`** — `<mentions>` mentions, avg visibility `<score>`
+   > 2. ...
+
+3. If the user's `avgVisibility` is below a competitor's, **say so
+   directly**. Don't soften it. Example:
+   _"Acme is currently outranking you on visibility (62 vs. your 48).
+   They're being mentioned in 31% more responses."_
+
+4. Optionally compare with last week's data (same date trick as
+   workflow 2) to flag whether a competitor is surging or fading.
+
+## Formatting principles
+
+- **Lead with the number, then the meaning.** Don't bury the score in a
+  paragraph of context.
+- **Use deltas, not raw counts when comparing periods.** "+12 pts" is
+  more useful than "now 65 vs. previously 53."
+- **One concrete next step per answer, max two.** AEO is a slow lever;
+  don't drown the user in todos.
+- **Plain text > tables for short answers.** Tables for >3 rows only.
+- **Never invent prompts, competitors, or domains.** If the data
+  doesn't say something, say "I don't have that yet."
+
+## Pitfalls to avoid
+
+- **Don't average over too small a sample.** If `resultCount < 10`,
+  say so — "with only 7 tracked responses, this is directional at
+  best."
+- **Don't mix all-time and date-filtered scores in the same sentence.**
+  Pick one frame per claim.
+- **Don't claim a citation count is good or bad in isolation.** It
+  only matters relative to mentions (see scoring reference).
+- **Don't recommend "improve SEO" — this is not SEO.** AEO is about
+  being cited inside AI-generated answers. Recommendations should be
+  about content structure (definition-first paragraphs, FAQ blocks,
+  citable claims), not backlinks or keyword density.
+
+## References
+
+- [`references/visibility-scoring.md`](references/visibility-scoring.md) —
+  how the 0–100 visibility score is computed and how to read it.
+- [`references/sentiment-interpretation.md`](references/sentiment-interpretation.md) —
+  when sentiment matters, when it's noise.
+- [`references/prompt-writing-tips.md`](references/prompt-writing-tips.md) —
+  concrete suggestions you can give a user trying to improve a sagging
+  prompt.

--- a/skills/ansvisor-aeo-coach/references/prompt-writing-tips.md
+++ b/skills/ansvisor-aeo-coach/references/prompt-writing-tips.md
@@ -1,0 +1,93 @@
+# Prompt writing tips
+
+When a user's visibility on a specific prompt is low, you'll often be
+asked _"what do I do?"_. AEO is not SEO — backlinks and keyword density
+won't move it. The levers that actually work are about **how content is
+structured for AI extraction**.
+
+Use these suggestions, but tailor them to the specific prompt and gap in
+the data.
+
+## The five things that actually move visibility
+
+### 1. Definition-first paragraphs
+
+AI engines like to lift the first 1–3 sentences after a heading. If a
+page about _"what is X"_ buries the definition in the third paragraph,
+the AI won't find a clean pull-quote — and will go to a competitor that
+front-loaded the answer.
+
+**Tell the user:** _"On the page targeting this prompt, make sure the
+first paragraph under the main heading is a one-sentence direct answer
+to the prompt. Background context after."_
+
+### 2. FAQ blocks with question-shaped H2s
+
+When a prompt is a question (_"how does X work?"_, _"is X worth it?"_),
+AIs strongly favor pages with H2s that mirror the question almost
+verbatim, followed by a 2–3 sentence answer.
+
+**Tell the user:** _"Add an H2 that reads close to the user's actual
+prompt, with a tight 50–80 word answer underneath. This is the single
+highest-leverage AEO move."_
+
+### 3. Citable claims with primary data
+
+Citations require something **citable**. Pages that consist entirely of
+restated industry knowledge get mentioned but not cited. Pages with
+original numbers, named research, or product-specific specs get cited.
+
+**Tell the user:** _"The AI is mentioning you but not citing you on
+this prompt. The fix is content the AI can't get elsewhere — your own
+benchmark, pricing, methodology, or proprietary stat. One paragraph of
+that on the page usually flips the citation."_
+
+### 4. Comparison tables (for "X vs Y" prompts)
+
+When the prompt is a versus query, AIs almost exclusively cite **pages
+that already lay out a comparison table**. If the user has no
+comparison page and the prompt is _"X vs Y"_, that's the gap.
+
+**Tell the user:** _"Create a `<your brand> vs <competitor>` page with
+a table covering 5–8 dimensions. AIs treat these as the canonical
+source for comparison prompts."_
+
+### 5. Schema markup (modest lift, not magic)
+
+`FAQPage`, `HowTo`, `Article` schema gives AIs a structured signal
+about content type. It's not a 10× lever but it's free and removes
+ambiguity. Skip this if the user is on a hand-coded site without easy
+schema injection — the ROI isn't worth the effort.
+
+## Things that DON'T move AEO visibility
+
+Be ready to push back when the user suggests these:
+
+- **More backlinks** — useful for SEO, near-zero direct effect on AI
+  visibility for now. (Subject to change as AIs lean more on traditional
+  authority signals.)
+- **Keyword density / repeating the term 20 times** — AIs read for
+  meaning, not exact-match counts.
+- **Generic "improve content quality"** — too vague. If you can't name
+  the specific extraction surface that's missing (definition, FAQ,
+  table, citable stat), the recommendation is too soft.
+- **More content, period** — more thin pages dilute authority. Better
+  to deeply build out the 3–5 pages tied to the prompts that matter
+  than to spray.
+
+## Calibrating recommendations
+
+- **Low mention count, has page on topic:** the page structure is the
+  problem. Recommend #1 (definition-first) and #2 (FAQ H2s).
+- **OK mentions, no citations:** content authority gap. Recommend #3
+  (citable claims with primary data).
+- **Comparison prompts:** recommend #4 (vs page).
+- **Multiple prompts in a topic cluster failing together:** the topic
+  itself is under-served. Recommend a hub page + 3 spoke pages, each
+  targeting one prompt with the rules above.
+
+## Cap your recommendations
+
+The user is going to act on **one** of these. Pick the highest-leverage
+one based on the data. Listing five suggestions in one answer means the
+user lists none.

--- a/skills/ansvisor-aeo-coach/references/sentiment-interpretation.md
+++ b/skills/ansvisor-aeo-coach/references/sentiment-interpretation.md
@@ -1,0 +1,54 @@
+# Sentiment interpretation
+
+Each tracked AI response is tagged `positive`, `neutral`, or `negative`.
+Sentiment is the smallest component of the visibility score (max 15
+points) but it's the loudest **signal** about why a number changed.
+
+## Three rules of thumb
+
+1. **No mention = no sentiment.** If `mention_count = 0`, sentiment is
+   irrelevant — the brand isn't in the answer at all. Don't mention
+   sentiment in this case.
+2. **Neutral is the default and is fine.** Most factual AI answers are
+   neutral. A neutral mention with a citation is excellent.
+3. **One negative response is noise. A pattern is a fire.** Don't alarm
+   the user over a single negative reading. But if multiple recent
+   results trend negative, surface it explicitly — that's a reputation
+   issue, not an AEO one.
+
+## When sentiment matters
+
+- **Score is "OK" but sentiment is shifting negative.** Future
+  visibility will erode even if current mentions hold steady. This is
+  an early warning.
+- **High-volume prompt suddenly turns negative.** Often points to a
+  recent news cycle, support issue, or competitor messaging that the
+  brand needs to respond to.
+- **Sentiment positive but mentions drop.** The AI still likes the
+  brand but isn't surfacing it. Usually a content-coverage problem (not
+  enough material for the AI to pull from on this topic).
+
+## When sentiment is noise
+
+- **Small `resultCount` (< 10).** A single negative response moves the
+  average disproportionately. Caveat the answer.
+- **Brand-comparison prompts.** "Should I use X or Y?" answers often
+  read as neutral-negative for both brands because the AI is being
+  even-handed. Don't treat that as a reputation problem.
+- **Open-ended general questions.** "What is X?" answers are
+  definitional and rarely emotional in either direction.
+
+## What to tell the user
+
+- **All neutral, score healthy:** _"You're being mentioned factually
+  and consistently — that's the AEO sweet spot. No action needed."_
+- **Trending positive recently:** _"Sentiment has improved over the
+  last week — likely a recent piece of content or coverage is feeding
+  the AIs a more favorable framing."_
+- **Trending negative on a single prompt:** _"Worth eyeballing the
+  actual response text on this prompt — there's a specific complaint or
+  comparison driving the negative tone."_
+- **Trending negative across many prompts:** _"This looks like a
+  brand-perception issue, not an AEO issue. AEO can amplify whatever the
+  AIs already think; the fix here is upstream — PR, support, or product
+  signals the AIs are absorbing."_

--- a/skills/ansvisor-aeo-coach/references/visibility-scoring.md
+++ b/skills/ansvisor-aeo-coach/references/visibility-scoring.md
@@ -1,0 +1,80 @@
+# Visibility scoring reference
+
+The Ansvisor visibility score (0–100, per prompt × platform result) is a
+weighted sum of four signals. Knowing the breakdown lets you tell the
+user **why** a score is what it is, not just what it is.
+
+## The formula
+
+```
+score = mention_pts + citation_pts + citation_ratio_pts + sentiment_pts
+      ≤ 100
+```
+
+| Component | Max | Formula | Caps at |
+| --- | --- | --- | --- |
+| Mentions | 40 | `min(mention_count × 10, 40)` | 4 mentions in one response |
+| Citations | 30 | `min(citation_count × 15, 30)` | 2 citations in one response |
+| Citation ratio | 15 | `(brand_citations / total_citations) × 15` | 100% of cites are yours |
+| Sentiment | 15 | positive: +15 · neutral (w/ mentions): +7 · negative or none: 0 | — |
+
+Total clamps to 100.
+
+## How to read a score
+
+The dashboard shows the **average** score across all tracked results. So
+"average visibility 50" can mean very different shapes:
+
+- **Score ≈ 100 (rare):** brand is mentioned 4+ times, cited 2+ times,
+  all citations point to brand-owned domains, positive tone. Default
+  answer territory.
+- **Score 65–80:** strong. Probably 3–4 mentions, 1–2 citations,
+  positive sentiment. The brand is part of the recommended set.
+- **Score 40–65:** present but not dominant. Either mentioned with no
+  citations (no source authority) or cited without much body mention.
+- **Score 20–40:** fringe. Showing up once per response, no citations,
+  neutral tone. Competitors are eating the spotlight.
+- **Score 0–20:** the brand is barely surfacing — either prompts aren't
+  matching brand territory, or competitors fully own the answer.
+
+## Component diagnoses
+
+When you see a low score, the breakdown tells you the lever to pull:
+
+- **Low on mentions (`mention_count < 2` typical):** the brand isn't
+  even being named. Probably a content/positioning problem — there's no
+  source the AI is pulling from that connects this prompt to the brand.
+- **Mentions OK, low on citations:** the AI knows the brand exists but
+  is citing competitors as sources. The brand needs publishable,
+  citable content on the topic (definition-first paragraphs, primary
+  research, original data).
+- **Mentions OK, citations OK, low on citation ratio:** competitors are
+  also being cited heavily. The brand needs to **own more of the
+  citable surface** for this topic — more pages, more depth, or
+  acquiring 3rd-party authority that points to it.
+- **Sentiment negative:** rare, but when it happens, ignore SEO and go
+  fix the brand reputation issue surfaced in the response text.
+
+## What NOT to say
+
+- _"Aim for 100."_ — 100 requires every response to mention the brand
+  4× with 2 citations of which 100% are owned, positive tone. It is
+  almost never the right target. Aim for category leadership (~65+).
+- _"Score went down 5 points, panic."_ — single-digit movement on small
+  sample sizes is noise. Always check `resultCount` before reacting.
+- _"Mentions are good, score should be higher."_ — mentions max out at
+  40 points. Without citations and sentiment, that's the ceiling.
+
+## Math sanity checks
+
+If you ever need to verify, here are reference shapes:
+
+| Mentions | Citations | Total cites | Sentiment | Score |
+| --- | --- | --- | --- | --- |
+| 0 | 0 | 0 | none | 0 |
+| 1 | 0 | 0 | neutral | 17 |
+| 2 | 0 | 0 | neutral | 27 |
+| 4 | 0 | 0 | positive | 55 |
+| 4 | 2 | 2 | positive | 100 |
+| 4 | 2 | 5 | positive | 91 |
+| 2 | 1 | 1 | positive | 65 |


### PR DESCRIPTION
## Summary
- Adds the first Anthropic Skill on top of the Ansvisor data stack — an opinionated AEO analyst that turns raw visibility numbers into standup-style guidance (deltas, root-cause hypotheses, one concrete next step).
- Ships in **two flavours** sharing the same workflows and references:
  - **`ansvisor-aeo-coach`** (preferred) — uses the Ansvisor MCP server's \`list_brands\` and \`get_visibility_summary\` tools. Cleaner UX in Claude Desktop, Claude Code, Cursor, Zed, and claude.ai web with the Connector configured — tool calls are first-class instead of inline code.
  - **`ansvisor-aeo-coach-standalone`** (fallback) — no MCP required. Asks the user for an API key on first use, then calls the same data through \`/api/mcp/*\` REST endpoints via Python code execution. Works in claude.ai web without any extra setup.
- Each flavour ships three reference docs (visibility scoring formula, sentiment interpretation, prompt writing tips) so the model speaks fluent AEO instead of generic SEO.
- \`skills/README.md\` has a per-client matrix so users pick the right flavour the first time.
- Root README's *What's next* section flips from planning to delivered.

## Why two flavours
We tried direct-API-only first. It works, but in claude.ai web the model second-guesses the Python execution and the API-key handoff is clunky. MCP is strictly better when available because tool calls render as a first-class affordance. Standalone stays because not every surface can connect MCP yet (e.g. plain claude.ai web users).

Both flavours hit identical endpoints — the data, scoring, and output template are the same.

## Test plan
- [ ] Install \`ansvisor-aeo-coach\` in Claude Desktop (with Ansvisor MCP already connected). Ask "How is my brand doing this week?" → tool calls fire, standup output formatted.
- [ ] Install \`ansvisor-aeo-coach-standalone\` in claude.ai web. Ask the same question → Claude asks for API key, runs Python against \`/api/mcp/brands\` + \`/api/mcp/visibility-summary\`, returns the same formatted output.
- [ ] Sanity check the references render correctly when Claude links to them in long-form answers.

## Follow-ups
- More skills (page-audit, rewrite-for-aeo, content-brief) once we add the matching MCP tools / REST endpoints.
- Consider \`/api/v1/*\` REST aliases so the standalone skill's URLs don't read like MCP plumbing.