### PR TITLE
feat(prompts): added csv export button in all prompts tab

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -31,6 +31,7 @@ import {
   RefreshCw,
   Pencil,
   Settings2,
+  Download,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useBrandStore } from '@/stores/use-brand-store';
@@ -48,6 +49,7 @@ import {
 import { aggregatePromptVolumeClusters } from '@/lib/prompt-volume-clusters';
 import type { PromptVolume, Prompt } from '@/types';
 import { toast } from 'sonner';
+import { toCsv } from '@/lib/csv';
 
 // ─── Info Tooltip ─────────────────────────────────────────────────────────────
 
@@ -131,6 +133,26 @@ const INTENT_COLORS: Record<string, string> = {
   'problem-solving':
     'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400',
 };
+
+const PROMPT_EXPORT_HEADERS = [
+  'text',
+  'topic_id',
+  'category',
+  'platforms',
+  'models',
+  'regions',
+  'is_active',
+  'created_at',
+  'est_ai_volume',
+  'total_google_volume',
+  'intent',
+  'avg_visibility_30d',
+  'total_mentions_30d',
+  'runs_30d',
+  'last_run_at',
+];
+
+const PROMPT_EXPORT_HINT = 'No prompts yet - add prompts first.';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -222,6 +244,9 @@ export default function PromptsPage() {
   const [quota, setQuota] = useState<VolumeQuota | null>(null);
 
   const activeBrandId = useBrandStore((s) => s.activeBrandId);
+  const activeBrand = useBrandStore(
+    (s) => s.brands.find((brand) => brand.id === s.activeBrandId) ?? null,
+  );
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -422,6 +447,43 @@ export default function PromptsPage() {
     return m;
   }, [volumes]);
 
+  const canExport = !loading && allPrompts.length > 0;
+
+  const handleExportCsv = useCallback(() => {
+    if (!canExport) return;
+
+    const rows = allPrompts.map((p) => ({
+      text: p.text,
+      topic_id: p.topicId ?? '',
+      category: p.category ?? '',
+      platforms: p.platforms.join(', '),
+      models: p.models.join(', '),
+      regions: p.regions.join(', '),
+      is_active: p.isActive,
+      created_at: p.createdAt,
+      est_ai_volume: volumeByPromptId.get(p.id)?.estAiVolume ?? '',
+      total_google_volume: volumeByPromptId.get(p.id)?.totalGoogleVolume ?? '',
+      intent: volumeByPromptId.get(p.id)?.intent ?? '',
+      avg_visibility_30d: visibility[p.id]?.avgVisibility ?? '',
+      total_mentions_30d: visibility[p.id]?.totalMentions ?? '',
+      runs_30d: visibility[p.id]?.runs ?? '',
+      last_run_at: visibility[p.id]?.lastRunAt ?? '',
+    }));
+
+    const csv = toCsv(rows, PROMPT_EXPORT_HEADERS);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const date = new Date().toISOString().slice(0, 10);
+    const slug = activeBrand?.slug ?? 'brand';
+
+    link.href = url;
+    link.download = `ansvisor_${slug}_prompts_${date}.csv`;
+    link.click();
+
+    URL.revokeObjectURL(url);
+  }, [activeBrand?.slug, canExport, allPrompts, visibility, volumeByPromptId]);
+
   if (!activeBrandId) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -452,13 +514,31 @@ export default function PromptsPage() {
             <TabsTrigger value="all">All Prompts</TabsTrigger>
             <TabsTrigger value="insights">Insights</TabsTrigger>
           </TabsList>
-          <Link
-            href={`/dashboard/brands/${activeBrandId}/prompts`}
-            className={buttonVariants({ variant: 'outline', size: 'sm' })}
-          >
-            <Settings2 className="h-4 w-4" />
-            Manage prompts
-          </Link>
+          <div className="flex items-center gap-2">
+            {tab === 'all' && (
+              <span title={!canExport ? PROMPT_EXPORT_HINT : undefined}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={handleExportCsv}
+                  disabled={!canExport}
+                >
+                  <Download className="h-4 w-4" />
+                  Export CSV
+                </Button>
+              </span>
+            )}
+
+            <Link
+              href={`/dashboard/brands/${activeBrandId}/prompts`}
+              className={buttonVariants({ variant: 'outline', size: 'sm' })}
+            >
+              <Settings2 className="h-4 w-4" />
+              Manage prompts
+            </Link>
+          </div>
         </div>
 
         {/* ─── All Prompts tab ─────────────────────────────────────────── */}


### PR DESCRIPTION
### What Changed and Why

- Added CSV export support to the Prompts dashboard.
- The export action was added only to the All Prompts tab, not the Insights tab, because the CSV output is based on the prompt list and its related table data.
- Reused the shared CSV serializer in csv.ts (line 9) to keep export formatting consistent.
- Kept the export handler inside prompts/page.tsx (line 452) since the exported columns, row mapping, and filename are specific to the Prompts page.
- Disabled the export action when there is no prompt data to avoid empty downloads.

### How to Test the Change

1. Open the Prompts dashboard for a brand with prompt data.
2. Go to the All Prompts tab and confirm the Export CSV action is visible and enabled.
3. Click Export CSV and verify a file downloads with a name like ansvisor_<brand-slug>_prompts_<yyyy-mm-dd>.csv.
4. Open the downloaded file and confirm the headers and rows match the data shown in the All Prompts table.
5. Switch to the Insights tab and confirm the CSV export action is not shown there.
6. Check a brand with no prompts and confirm the export action is disabled or unavailable as expected.
7. Spot-check rows with empty optional fields or comma-separated values to confirm the CSV formatting is valid.

### Screenshots
<img width="1902" height="722" alt="image" src="https://github.com/user-attachments/assets/b46bdc71-a474-48ce-b111-eea757b3c9e0" />

This closes issue #41 