### PR TITLE
chore(docs): add Google Search Console verification meta tag

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -11,7 +11,8 @@
     "og:description": "Open-source Answer Engine Optimization platform — track ChatGPT, Gemini, Perplexity, Claude, Copilot brand mentions.",
     "og:image": "https://app.ansvisor.com/opengraph-image",
     "twitter:card": "summary_large_image",
-    "twitter:image": "https://app.ansvisor.com/opengraph-image"
+    "twitter:image": "https://app.ansvisor.com/opengraph-image",
+    "google-site-verification": "mQlyZ6XbIBAH31OrIjuNhO7_0N-CJGobmf"
   },
   "colors": {
     "primary": "#6366f1",


### PR DESCRIPTION
## Summary
- Adds the \`google-site-verification\` token under \`metadata\` in \`docs/mint.json\` so Mintlify emits the corresponding \`<meta>\` tag in the docs site \`<head>\`.
- Lets us register **docs.ansvisor.com** as a Search Console property and start seeing organic-search performance / indexing health for the docs domain.

Scoped to docs only — app and marketing site verifications are separate properties if/when we add them.

## After merge
1. Mintlify auto-deploys from \`main\` → meta tag goes live on docs.ansvisor.com
2. Go to Google Search Console → the docs.ansvisor.com property → click **Verify**
3. GSC confirms ownership and starts collecting search data

## Test plan
- After deploy, view source of any docs.ansvisor.com page → \`<meta name="google-site-verification" content="mQlyZ6XbIBAH31OrIjuNhO7_0N-CJGobmf" />\` present in head.