### PR TITLE
fix(billing): block tracking + features for orgs without active subscription

### DIFF
--- a/server/src/config/plans.js
+++ b/server/src/config/plans.js
@@ -112,6 +112,19 @@ export function isCloud() {
   return process.env.IS_CLOUD === 'true';
 }
 
+/**
+ * Whether an organization's Stripe subscription is in a state that grants
+ * access to billed features. `trialing` counts — it's a paid plan in its
+ * free-trial period. Everything else (incomplete, canceled, past_due,
+ * unpaid) does NOT grant access.
+ *
+ * Self-hosted instances always return true since billing doesn't apply.
+ */
+export function isSubscriptionActive(status) {
+  if (!isCloud()) return true;
+  return status === 'active' || status === 'trialing';
+}
+
 export function getPlan(planId) {
   if (!isCloud()) return PLANS.self_hosted;
   return PLANS[planId] || PLANS.starter;

--- a/server/src/lib/plan-guard.js
+++ b/server/src/lib/plan-guard.js
@@ -4,6 +4,7 @@ import {
   hasFeature,
   isWithinLimit,
   isCloud,
+  isSubscriptionActive,
 } from '../config/plans.js';
 
 export class PlanLimitError extends Error {
@@ -37,8 +38,15 @@ async function resolveOrgPlan(userId) {
     .eq('id', profile.organization_id)
     .single();
 
-  if (!org || org.subscription_status !== 'active') {
-    return getPlan('starter');
+  // Block feature access for orgs without an active or trialing Stripe
+  // subscription. Previously this fell back to starter, which silently
+  // granted billed features (volume fetch, content generation, etc.) to
+  // unsubscribed signups.
+  if (!isSubscriptionActive(org?.subscription_status)) {
+    throw new PlanLimitError(
+      'An active subscription or free trial is required. Please choose a plan to continue.',
+      402,
+    );
   }
 
   return getPlan(org.plan);

--- a/server/src/routes/tracking.js
+++ b/server/src/routes/tracking.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { createJob, getJob, cancelJob } from '../lib/job-manager.js';
 import { runTrackingJob } from '../lib/job-runner.js';
 import supabaseAdmin from '../config/supabase.js';
-import { isCloud, getPlan } from '../config/plans.js';
+import { isCloud, getPlan, isSubscriptionActive } from '../config/plans.js';
 
 const router = Router();
 
@@ -154,7 +154,7 @@ router.post('/analyze-new', async (req, res) => {
       return res.json({ success: true, newCount: 0, message: 'All prompts already analyzed' });
     }
 
-    // --- Cloud-mode rate limiting ---
+    // --- Cloud-mode subscription gate + rate limiting ---
     if (isCloud()) {
       const { data: org } = await supabaseAdmin
         .from('organizations')
@@ -162,9 +162,17 @@ router.post('/analyze-new', async (req, res) => {
         .eq('id', brand.organization_id)
         .single();
 
-      const plan = !org || org.subscription_status !== 'active'
-        ? getPlan('starter')
-        : getPlan(org.plan);
+      // Block tracking outright when the org's Stripe subscription isn't
+      // active or trialing. Previously this fell back to starter limits,
+      // which let unsubscribed signups run jobs silently.
+      if (!isSubscriptionActive(org?.subscription_status)) {
+        return res.status(402).json({
+          message:
+            'An active subscription or free trial is required to run tracking. Please choose a plan to continue.',
+        });
+      }
+
+      const plan = getPlan(org.plan);
 
       const { maxDailyOnDemand, onDemandCooldownMinutes } = plan.limits;
 

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -16,7 +16,12 @@ import { runTrackingJob } from './lib/job-runner.js';
 import { parseScraperResponse } from './lib/cloro-scraper.js';
 import { handleScraperResult } from './lib/cloro-result-handler.js';
 import supabaseAdmin from './config/supabase.js';
-import { getPlan, hasFeature, isCloud } from './config/plans.js';
+import {
+  getPlan,
+  hasFeature,
+  isCloud,
+  isSubscriptionActive,
+} from './config/plans.js';
 
 const app = express();
 app.set('trust proxy', 1);
@@ -107,14 +112,20 @@ async function runDailyTracking() {
           .select('plan, subscription_status')
           .eq('id', brand.organization_id)
           .single();
-        orgPlanCache[brand.organization_id] =
-          !org || org.subscription_status !== 'active'
-            ? getPlan('starter')
-            : getPlan(org.plan);
+        // Skip orgs without an active or trialing Stripe subscription.
+        // Previously this fell back to starter limits, which silently kept
+        // running daily monitoring (and Cloro / AI provider spend) for
+        // unsubscribed signups.
+        if (!isSubscriptionActive(org?.subscription_status)) {
+          orgPlanCache[brand.organization_id] = null;
+        } else {
+          orgPlanCache[brand.organization_id] = getPlan(org.plan);
+        }
       }
     }
 
     const plan = orgPlanCache[brand.organization_id];
+    if (!plan) continue; // unsubscribed → skip silently
     if (!hasFeature(plan, 'daily_monitoring')) continue;
 
     const { count } = await supabaseAdmin


### PR DESCRIPTION
## Summary
- Three places on the aeo-server fell back to **starter** plan limits whenever an org's Stripe subscription wasn't \`active\`. That meant any signup who completed onboarding and closed the Stripe checkout tab — leaving the org at \`plan='free'\` \`subscription_status='incomplete'\` — silently kept running on-demand tracking, daily monitoring cron, and gated feature calls. Cloro + AI provider spend continued landing on us for users who never paid.
- The intended rule is: only orgs with \`subscription_status\` of \`'active'\` or \`'trialing'\` (Stripe sets \`trialing\` during the free-trial period of a paid plan) may use billed features. Everything else (\`incomplete\`, \`canceled\`, \`past_due\`, \`unpaid\`) is blocked.

## What changes

Centralizes the check as **\`isSubscriptionActive(status)\`** in \`server/src/config/plans.js\` and applies it in three spots:

| File | Old behaviour | New behaviour |
| --- | --- | --- |
| \`routes/tracking.js\` POST \`/check\` | \`subscription_status !== 'active'\` → starter fallback, job runs | Returns **402** with a "subscribe to continue" message |
| \`server.js\` \`runDailyTracking()\` cron | Same fallback, processed brand silently | Skips the brand entirely (\`plan = null\` → continue) |
| \`lib/plan-guard.js\` \`resolveOrgPlan()\` | Same fallback for feature checks (volume fetch, content gen, etc.) | Throws \`PlanLimitError(402)\` with the same message |

Self-hosted instances are unaffected — \`isSubscriptionActive()\` short-circuits to \`true\` when \`IS_CLOUD !== 'true'\`.

## What this does NOT change

The Next.js \`(dashboard)\` layout already redirects when \`subscription_status\` is not active/trialing. The gap was entirely on the aeo-server endpoints/cron that don't go through that layout — they were the silent leak. UI behaviour stays the same; users hitting a blocked endpoint will see a "subscribe to continue" message instead of phantom progress.

## Existing 6 unsubscribed orgs

There are 6 orgs at \`plan='free'\` / \`subscription_status='incomplete'\` today (real prospect signups, including one major TR retail brand). After this lands they lose tracking access on their next attempt. The "soft cut + manual outreach" path is intentional — they're high-value prospects, the maintainer will email them to push through Stripe checkout before merge.

## Test plan
- [ ] On a brand whose org has \`subscription_status='incomplete'\` or \`'canceled'\`, hit \`POST /api/tracking/check\` → response is \`402\` with the subscribe message
- [ ] Same org, daily cron run → that brand is logged as skipped and produces no \`prompt_results\` rows
- [ ] Feature-gated endpoint (e.g. volume re-fetch) for that org → returns \`402\`
- [ ] On a brand whose org has \`subscription_status='trialing'\` → all of the above succeed normally (this is the legit free-trial case and must NOT regress)
- [ ] On a brand whose org has \`subscription_status='active'\` → all of the above succeed normally
- [ ] Self-hosted instance with \`IS_CLOUD=false\` → all of the above succeed regardless of subscription_status (it doesn't apply)