### PR TITLE
fix(ui): point auth header logo to marketing site instead of /sign-in

### DIFF
--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -10,7 +10,7 @@ export function MarketingHeader() {
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between">
-        <Link href="/sign-in" className="flex items-center gap-2">
+        <Link href="/" className="flex items-center gap-2">
           <Image
             src="/logo_light.svg"
             alt=""


### PR DESCRIPTION
## Summary

Fix the header logo link on sign-in and sign-up pages so it points to the marketing site (`/`) instead of the sign-in page (`/sign-in`).

Fixes #24

## Root Cause

`MarketingHeader` component in `web/src/components/marketing/marketing-header.tsx` has the logo/wordmark `<Link>` pointing to `/sign-in`. Since the auth pages use this shared header, clicking the brand logo on either `/sign-in` or `/sign-up` just refreshes or bounces between auth pages instead of navigating to the marketing site.

## Fix

Changed the logo link `href` from `/sign-in` to `/` in `MarketingHeader`.

**File changed:** `web/src/components/marketing/marketing-header.tsx` (+1 -1)

## Testing

1. Visit `/sign-in` → click Ansvisor logo → should navigate to `/` (marketing site) ✅
2. Visit `/sign-up` → click Ansvisor logo → should navigate to `/` (marketing site) ✅
3. Sign-in and sign-up buttons in header still work correctly (unchanged) ✅