### PR TITLE
fix(insights): silence navigation-cancellation toast

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -1471,14 +1471,21 @@ export default function InsightsPage() {
           ),
         );
       } catch (err) {
-        // Silent refreshes fire every ~10s while a tracking job runs; a transient
-        // 5xx or network blip there shouldn't pop a red toast — the next poll
-        // will retry and the user sees nothing.
-        if (!silent) {
-          toast.error(
-            err instanceof Error ? err.message : 'Failed to load insights',
-          );
+        const message = err instanceof Error ? err.message : '';
+
+        // Next.js surfaces this when a server action's response stream is
+        // cut because the user navigated away mid-load. The destination
+        // page renders fine; the toast is pure noise. Matched
+        // case-insensitively so a wording tweak between Next versions
+        // doesn't reopen the issue.
+        if (/unexpected response/i.test(message)) {
+          console.debug('[insights] load aborted by navigation', err);
+        } else if (!silent) {
+          toast.error(message || 'Failed to load insights');
         } else {
+          // Silent refreshes fire every ~10s while a tracking job runs; a
+          // transient 5xx or network blip there shouldn't pop a red toast —
+          // the next poll will retry and the user sees nothing.
           console.warn('[insights] silent refresh failed', err);
         }
       } finally {


### PR DESCRIPTION
## Summary

Closes #40.

When the user navigates away from `/dashboard/insights` while `loadData` is still in flight, Next.js surfaces an `"An unexpected response was received from the server"` error from the aborted stream. The destination page renders fine — the toast is purely cosmetic noise, but it scares users into thinking something broke.

The `catch` block of `loadData` now guards on a case-insensitive match of `"unexpected response"` and routes that one specific error to `console.debug` instead of `toast.error`. Real errors (5xx, malformed payload, etc.) still surface as toasts. The silent-refresh branch is untouched.

Case-insensitive matching is deliberate so a minor wording change in a future Next.js version doesn't reopen the issue.

## Test plan

- [ ] Open `/dashboard/insights` cold (no cache), click a sidebar link while spinners are still showing → **no red toast**
- [ ] Stop the dev API server, reload `/dashboard/insights` → a real error toast still appears (we only suppress one specific string, not all errors)
- [ ] Normal page load with data → loads cleanly, no toast either way
- [ ] Silent refresh path (long-running tracking job) still warns via `console.warn` instead of toasting