### PR TITLE
fix(insights): adaptive Y-axis on the Brand vs Competitors chart

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
@@ -23,6 +23,25 @@ import type {
   SoVTrendPoint,
 } from '@/lib/actions/tracking';
 
+// ─── Adaptive Y-axis ─────────────────────────────────────────────────────────
+// Visibility scores are theoretically 0–100 but realistic values for most
+// brands cluster in the 5–30 band. Pinning the Y-axis to 100 makes bars look
+// uniformly stubby and kills the perceived difference between, say, 8 and 22.
+// We rescale upward with 30% headroom, but snap to a "nice" tick value so
+// gridlines stay clean — and keep a minimum ceiling of 20 so very low values
+// don't look absurdly zoomed (a 3-point chart shouldn't fill the canvas).
+
+const NICE_YMAX_STEPS = [20, 25, 30, 40, 50, 60, 80, 100] as const;
+
+function niceVisibilityYMax(values: number[]): number {
+  if (values.length === 0) return 20;
+  const actualMax = Math.max(0, ...values);
+  if (actualMax <= 0) return 20;
+  const target = actualMax * 1.3;
+  for (const step of NICE_YMAX_STEPS) if (target <= step) return step;
+  return 100;
+}
+
 // ─── Auto-sizing wrapper ─────────────────────────────────────────────────────
 // Replaces ResponsiveContainer which has issues with React 19
 
@@ -409,6 +428,16 @@ export function CompetitorChart({
 }) {
   const brandNames = brands.slice(0, 5).map((b) => b.name);
 
+  // Pull every numeric visibility value across all brands × providers and
+  // pick a sensible upper bound. See niceVisibilityYMax for the rules.
+  const yMax = niceVisibilityYMax(
+    providerRows.flatMap((row) =>
+      brandNames
+        .map((name) => row[name])
+        .filter((v): v is number => typeof v === 'number'),
+    ),
+  );
+
   return (
     <ChartContainer height={320}>
       {(width) => (
@@ -437,7 +466,7 @@ export function CompetitorChart({
             tickLine={false}
             axisLine={false}
             className="fill-muted-foreground"
-            domain={[0, 100]}
+            domain={[0, yMax]}
             tickFormatter={(v: number) => `${v}%`}
           />
           <Tooltip


### PR DESCRIPTION
## Summary
- Visibility scores are theoretically 0–100 but realistic values for most brands cluster in the **5–30 band**. Pinning the Y-axis to 100 made every bar look uniformly stubby and killed the perceived difference between, say, 8 and 22.
- The chart now rescales the Y-axis upward with **30% headroom**, snapped to a "nice" tick value so gridlines stay clean. A floor of 20 keeps very low values from looking absurdly zoomed (a 3-point chart shouldn't fill the canvas either).

## Before / after

| Scenario | Old Y-axis | New Y-axis |
| --- | --- | --- |
| All brands 5–15 pts | 0–100 (bars use ~15% of canvas) | 0–20 (bars use ~75% of canvas) |
| One brand at 45 pts | 0–100 | 0–60 (45 × 1.3 = 58.5 → snaps to 60) |
| Highest brand 75 pts | 0–100 | 0–100 (75 × 1.3 = 97.5 → snaps to 100) |
| No data | 0–100 | 0–20 (floor protects against absurd zoom) |

## Scope
- Touches only \`CompetitorChart\` (\`AI Visibility — Brand vs Competitors\` card on /dashboard/insights) — that's the one with visible squish.
- \`VisibilityTrend\` and \`SoVTrend\` charts still pin to 0–100 and can adopt the new \`niceVisibilityYMax\` helper as a follow-up.
- "%" suffix on tick labels is kept as-is for this change — that label is a separate copy concern (visibility score is a 0–100 weighted score, not strictly a percentage).

## Test plan
- [x] Open /dashboard/insights with a brand where competitor scores are all under 20 → bars are visibly proportional, Y-axis maxes at 20.
- [x] Same page with a brand where at least one score is in the 40s → Y-axis maxes at 60.
- [x] Empty/loading state still renders cleanly without zero-division weirdness.
- [x] Tooltip values unchanged; sorting / legend unaffected.