### PR TITLE
feat(sidebar): added user profile as (avatar + name) → settings

### DIFF
--- a/web/src/components/layout/mobile-nav.tsx
+++ b/web/src/components/layout/mobile-nav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { usePathname, Link } from '@/i18n/navigation';
 import { dashboardNav } from '@/config/dashboard';
@@ -10,8 +10,11 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { UserProfileNavItem } from '@/components/layout/user-profile-nav-item';
 import { useBrandStore } from '@/stores/use-brand-store';
 import { Crown, Menu, MessageSquareText } from 'lucide-react';
+import Image from 'next/image';
+import { useTheme } from 'next-themes';
 
 export function MobileNav() {
   const [open, setOpen] = useState(false);
@@ -20,6 +23,12 @@ export function MobileNav() {
   const tBrands = useTranslations('brands');
   const { canUse, requiredPlanFor, isCloud } = useFeatureGate();
   const { activeBrandId } = useBrandStore();
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const logoSrc =
+    mounted && resolvedTheme === 'dark' ? '/logo_dark.svg' : '/logo_light.svg';
 
   const getLabel = (title: string): string => {
     const map: Record<string, string> = {
@@ -45,83 +54,96 @@ export function MobileNav() {
         <Menu className="h-5 w-5" />
         <span className="sr-only">Toggle menu</span>
       </SheetTrigger>
-      <SheetContent side="left" className="w-64 p-0">
-        <div className="flex h-16 items-center border-b px-4">
+      <SheetContent side="left" className="flex w-64 flex-col p-0">
+        <div className="flex gap-2 h-16 items-center border-b px-4">
+          <Image
+            src={logoSrc}
+            alt={siteConfig.name}
+            width={24}
+            height={24}
+            className="h-6 w-6 shrink-0"
+            priority
+          />
           <span className="font-semibold">{siteConfig.name}</span>
         </div>
-        <nav className="space-y-0.5 p-3">
-          {activeBrandId && (
-            <Link
-              href={`/dashboard/brands/${activeBrandId}/prompts`}
-              onClick={() => setOpen(false)}
-            >
-              <span
-                className={cn(
-                  'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                  pathname.includes(`/brands/${activeBrandId}/prompts`)
-                    ? 'bg-primary/10 text-primary'
-                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                )}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <nav className="space-y-0.5 p-3">
+            {activeBrandId && (
+              <Link
+                href={`/dashboard/brands/${activeBrandId}/prompts`}
+                onClick={() => setOpen(false)}
               >
-                <MessageSquareText className="h-4 w-4 shrink-0" />
-                Prompts
-              </span>
-            </Link>
-          )}
-          {dashboardNav.flatMap((group) =>
-            group.items.map((item) => {
-              const isActive =
-                item.href === '/dashboard'
-                  ? pathname === '/dashboard'
-                  : pathname.startsWith(item.href);
-              const label = getLabel(item.title);
-
-              const isLocked =
-                isCloud &&
-                item.requiredFeature != null &&
-                !canUse(item.requiredFeature);
-
-              if (isLocked) {
-                return (
-                  <span
-                    key={item.href}
-                    className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground/50 cursor-not-allowed"
-                  >
-                    <item.icon className="h-4 w-4 shrink-0" />
-                    <span className="flex-1">{label}</span>
-                    <Badge
-                      variant="outline"
-                      className="h-5 gap-0.5 px-1.5 text-[10px] font-normal"
-                    >
-                      <Crown className="h-2.5 w-2.5" />
-                      {requiredPlanFor(item.requiredFeature!)}
-                    </Badge>
-                  </span>
-                );
-              }
-
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onClick={() => setOpen(false)}
+                <span
+                  className={cn(
+                    'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                    pathname.includes(`/brands/${activeBrandId}/prompts`)
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                  )}
                 >
-                  <span
-                    className={cn(
-                      'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                      isActive
-                        ? 'bg-primary/10 text-primary'
-                        : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                    )}
+                  <MessageSquareText className="h-4 w-4 shrink-0" />
+                  Prompts
+                </span>
+              </Link>
+            )}
+            {dashboardNav.flatMap((group) =>
+              group.items.map((item) => {
+                const isActive =
+                  item.href === '/dashboard'
+                    ? pathname === '/dashboard'
+                    : pathname.startsWith(item.href);
+                const label = getLabel(item.title);
+
+                const isLocked =
+                  isCloud &&
+                  item.requiredFeature != null &&
+                  !canUse(item.requiredFeature);
+
+                if (isLocked) {
+                  return (
+                    <span
+                      key={item.href}
+                      className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground/50 cursor-not-allowed"
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" />
+                      <span className="flex-1">{label}</span>
+                      <Badge
+                        variant="outline"
+                        className="h-5 gap-0.5 px-1.5 text-[10px] font-normal"
+                      >
+                        <Crown className="h-2.5 w-2.5" />
+                        {requiredPlanFor(item.requiredFeature!)}
+                      </Badge>
+                    </span>
+                  );
+                }
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setOpen(false)}
                   >
-                    <item.icon className="h-4 w-4 shrink-0" />
-                    {label}
-                  </span>
-                </Link>
-              );
-            }),
-          )}
-        </nav>
+                    <span
+                      className={cn(
+                        'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                        isActive
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                      )}
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" />
+                      {label}
+                    </span>
+                  </Link>
+                );
+              }),
+            )}
+          </nav>
+        </div>
+        <div className="border-t p-2">
+          <UserProfileNavItem onClick={() => setOpen(false)} />
+        </div>
       </SheetContent>
     </Sheet>
   );

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -15,12 +15,8 @@ import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import { BrandSwitcher } from '@/components/layout/brand-switcher';
-import {
-  Crown,
-  Lock,
-  PanelLeftClose,
-  PanelLeftOpen,
-} from 'lucide-react';
+import { UserProfileNavItem } from '@/components/layout/user-profile-nav-item';
+import { Crown, Lock, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -31,6 +27,7 @@ export function Sidebar() {
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
+
   const logoSrc =
     mounted && resolvedTheme === 'dark' ? '/logo_dark.svg' : '/logo_light.svg';
 
@@ -55,11 +52,18 @@ export function Sidebar() {
         isCollapsed ? 'w-16' : 'w-60',
       )}
     >
-      {/* Logo */}
-      <div className="flex h-16 items-center border-b px-3">
+      <div
+        className={cn(
+          'flex h-16 items-center border-b px-3',
+          isCollapsed && 'justify-center px-0',
+        )}
+      >
         <Link
           href="/dashboard"
-          className="flex items-center gap-2 overflow-hidden"
+          className={cn(
+            'flex items-center gap-2 overflow-hidden',
+            !isCollapsed && 'w-full',
+          )}
         >
           <Image
             src={logoSrc}
@@ -75,14 +79,10 @@ export function Sidebar() {
         </Link>
       </div>
 
-      {/* Brand Switcher */}
-      <div
-        className={cn('border-b px-2 py-2', isCollapsed && 'px-1')}
-      >
+      <div className={cn('border-b px-2 py-2', isCollapsed && 'px-1')}>
         <BrandSwitcher collapsed={isCollapsed} />
       </div>
 
-      {/* Nav */}
       <ScrollArea className="flex-1 px-2 py-3">
         {dashboardNav.map((group, i) => (
           <div key={i} className="mb-4">
@@ -113,7 +113,7 @@ export function Sidebar() {
                     <span
                       key={item.href}
                       className={cn(
-                        'flex items-center gap-3 rounded-md px-2 py-2 text-sm font-medium text-muted-foreground/50 cursor-not-allowed',
+                        'flex cursor-not-allowed items-center gap-3 rounded-md px-2 py-2 text-sm font-medium text-muted-foreground/50',
                         isCollapsed && 'justify-center',
                       )}
                       title={
@@ -128,7 +128,7 @@ export function Sidebar() {
                           <span className="flex-1 truncate">{label}</span>
                           <Badge
                             variant="outline"
-                            className="ml-auto h-5 gap-0.5 px-1.5 text-[10px] font-normal shrink-0"
+                            className="ml-auto h-5 shrink-0 gap-0.5 px-1.5 text-[10px] font-normal"
                           >
                             <Crown className="h-2.5 w-2.5" />
                             {requiredPlanFor(item.requiredFeature!)}
@@ -167,12 +167,15 @@ export function Sidebar() {
         ))}
       </ScrollArea>
 
-      {/* Collapse toggle */}
+      <div className="border-t p-2">
+        <UserProfileNavItem collapsed={isCollapsed} />
+      </div>
+
       <div className="border-t p-2">
         <Button
           variant="ghost"
           size="icon"
-          className="w-full"
+          className="mt-1 w-full"
           onClick={toggleCollapse}
         >
           {isCollapsed ? (

--- a/web/src/components/layout/user-profile-nav-item.tsx
+++ b/web/src/components/layout/user-profile-nav-item.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Link } from '@/i18n/navigation';
+import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/stores/use-auth-store';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+
+interface UserProfileNavItemProps {
+  collapsed?: boolean;
+  onClick?: () => void;
+  className?: string;
+}
+
+export function UserProfileNavItem({
+  collapsed = false,
+  onClick,
+  className,
+}: UserProfileNavItemProps) {
+  const user = useAuthStore((state) => state.user);
+  const fullName = user?.user_metadata?.full_name;
+  const displayName = typeof fullName === 'string' ? fullName : '';
+  const email = user?.email ?? '';
+
+  const label = displayName || email || 'User Name';
+  const initials = displayName
+    ? displayName
+        .trim()
+        .split(/\s+/)
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase() || '')
+        .join('')
+    : (email[0]?.toUpperCase() ?? 'U');
+
+  return (
+    <Link
+      href="/dashboard/settings"
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-2 rounded-md px-2 py-2 text-sm transition-colors hover:bg-accent',
+        collapsed && 'justify-center px-0',
+        className,
+      )}
+      title={collapsed ? label : undefined}
+    >
+      <Avatar className="h-8 w-8 shrink-0">
+        <AvatarFallback className="bg-primary/10 text-xs font-semibold text-primary">
+          {initials}
+        </AvatarFallback>
+      </Avatar>
+      {!collapsed && (
+        <span className="truncate text-sm font-medium capitalize">{label}</span>
+      )}
+    </Link>
+  );
+}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,26 +1,26 @@
-'use client';
+"use client"
 
-import * as React from 'react';
-import { Dialog as SheetPrimitive } from '@base-ui/react/dialog';
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
 
-import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
-import { XIcon } from 'lucide-react';
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
 }
 
 function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
 }
 
 function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
-  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
 }
 
 function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
 }
 
 function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
@@ -28,23 +28,23 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
     <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
-        className,
+        "fixed inset-0 z-50 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
 function SheetContent({
   className,
   children,
-  side = 'right',
+  side = "right",
   showCloseButton = true,
   ...props
 }: SheetPrimitive.Popup.Props & {
-  side?: 'top' | 'right' | 'bottom' | 'left';
-  showCloseButton?: boolean;
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
 }) {
   return (
     <SheetPortal>
@@ -53,8 +53,8 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         className={cn(
-          'fixed z-50 flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10',
-          className,
+          "fixed z-50 flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          className
         )}
         {...props}
       >
@@ -65,48 +65,49 @@ function SheetContent({
             render={
               <Button
                 variant="ghost"
-                className="absolute top-4 right-3"
+                className="absolute top-3 right-3"
                 size="icon-sm"
               />
             }
           >
-            <XIcon />
+            <XIcon
+            />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Popup>
     </SheetPortal>
-  );
+  )
 }
 
-function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn('flex flex-col gap-0.5 p-4', className)}
+      className={cn("flex flex-col gap-0.5 p-4", className)}
       {...props}
     />
-  );
+  )
 }
 
