### PR TITLE
chore(docs): refresh Google Search Console verification token

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -12,7 +12,7 @@
     "og:image": "https://app.ansvisor.com/opengraph-image",
     "twitter:card": "summary_large_image",
     "twitter:image": "https://app.ansvisor.com/opengraph-image",
-    "google-site-verification": "mQlyZ6XbIBAH31OrIjuNhO7_0N-CJGobmf"
+    "google-site-verification": "mQlyZ6XbIBAH31OrIjuNhO7_0N-CJGobmfqcpq6biek"
   },
   "colors": {
     "primary": "#6366f1",


### PR DESCRIPTION
## Summary
- Mintlify issued a new GSC verification token; this PR swaps the meta tag value so the docs.ansvisor.com property can be verified in Search Console.

## Test plan
- After merge → Mintlify auto-deploy → view source on any docs.ansvisor.com page → \`<meta name="google-site-verification" content="mQlyZ6XbIBAH31OrIjuNhO7_0N-CJGobmfqcpq6biek" />\` present in head.
- Go to GSC → click **Verify** on the docs.ansvisor.com property.