### PR TITLE
fix(ui): point sign-in / sign-up header logo at the marketing site

### DIFF
--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -10,7 +10,7 @@ export function MarketingHeader() {
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between">
-        <Link href="/sign-in" className="flex items-center gap-2">
+        <a href={siteConfig.url} className="flex items-center gap-2">
           <Image
             src="/logo_light.svg"
             alt=""
@@ -30,7 +30,7 @@ export function MarketingHeader() {
           <span className="text-xl font-bold tracking-tight">
             {siteConfig.name}
           </span>
-        </Link>
+        </a>
 
         <div className="flex items-center gap-3">
           <Link href="/sign-in">


### PR DESCRIPTION
Closes #24. Changes the internal next-intl Link on the auth pages header to a standard anchor tag pointing to `siteConfig.url`. This ensures that when signed-out users click the logo, they are successfully routed back to the canonical marketing site rather than refreshing the auth screen.