-function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
       {...props}
     />
-  );
+  )
 }
 
 function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('text-base font-medium text-foreground', className)}
+      className={cn("text-base font-medium text-foreground", className)}
       {...props}
     />
-  );
+  )
 }
 
 function SheetDescription({
@@ -116,10 +117,10 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn('text-sm text-muted-foreground', className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  );
+  )
 }
 
 export {
@@ -131,4 +132,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-};
+}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,26 +1,26 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
+import * as React from 'react';
+import { Dialog as SheetPrimitive } from '@base-ui/react/dialog';
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { XIcon } from 'lucide-react';
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
 function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
 function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
-  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
 function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
 function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
@@ -28,23 +28,23 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
     <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        'fixed inset-0 z-50 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function SheetContent({
   className,
   children,
-  side = "right",
+  side = 'right',
   showCloseButton = true,
   ...props
 }: SheetPrimitive.Popup.Props & {
-  side?: "top" | "right" | "bottom" | "left"
-  showCloseButton?: boolean
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  showCloseButton?: boolean;
 }) {
   return (
     <SheetPortal>
@@ -53,8 +53,8 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         className={cn(
-          "fixed z-50 flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
-          className
+          'fixed z-50 flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10',
+          className,
         )}
         {...props}
       >
@@ -65,49 +65,48 @@ function SheetContent({
             render={
               <Button
                 variant="ghost"
-                className="absolute top-3 right-3"
+                className="absolute top-4 right-3"
                 size="icon-sm"
               />
             }
           >
-            <XIcon
-            />
+            <XIcon />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Popup>
     </SheetPortal>
-  )
+  );
 }
 
-function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn("flex flex-col gap-0.5 p-4", className)}
+      className={cn('flex flex-col gap-0.5 p-4', className)}
       {...props}
     />
