### PR TITLE
fix(ui): Settings → Theme — selected tab is invisible in dark mode #28

### DIFF
--- a/web/src/components/settings/theme-switch.tsx
+++ b/web/src/components/settings/theme-switch.tsx
@@ -32,18 +32,24 @@ export function ThemeSwitch() {
   return (
     <div className="flex rounded-lg border bg-muted p-1">
       <Button
-        variant={theme === "light" ? "secondary" : "ghost"}
+        variant="ghost"
         size="sm"
-        className={cn("flex-1 gap-2", theme === "light" && "shadow-sm")}
+        className={cn(
+          "flex-1 gap-2 transition-colors",
+          theme === "light" && "bg-background text-foreground shadow-sm dark:border-input dark:bg-input/30"
+        )}
         onClick={() => setTheme("light")}
       >
         <Sun className="h-4 w-4" />
         Light
       </Button>
       <Button
-        variant={theme === "dark" ? "secondary" : "ghost"}
+        variant="ghost"
         size="sm"
-        className={cn("flex-1 gap-2", theme === "dark" && "shadow-sm")}
+        className={cn(
+          "flex-1 gap-2 transition-colors",
+          theme === "dark" && "bg-background text-foreground shadow-sm dark:border-input dark:bg-input/30"
+        )}
         onClick={() => setTheme("dark")}
       >
         <Moon className="h-4 w-4" />


### PR DESCRIPTION
<img width="467" height="58" alt="Screenshot 2026-05-16 at 9 02 40 PM" src="https://github.com/user-attachments/assets/248641f3-c625-4239-86c7-4943aed57f2a" />


<img width="485" height="63" alt="Screenshot 2026-05-16 at 9 02 30 PM" src="https://github.com/user-attachments/assets/ae5c0dbb-1a4f-4e27-8c06-678e7d65c1c0" />

Tested by importing theme-switch.tsx in a route directly.