### PR TITLE
feat(citations): add prompt filter with a searchable combobox

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -32,6 +32,18 @@ import {
   type CitationsDatePreset,
 } from '@/lib/actions/citations';
 import { getTopics } from '@/lib/actions/topic';
+import { getBrandPrompts } from '@/lib/actions/tracking';
+import {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+  ComboboxValue,
+} from '@/components/ui/combobox';
 import type { Topic } from '@/types';
 import {
   SOURCE_CATEGORY_LABELS,
@@ -185,8 +197,21 @@ interface UIFilters {
   platform: string;
   region: string;
   topic: string;
+  prompt: string;
   excludeOwnDomain: boolean;
   competitorOnly: boolean;
+}
+
+interface PromptOption {
+  id: string;
+  text: string;
+}
+
+// base-ui's Combobox auto-uses `label` for display and `value` for selection
+// when items are `{ value, label }` shaped — no extra helpers needed.
+interface PromptComboboxItem {
+  value: string;
+  label: string;
 }
 
 interface PlatformOption {
@@ -201,6 +226,7 @@ const DEFAULT_FILTERS: UIFilters = {
   platform: '',
   region: '',
   topic: '',
+  prompt: '',
   excludeOwnDomain: false,
   competitorOnly: false,
 };
@@ -433,15 +459,29 @@ function FilterBar({
   filters,
   onChange,
   topics,
+  prompts,
   platforms,
   regions,
 }: {
   filters: UIFilters;
   onChange: (patch: Partial<UIFilters>) => void;
   topics: Topic[];
+  prompts: PromptOption[];
   platforms: PlatformOption[];
   regions: string[];
 }) {
+  // base-ui Combobox needs `{ value, label }` shaped items so it can use the
+  // built-in filter and display logic without custom item-to-string helpers.
+  // Truncate long prompt text so the dropdown stays a sensible width.
+  const promptComboboxItems = useMemo<PromptComboboxItem[]>(
+    () =>
+      prompts.map((p) => ({
+        value: p.id,
+        label: p.text.length > 80 ? `${p.text.slice(0, 80)}…` : p.text,
+      })),
+    [prompts],
+  );
+
   return (
     <div className="flex flex-wrap items-end gap-3">
       <div>
@@ -523,6 +563,46 @@ function FilterBar({
               ))}
             </SelectContent>
           </Select>
+        </div>
+      )}
+
+      {prompts.length > 0 && (
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            Prompt
+          </label>
+          <Combobox
+            items={promptComboboxItems}
+            value={
+              filters.prompt
+                ? (promptComboboxItems.find(
+                    (item) => item.value === filters.prompt,
+                  ) ?? null)
+                : null
+            }
+            onValueChange={(item: PromptComboboxItem | null) =>
+              onChange({
+                prompt: !item || item.value === '__all__' ? '' : item.value,
+              })
+            }
+          >
+            <ComboboxTrigger className="h-8 w-56 text-xs">
+              <ComboboxValue placeholder="All Prompts" />
+            </ComboboxTrigger>
+            <ComboboxContent>
+              <ComboboxInput placeholder="Search prompts…" />
+              <ComboboxList>
+                <ComboboxEmpty>No prompts match.</ComboboxEmpty>
+                <ComboboxCollection>
+                  {(item: PromptComboboxItem) => (
+                    <ComboboxItem key={item.value} value={item}>
+                      {item.label}
+                    </ComboboxItem>
+                  )}
+                </ComboboxCollection>
+              </ComboboxList>
+            </ComboboxContent>
+          </Combobox>
         </div>
       )}
 
@@ -806,6 +886,7 @@ export default function CitationsPage() {
   const [data, setData] = useState<CitationsOverview | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [topics, setTopics] = useState<Topic[]>([]);
+  const [prompts, setPrompts] = useState<PromptOption[]>([]);
   const [availablePlatforms, setAvailablePlatforms] = useState<PlatformOption[]>(
     [],
   );
@@ -816,6 +897,9 @@ export default function CitationsPage() {
   useEffect(() => {
     if (!activeBrandId) return;
     getTopics(activeBrandId).then(setTopics).catch(() => {});
+    getBrandPrompts(activeBrandId)
+      .then((rows) => setPrompts(rows.map((r) => ({ id: r.id, text: r.text }))))
+      .catch(() => {});
   }, [activeBrandId]);
 
   const loadData = useCallback(async () => {
@@ -836,6 +920,7 @@ export default function CitationsPage() {
         platforms: filters.platform ? [filters.platform] : undefined,
         regions: filters.region ? [filters.region] : undefined,
         topicIds: filters.topic ? [filters.topic] : undefined,
+        promptIds: filters.prompt ? [filters.prompt] : undefined,
         excludeOwnDomain: filters.excludeOwnDomain,
         competitorOnly: filters.competitorOnly,
       };
@@ -878,6 +963,7 @@ export default function CitationsPage() {
     filters.platform,
     filters.region,
     filters.topic,
+    filters.prompt,
     filters.excludeOwnDomain,
     filters.competitorOnly,
   ]);
@@ -942,6 +1028,7 @@ export default function CitationsPage() {
         filters={filters}
         onChange={(patch) => setFilters((f) => ({ ...f, ...patch }))}
         topics={topics}
+        prompts={prompts}
         platforms={availablePlatforms}
         regions={availableRegions}
       />

--- a/web/src/components/ui/combobox.tsx
+++ b/web/src/components/ui/combobox.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import * as React from "react";
+import { Combobox as ComboboxPrimitive } from "@base-ui/react/combobox";
+
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, CheckIcon } from "lucide-react";
+
+// Thin styled wrapper around `@base-ui/react/combobox`, matching the look /
+// data-slot conventions of `select.tsx` so callers can swap between Select
+// and Combobox without restyling the surrounding layout.
+
+const Combobox = ComboboxPrimitive.Root;
+const ComboboxPortal = ComboboxPrimitive.Portal;
+// Render-prop wrapper that applies base-ui's built-in filtering to the
+// `items` array passed on `<Combobox>`. Manual `.map()` over items bypasses
+// the filter — use Collection to keep the search input working.
+const ComboboxCollection = ComboboxPrimitive.Collection;
+
+function ComboboxValue(props: ComboboxPrimitive.Value.Props) {
+  return <ComboboxPrimitive.Value {...props} />;
+}
+
+function ComboboxTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: ComboboxPrimitive.Trigger.Props & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <ComboboxPrimitive.Trigger
+      data-slot="combobox-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] dark:bg-input/30 dark:hover:bg-input/50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ComboboxPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </ComboboxPrimitive.Trigger>
+  );
+}
+
+function ComboboxInput({
+  className,
+  ...props
+}: ComboboxPrimitive.Input.Props) {
+  return (
+    <ComboboxPrimitive.Input
+      data-slot="combobox-input"
+      className={cn(
+        "h-9 w-full border-b border-border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground focus-visible:outline-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "start",
+  ...props
+}: ComboboxPrimitive.Popup.Props &
+  Pick<
+    ComboboxPrimitive.Positioner.Props,
+    "align" | "side" | "sideOffset"
+  >) {
+  return (
+    <ComboboxPrimitive.Portal>
+      <ComboboxPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        className="isolate z-50"
+      >
+        <ComboboxPrimitive.Popup
+          data-slot="combobox-content"
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-56 origin-(--transform-origin) overflow-hidden rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </ComboboxPrimitive.Popup>
+      </ComboboxPrimitive.Positioner>
+    </ComboboxPrimitive.Portal>
+  );
+}
+
+function ComboboxList({
+  className,
+  ...props
+}: ComboboxPrimitive.List.Props) {
+  return (
+    <ComboboxPrimitive.List
+      data-slot="combobox-list"
+      className={cn("max-h-64 overflow-y-auto p-1", className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxItem({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Item.Props) {
+  return (
+    <ComboboxPrimitive.Item
+      data-slot="combobox-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1.5 pr-8 pl-1.5 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <span className="flex flex-1 shrink-0 gap-2 whitespace-nowrap truncate">
+        {children}
+      </span>
+      <ComboboxPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none size-4" />
+      </ComboboxPrimitive.ItemIndicator>
+    </ComboboxPrimitive.Item>
+  );
+}
+
+function ComboboxEmpty({
+  className,
+  ...props
+}: ComboboxPrimitive.Empty.Props) {
+  return (
+    <ComboboxPrimitive.Empty
+      data-slot="combobox-empty"
+      className={cn(
+        // base-ui keeps this element in the DOM as an aria-live region even
+        // when there are matches (so screen readers can announce empty
+        // state changes). `empty:hidden` collapses it to zero height when
+        // there are matches — otherwise the padding leaks vertical space
+        // above the list.
+        "px-3 py-6 text-center text-sm text-muted-foreground empty:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxPortal,
+  ComboboxTrigger,
+  ComboboxValue,
+};

--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -27,6 +27,7 @@ export interface CitationsFilters {
   dateTo?: string;
   platforms?: string[];
   topicIds?: string[];
+  promptIds?: string[];
   regions?: string[];
   excludeOwnDomain?: boolean;
   competitorOnly?: boolean;
@@ -182,6 +183,9 @@ export async function getCitationsOverview(
   }
   if (filters.regions && filters.regions.length > 0) {
     query = query.in('region', filters.regions);
+  }
+  if (filters.promptIds && filters.promptIds.length > 0) {
+    query = query.in('prompt_id', filters.promptIds);
   }
 
   if (filters.topicIds && filters.topicIds.length > 0) {


### PR DESCRIPTION
## Summary
- Adds a **Prompt** filter to the Citations page filter bar, between Topic and Platform, so users can scope citations to a single prompt's tracked results.
- Implements it as a **searchable combobox** (not a plain select) so it stays usable on brands with 50+ prompts — live filter, keyboard navigation, truncated long-prompt labels.
- Backend just gains \`promptIds: string[]\` on \`CitationsFilters\` and a matching \`.in('prompt_id', ...)\` clause; everything else is UI.

Closes #43, closes #17 (duplicate).

## What's new for the codebase

- **\`web/src/components/ui/combobox.tsx\`** — new shadcn-style wrapper around \`@base-ui/react/combobox\` (the project's existing primitive library already ships a Combobox component). Exports the usual parts: \`Combobox\`, \`ComboboxTrigger\`, \`ComboboxInput\`, \`ComboboxContent\`, \`ComboboxList\`, \`ComboboxCollection\`, \`ComboboxItem\`, \`ComboboxEmpty\`, \`ComboboxValue\`, \`ComboboxPortal\`. No new package deps — no \`cmdk\`, no radix-popover.
- This wrapper is now available for any future filter that needs search-in-dropdown UX (no more "should we add a search box?" debates).

## Two implementation notes worth flagging for review

1. **Items render through \`<ComboboxCollection>\`, not a manual \`.map()\`.** base-ui's built-in filter only applies to children rendered through Collection — a manual map silently bypasses the search input and produces a non-filtering combobox.
2. **\`<ComboboxEmpty>\` uses \`empty:hidden\`** so it collapses to zero height when there are matches. base-ui keeps the element in the DOM as an aria-live region (for screen-reader announcements of the empty state), which means without \`:empty\` collapsing, its padding leaks visible whitespace above the list whenever the search hasn't narrowed anything down. Took a round to spot; left a comment in the wrapper.

## Test plan
- [ ] /dashboard/citations with a brand that has prompts → **Prompt** filter renders between Topic and Platform
- [ ] Open the combobox → live items list, search input auto-focused
- [ ] Type → list filters down; clearing the search restores full list
- [ ] No-match query → \"No prompts match.\" empty state, no phantom space above
- [ ] Pick a prompt → citations table narrows to that prompt's rows; URL stays at /dashboard/citations
- [ ] Pick another or clear → table updates; trigger label reflects the current selection (truncated if >80 chars)
- [ ] Brand with zero prompts → Prompt filter is hidden entirely