### PR TITLE
fix: refresh stale package-lock metadata

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "aeo-server",
-  "version": "1.0.0",
+  "name": "@aeohub/ansvisor-server",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aeo-server",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "@aeohub/ansvisor-server",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.58",
         "@ai-sdk/google": "^3.0.43",


### PR DESCRIPTION
- What changed

Regenerated server/package-lock.json so its root metadata matches the current package.json values.

Updated fields:

- name
- version
- license

- Why

The lockfile was carrying stale metadata from before the project rename/license change.

Closes #50.