-  )
+  );
 }
 
-function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
       {...props}
     />
-  )
+  );
 }
 
 function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-base font-medium text-foreground", className)}
+      className={cn('text-base font-medium text-foreground', className)}
       {...props}
     />
-  )
+  );
 }
 
 function SheetDescription({
@@ -117,10 +116,10 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -132,4 +131,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-}
+};


### PR DESCRIPTION
### What Changed And Why

- Added a shared profile nav component in user-profile-nav-item.tsx and reused it in both sidebar.tsx and mobile-nav.tsx. This keeps the user profile UI consistent across desktop and mobile.
- Added a safe loading fallback in the shared profile item: while auth data is not ready, the avatar shows U and the label shows User Name, so the UI never looks empty.
- The profile label uses truncate so long names or emails do not break the sidebar/mobile-nav layout.
- Avatar initials are derived from only the first two name parts, so a name like Jack D Harlow would render as JD instead of using more than two initials.
- Updated mobile nav so the menu items are scrollable and the user profile stays fixed at the bottom.
- Fixed the collapsed desktop sidebar header so the logo is centered properly when minimized.

---

### How To Test The Change

1. Open the dashboard on desktop and verify the profile row appears at the bottom of the sidebar above the collapse button.
2. Refresh the page and confirm the temporary fallback state can show avatar U and label User Name before auth data is available.
3. Verify a long display name or email is visually truncated and does not overflow the sidebar or mobile nav row.
4. Verify initials use only the first two name parts. For example, a user with First Middle Last should show FM.
5. Collapse the desktop sidebar and confirm the logo is centered and the profile switches to avatar-only.
6. Open the mobile nav sheet and confirm the nav items scroll while the profile row stays fixed at the bottom.
7. Tap the profile row in mobile nav and confirm the sheet closes and navigation goes to /dashboard/settings.

---

### Screenshots
<img width="1420" height="911" alt="image" src="https://github.com/user-attachments/assets/88a95041-3feb-497e-96ed-35b52a8aa1a5" />
<img width="625" height="765" alt="image" src="https://github.com/user-attachments/assets/77e15735-4713-4f63-8641-9bed4583766b" />

This should fix #45 