### PR TITLE
fix(web): use app url for MCP endpoint

### DIFF
--- a/web/src/components/settings/api-keys-section.tsx
+++ b/web/src/components/settings/api-keys-section.tsx
@@ -34,6 +34,15 @@ interface ApiKey {
   created_at: string;
 }
 
+const configuredAppUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") ?? "";
+
+function getMcpEndpoint(): string {
+  const appUrl =
+    configuredAppUrl ||
+    (typeof window !== "undefined" ? window.location.origin : "");
+  return `${appUrl}/api/mcp`;
+}
+
 function formatDate(iso: string | null): string {
   if (!iso) return "—";
   return new Date(iso).toLocaleDateString(undefined, {
@@ -50,6 +59,7 @@ export function ApiKeysSection() {
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
   const [revealedToken, setRevealedToken] = useState<string | null>(null);
+  const mcpEndpoint = getMcpEndpoint();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -141,16 +151,13 @@ export function ApiKeysSection() {
           <p className="font-medium text-foreground">MCP endpoint</p>
           <div className="flex items-center gap-2">
             <code className="flex-1 truncate font-mono">
-              {typeof window !== "undefined" ? window.location.origin : ""}
-              /api/mcp
+              {mcpEndpoint}
             </code>
             <Button
               size="sm"
               variant="ghost"
               className="h-6 px-2"
-              onClick={() =>
-                copy(`${window.location.origin}/api/mcp`)
-              }
+              onClick={() => copy(mcpEndpoint)}
             >
               <Copy className="h-3 w-3" />
             </Button>


### PR DESCRIPTION
## Summary

- Use `NEXT_PUBLIC_APP_URL` as the canonical base for the Settings API Keys MCP endpoint.
- Reuse one computed endpoint string for both the displayed URL and copy button.

## Context

Fixes #27.

The settings page was using `window.location.origin` directly for the MCP endpoint, while the rest of the app uses `NEXT_PUBLIC_APP_URL` for canonical app URLs.

## Changes

- Added a small MCP endpoint helper in `api-keys-section.tsx`.
- Normalized a trailing slash from `NEXT_PUBLIC_APP_URL`.
- Kept `window.location.origin` as the fallback when the env var is not configured.

## Testing

- `corepack yarn eslint src/components/settings/api-keys-section.tsx`
- `corepack yarn typecheck`
- `npm run version:check`
- `git diff --check`
- `git diff --cached --check`
- `gitleaks protect --staged --no-banner --redact`

## Notes

`corepack yarn lint` is currently blocked by existing unrelated lint errors outside this change:

- `web/src/app/[locale]/invite/[token]/page.tsx:24`
- `web/src/components/layout/sidebar.tsx:33`

I did not run the dashboard manually because full local app startup requires environment-backed services that are outside this fix.
