### PR TITLE
chore(ci): auto-welcome first-time contributors on issues and PRs

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,44 @@
+name: First-time contributor welcome
+
+# Posts a one-time welcome comment when someone opens their FIRST issue or
+# pull request in this repo. Subsequent issues/PRs from the same person do
+# not trigger this — the action checks contribution history per user.
+#
+# Triggers `pull_request_target` (not `pull_request`) so the workflow runs
+# in the base repo's context and has the write permission needed to comment.
+# We never check out or execute the PR's code here, so this is safe to use
+# with PRs from forks.
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Welcome to Ansvisor, and thanks for opening your first issue!
+
+            A maintainer will take a look soon. A few things that help us move fast:
+            - **Bug reports** — exact steps to reproduce, what you expected vs. what happened, browser / Node version where relevant.
+            - **Feature requests** — the use case behind the ask, so we can think about it well rather than guessing.
+
+            If you'd like to follow Ansvisor's evolution, a ⭐ on the repo helps others discover it (and Watch sends you a ping when related issues land).
+          pr-message: |
+            Welcome to Ansvisor, and thank you for your first PR! A maintainer will be by soon to review.
+
+            In the meantime, two things that make review faster:
+            - A short description of *why* the change matters, not just *what* it does — most of our PRs link a `Fixes #...` to the issue that explains the *why*.
+            - A quick local test note if there's anything worth eyeballing in the browser.
+
+            If you'd like to keep an eye on where Ansvisor goes next, a ⭐ on the repo helps others discover it (and Watch sends you a ping when related issues land). Either way — looking forward to your next one.


### PR DESCRIPTION
## Summary
- Adds a single GitHub Actions workflow (\`actions/first-interaction@v1\`) that posts a one-time welcome comment when someone opens their **first** issue or pull request in this repo. Subsequent activity from the same person doesn't re-trigger.
- Saves the maintainer from manually writing the same warm-welcome boilerplate every time, while keeping the door open for personalised follow-up review comments later in the thread.
- Quietly nudges new contributors toward starring / watching the repo so they hear about related work.

## What the messages say

**Issue (opened by first-time user):**
Asks for reproduction steps on bug reports and a use case on feature requests. Soft star + watch CTA at the end.

**Pull request (opened by first-time user):**
Asks for the *why* behind the change + a quick local test note. Soft star + watch CTA at the end.

## Safety notes
- Uses \`pull_request_target\` (not \`pull_request\`) so the workflow runs in the base repo's context with the write permission needed to comment. PR code is never checked out or executed in this job, so it's safe with forks.
- Permissions scoped to exactly what's needed: \`issues: write\`, \`pull-requests: write\`. No \`contents: write\`, no secrets exposure.

## Test plan
- [ ] After merge, ask a brand-new GitHub account (or someone who's never contributed) to open a test issue → workflow fires, comment appears.
- [ ] Same person opens an issue again → no second comment (action checks contribution history).
- [ ] An existing contributor opens an issue → no comment (first-time check excludes them).