### PR TITLE
feat(insights): added csv export button on the answer engine insights page header

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -4,12 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from '@/i18n/navigation';
 import { useSearchParams } from 'next/navigation';
 import { createPortal } from 'react-dom';
-import {
-  CompetitorChart,
-  CompetitorLeaderboard,
-  ShareOfVoicePlatformChart,
-  ShareOfVoiceTrendChart,
-} from './_charts';
+import { CompetitorChart, CompetitorLeaderboard, ShareOfVoicePlatformChart, ShareOfVoiceTrendChart } from './_charts';
 import { MetricBreakdownSheet } from './_metric-breakdown-sheet';
 import { useBrandStore } from '@/stores/use-brand-store';
 import {
@@ -39,7 +34,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableRow, 
+} from '@/components/ui/table';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   BarChart3,
@@ -315,9 +315,7 @@ interface PromptGroup {
   totalCitations: number;
 }
 
-function groupResultsByPlatform(
-  items: PromptResultWithText[],
-): PlatformGroup[] {
+function groupResultsByPlatform( items: PromptResultWithText[]): PlatformGroup[] {
   const map = new Map<string, PromptResultWithText[]>();
   for (const r of items) {
     const key = `${r.platform}|${r.modelUsed ?? ''}`;
@@ -329,8 +327,7 @@ function groupResultsByPlatform(
   return Array.from(map.entries())
     .map(([key, arr]) => {
       const sorted = [...arr].sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
       );
       const latest = sorted[0];
       return {
@@ -343,9 +340,7 @@ function groupResultsByPlatform(
         latestScore: latest.visibilityScore,
         avgScore:
           Math.round(
-            (sorted.reduce((s, r) => s + r.visibilityScore, 0) /
-              sorted.length) *
-              10,
+            (sorted.reduce((s, r) => s + r.visibilityScore, 0) / sorted.length) * 10,
           ) / 10,
         totalMentions: sorted.reduce((s, r) => s + r.mentionCount, 0),
         totalCitations: sorted.reduce((s, r) => s + r.citationCount, 0),
@@ -354,10 +349,7 @@ function groupResultsByPlatform(
     .sort((a, b) => b.latestScore - a.latestScore);
 }
 
-function computePromptGroup(
-  promptId: string,
-  items: PromptResultWithText[],
-): PromptGroup {
+function computePromptGroup(promptId: string, items: PromptResultWithText[]): PromptGroup {
   const sorted = [...items].sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   );
@@ -419,8 +411,7 @@ function groupResultsByTopic(results: PromptResultWithText[]): TopicGroup[] {
       );
       return {
         topicId: items[0].topicId ?? `__cat_${topicName}`,
-        topicName:
-          topicName === '__uncategorized__' ? 'Uncategorized' : topicName,
+        topicName: topicName === '__uncategorized__' ? 'Uncategorized' : topicName,
         prompts,
         avgScore: Math.round(
           items.reduce((s, r) => s + r.visibilityScore, 0) / items.length,
@@ -747,8 +738,7 @@ function FilterBar({
               <SelectValue placeholder="All Topics">
                 {(value) =>
                   value && value !== '__all__'
-                    ? (availableTopics.find((t) => t.id === value)?.name ??
-                      'All Topics')
+                    ? (availableTopics.find((t) => t.id === value)?.name ?? 'All Topics')
                     : 'All Topics'
                 }
               </SelectValue>
@@ -933,11 +923,7 @@ function NoDataForPeriod({
 
 // ─── Tracking Progress ────────────────────────────────────────────────────────
 
-import {
-  saveTrackingJob,
-  loadTrackingJob,
-  clearTrackingJob,
-} from '@/lib/tracking-job-store';
+import { saveTrackingJob, loadTrackingJob, clearTrackingJob } from '@/lib/tracking-job-store';
 import { toCsv } from '@/lib/csv';
 
 function TrackingProgressBanner({
@@ -1051,28 +1037,18 @@ function PlatformSubGroup({
         tabIndex={0}
         onClick={onToggle}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onToggle();
-          }
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); }
         }}
         className="flex w-full items-center gap-3 px-3 py-2 hover:bg-muted/40 transition-colors cursor-pointer select-none"
       >
-        <ChevronDown
-          className={cn(
-            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
-            !expanded && '-rotate-90',
-          )}
-        />
+        <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', !expanded && '-rotate-90')} />
         <div className="flex-1 min-w-0 flex items-center gap-2">
           <ModelBadge
             model={latest.modelUsed ?? latest.platform}
             platform={latest.platform}
           />
           {latest.region && (
-            <Badge variant="outline" className="text-[10px]">
-              {latest.region}
-            </Badge>
+            <Badge variant="outline" className="text-[10px]">{latest.region}</Badge>
           )}
           <span className="text-[10px] text-muted-foreground tabular-nums ml-1">
             {group.results.length} run{group.results.length !== 1 ? 's' : ''}
@@ -1081,15 +1057,11 @@ function PlatformSubGroup({
         <div className="flex items-center gap-4 shrink-0">
           <div className="hidden sm:block text-right">
             <p className="text-[10px] text-muted-foreground">Mentions</p>
-            <p className="text-xs font-semibold tabular-nums">
-              {latest.mentionCount}
-            </p>
+            <p className="text-xs font-semibold tabular-nums">{latest.mentionCount}</p>
           </div>
           <div className="hidden sm:block text-right">
             <p className="text-[10px] text-muted-foreground">Citations</p>
-            <p className="text-xs font-semibold tabular-nums">
-              {latest.citationCount}
-            </p>
+            <p className="text-xs font-semibold tabular-nums">{latest.citationCount}</p>
           </div>
           <SentimentBadge sentiment={latest.sentiment} />
           <div className="w-[100px] sm:w-[140px]">
@@ -1109,10 +1081,7 @@ function PlatformSubGroup({
                 variant="ghost"
                 size="sm"
                 className="h-6 gap-1.5 text-[11px]"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onViewResult(latest);
-                }}
+                onClick={(e) => { e.stopPropagation(); onViewResult(latest); }}
               >
                 <Eye className="h-3 w-3" />
                 Full detail
@@ -1137,21 +1106,15 @@ function PlatformSubGroup({
                           {formatTimestamp(r.createdAt)}
                         </TableCell>
                         <TableCell className="text-center py-1.5 text-xs tabular-nums w-[110px]">
-                          <span className="font-semibold">
-                            {r.mentionCount}
-                          </span>
+                          <span className="font-semibold">{r.mentionCount}</span>
                           <span className="text-muted-foreground">
-                            {' '}
-                            mention{r.mentionCount !== 1 ? 's' : ''}
+                            {' '}mention{r.mentionCount !== 1 ? 's' : ''}
                           </span>
                         </TableCell>
                         <TableCell className="text-center py-1.5 text-xs tabular-nums w-[110px]">
-                          <span className="font-semibold">
-                            {r.citationCount}
-                          </span>
+                          <span className="font-semibold">{r.citationCount}</span>
                           <span className="text-muted-foreground">
-                            {' '}
-                            citation{r.citationCount !== 1 ? 's' : ''}
+                            {' '}citation{r.citationCount !== 1 ? 's' : ''}
                           </span>
                         </TableCell>
                         <TableCell className="text-center py-1.5 w-[100px]">
@@ -1166,10 +1129,7 @@ function PlatformSubGroup({
                             size="icon"
                             className="h-6 w-6"
                             title="View detail"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onViewResult(r);
-                            }}
+                            onClick={(e) => { e.stopPropagation();onViewResult(r); }}
                           >
                             <Eye className="h-3 w-3" />
                           </Button>
@@ -1181,8 +1141,7 @@ function PlatformSubGroup({
               </div>
               {hasMoreHistory && (
                 <p className="text-[10px] text-muted-foreground mt-1">
-                  Showing latest {HISTORY_LIMIT} of {group.results.length - 1}{' '}
-                  previous runs.
+                  Showing latest {HISTORY_LIMIT} of {group.results.length - 1}{' '} previous runs.
                 </p>
               )}
             </div>
@@ -1219,24 +1178,15 @@ function PromptSubGroup({
         tabIndex={0}
         onClick={onToggle}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onToggle();
-          }
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); }
         }}
         className="flex w-full items-center gap-3 px-4 py-2.5 text-left hover:bg-muted/50 transition-colors cursor-pointer select-none"
       >
-        <ChevronDown
-          className={cn(
-            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
-            !expanded && '-rotate-90',
-          )}
-        />
+        <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', !expanded && '-rotate-90')}/>
         <div className="flex-1 min-w-0">
           <p className="text-sm line-clamp-1">{group.promptText}</p>
           <span className="text-[11px] text-muted-foreground">
-            {group.platformGroups.length} platform
-            {group.platformGroups.length !== 1 ? 's' : ''}
+            {group.platformGroups.length} platform{group.platformGroups.length !== 1 ? 's' : ''}
             {' · '}
             {group.results.length} result{group.results.length !== 1 ? 's' : ''}
           </span>
@@ -1244,21 +1194,15 @@ function PromptSubGroup({
         <div className="flex items-center gap-4 shrink-0">
           <div className="text-right">
             <p className="text-[10px] text-muted-foreground">Score</p>
-            <p className="text-xs font-semibold tabular-nums">
-              {group.avgScore}
-            </p>
+            <p className="text-xs font-semibold tabular-nums">{group.avgScore}</p>
           </div>
           <div className="text-right">
             <p className="text-[10px] text-muted-foreground">Mentions</p>
-            <p className="text-xs font-semibold tabular-nums">
-              {group.totalMentions}
-            </p>
+            <p className="text-xs font-semibold tabular-nums">{group.totalMentions}</p>
           </div>
           <div className="text-right">
             <p className="text-[10px] text-muted-foreground">Citations</p>
-            <p className="text-xs font-semibold tabular-nums">
-              {group.totalCitations}
-            </p>
+            <p className="text-xs font-semibold tabular-nums">{group.totalCitations}</p>
           </div>
           <Button
             variant="ghost"
@@ -1266,10 +1210,7 @@ function PromptSubGroup({
             className="h-6 w-6"
             title="Refresh results"
             disabled={refreshingId !== null}
-            onClick={(e) => {
-              e.stopPropagation();
-              onRefresh(group.promptId);
-            }}
+            onClick={(e) => { e.stopPropagation(); onRefresh(group.promptId); }}
           >
             {refreshingId === group.promptId ? (
               <Loader2 className="h-3 w-3 animate-spin" />
@@ -1315,45 +1256,34 @@ function PromptResultsGrouped({
 }) {
   const topicGroups = groupResultsByTopic(results);
   const [expandedTopics, setExpandedTopics] = useState<Set<string>>(new Set());
-  const [expandedPrompts, setExpandedPrompts] = useState<Set<string>>(
-    new Set(),
-  );
-  const [expandedPlatforms, setExpandedPlatforms] = useState<Set<string>>(
-    new Set(),
-  );
+  const [expandedPrompts, setExpandedPrompts] = useState<Set<string>>(new Set());
+  const [expandedPlatforms, setExpandedPlatforms] = useState<Set<string>>(new Set());
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
 
   const toggleTopic = (id: string) =>
     setExpandedTopics((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(id)) next.delete(id); else next.add(id);
       return next;
     });
 
   const togglePrompt = (id: string) =>
     setExpandedPrompts((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(id)) next.delete(id); else next.add(id);
       return next;
     });
 
   const togglePlatform = (id: string) =>
     setExpandedPlatforms((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(id)) next.delete(id); else next.add(id);
       return next;
     });
 
   const handleRefresh = async (promptId: string) => {
     setRefreshingId(promptId);
-    try {
-      await onRefreshPrompt(promptId);
-    } finally {
-      setRefreshingId(null);
-    }
+    try { await onRefreshPrompt(promptId); } finally { setRefreshingId(null); }
   };
 
   const truncated = totalRowCount > loadedRowCount && loadedRowCount > 0;
@@ -1362,9 +1292,7 @@ function PromptResultsGrouped({
     <Card>
       <CardHeader className="pb-2">
         <div className="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
-          <CardTitle className="text-sm font-medium">
-            Prompt Results by Topic
-          </CardTitle>
+          <CardTitle className="text-sm font-medium">Prompt Results by Topic</CardTitle>
           {truncated && (
             <p className="text-xs text-muted-foreground font-normal">
               Showing {loadedRowCount} of {totalRowCount} rows (newest first).
@@ -1384,56 +1312,36 @@ function PromptResultsGrouped({
           {topicGroups.map((topic) => {
             const isTopicOpen = expandedTopics.has(topic.topicId);
             return (
-              <div
-                key={topic.topicId + topic.topicName}
-                className="rounded-lg border overflow-hidden"
-              >
+              <div key={topic.topicId + topic.topicName} className="rounded-lg border overflow-hidden">
                 <div
                   role="button"
                   tabIndex={0}
                   onClick={() => toggleTopic(topic.topicId)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      toggleTopic(topic.topicId);
-                    }
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleTopic(topic.topicId); }
                   }}
                   className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/50 transition-colors cursor-pointer select-none"
                 >
-                  <ChevronDown
-                    className={cn(
-                      'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
-                      !isTopicOpen && '-rotate-90',
-                    )}
-                  />
+                  <ChevronDown className={cn('h-4 w-4 shrink-0 text-muted-foreground transition-transform', !isTopicOpen && '-rotate-90')} />
                   <Tag className="h-4 w-4 shrink-0 text-muted-foreground" />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium">{topic.topicName}</p>
                     <span className="text-[11px] text-muted-foreground">
-                      {topic.prompts.length} prompt
-                      {topic.prompts.length !== 1 ? 's' : ''} ·{' '}
-                      {topic.totalResults} result
-                      {topic.totalResults !== 1 ? 's' : ''}
+                      {topic.prompts.length} prompt{topic.prompts.length !== 1 ? 's' : ''} · {topic.totalResults} result{topic.totalResults !== 1 ? 's' : ''}
                     </span>
                   </div>
                   <div className="flex items-center gap-4 shrink-0">
                     <div className="text-right">
                       <p className="text-xs text-muted-foreground">Avg Score</p>
-                      <p className="text-sm font-semibold tabular-nums">
-                        {topic.avgScore}
-                      </p>
+                      <p className="text-sm font-semibold tabular-nums">{topic.avgScore}</p>
                     </div>
                     <div className="text-right">
                       <p className="text-xs text-muted-foreground">Mentions</p>
-                      <p className="text-sm font-semibold tabular-nums">
-                        {topic.totalMentions}
-                      </p>
+                      <p className="text-sm font-semibold tabular-nums">{topic.totalMentions}</p>
                     </div>
                     <div className="text-right">
                       <p className="text-xs text-muted-foreground">Citations</p>
-                      <p className="text-sm font-semibold tabular-nums">
-                        {topic.totalCitations}
-                      </p>
+                      <p className="text-sm font-semibold tabular-nums">{topic.totalCitations}</p>
                     </div>
                   </div>
                 </div>
@@ -1486,8 +1394,7 @@ export default function InsightsPage() {
   const [competitorData, setCompetitorData] =
     useState<CompetitorComparisonData | null>(null);
   const [sovData, setSovData] = useState<ShareOfVoiceData | null>(null);
-  const [breakdownMetric, setBreakdownMetric] =
-    useState<BreakdownMetric | null>(null);
+  const [breakdownMetric, setBreakdownMetric] = useState<BreakdownMetric | null>(null);
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
 
@@ -1509,8 +1416,7 @@ export default function InsightsPage() {
           dateTo,
         };
 
-        const hasFilters =
-          f.datePreset !== 'all' || f.model || f.region || f.topic;
+        const hasFilters = f.datePreset !== 'all' || f.model || f.region || f.topic;
 
         const promises: [
           Promise<InsightsSummary>,
@@ -1527,14 +1433,11 @@ export default function InsightsPage() {
           getCompetitorComparison(brand.id, filterOpts),
           getShareOfVoiceData(brand.id, filterOpts),
           hasFilters
-            ? getPromptResults(brand.id, { limit: 1 }).then(({ total }) => ({
-                total,
-              }))
+            ? getPromptResults(brand.id, { limit: 1 }).then(({ total }) => ({ total }))
             : Promise.resolve(null),
         ];
 
-        const [summaryData, resultsData, compData, sovResult, unfilteredCheck] =
-          await Promise.all(promises);
+        const [summaryData, resultsData, compData, sovResult, unfilteredCheck] = await Promise.all(promises);
         setSummary(summaryData);
         setResults(resultsData.results);
         setTotalResults(resultsData.total);
@@ -1583,7 +1486,8 @@ export default function InsightsPage() {
           ),
         );
         setAvailableModels((prev) =>
-          [...new Set([...prev, ...models])].sort((a, b) => a.localeCompare(b)),
+          [...new Set([...prev, ...models])].sort((a, b) => 
+            a.localeCompare(b)),
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : '';
@@ -1618,9 +1522,7 @@ export default function InsightsPage() {
     const next = { ...filtersRef.current, region: '', model: '', topic: '' };
     filtersRef.current = next;
     setFilters(next);
-    getTopics(brand.id)
-      .then(setAvailableTopics)
-      .catch(() => {});
+    getTopics(brand.id).then(setAvailableTopics).catch(() => {});
   }, [brand?.id]);
 
   useEffect(() => {
@@ -1634,11 +1536,7 @@ export default function InsightsPage() {
 
     const urlJobId = searchParams.get('jobId');
     if (urlJobId) {
-      saveTrackingJob({
-        jobId: urlJobId,
-        brandId: brand.id,
-        startedAt: Date.now(),
-      });
+      saveTrackingJob({ jobId: urlJobId, brandId: brand.id, startedAt: Date.now() });
       setActiveJobId(urlJobId);
       setIsRunning(true);
       window.history.replaceState({}, '', window.location.pathname);
@@ -1781,9 +1679,7 @@ export default function InsightsPage() {
       });
       toast.success('Results refreshed');
     } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : 'Failed to refresh results',
-      );
+      toast.error(err instanceof Error ? err.message : 'Failed to refresh results');
     }
   };
 
@@ -1838,11 +1734,7 @@ export default function InsightsPage() {
           jobStatus={jobStatus}
           onStop={handleStopTracking}
         />
-        <EmptyState
-          onRunPrompts={handleRunPrompts}
-          isRunning={isRunning}
-          isCloud={isCloud}
-        />
+        <EmptyState onRunPrompts={handleRunPrompts} isRunning={isRunning} isCloud={isCloud} />
         {!isCloud && (
           <div className="flex justify-center">
             <Button
@@ -1954,12 +1846,9 @@ export default function InsightsPage() {
               tooltip="A composite score (0–100) reflecting how prominently your brand appears across AI engine responses. Combines mentions, citations, and sentiment."
               icon={BarChart3}
               value={summary!.avgVisibilityScore}
-              sub={
-                <DeltaBadge delta={summary!.visibilityChange} suffix=" pts" />
-              }
+              sub={<DeltaBadge delta={summary!.visibilityChange} suffix=" pts" />}
               subVariant={
-                summary!.visibilityChange !== null &&
-                summary!.visibilityChange > 0
+                summary!.visibilityChange !== null && summary!.visibilityChange > 0
                   ? 'positive'
                   : 'muted'
               }
@@ -1985,8 +1874,7 @@ export default function InsightsPage() {
               value={summary!.totalCitations}
               sub={<DeltaBadge delta={summary!.citationsChange} />}
               subVariant={
-                summary!.citationsChange !== null &&
-                summary!.citationsChange > 0
+                summary!.citationsChange !== null && summary!.citationsChange > 0
                   ? 'positive'
                   : 'muted'
               }
@@ -1997,12 +1885,9 @@ export default function InsightsPage() {
               tooltip="Percentage of AI responses that described your brand in a positive context."
               icon={AlertCircle}
               value={`${summary!.positiveSentimentPct}%`}
-              sub={
-                <DeltaBadge delta={summary!.sentimentChange} suffix=" pts" />
-              }
+              sub={<DeltaBadge delta={summary!.sentimentChange} suffix=" pts" />}
               subVariant={
-                summary!.sentimentChange !== null &&
-                summary!.sentimentChange > 0
+                summary!.sentimentChange !== null && summary!.sentimentChange > 0
                   ? 'positive'
                   : 'muted'
               }
@@ -2029,9 +1914,7 @@ export default function InsightsPage() {
 
               <Card className="lg:col-span-2">
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    Leaderboard
-                  </CardTitle>
+                  <CardTitle className="text-sm font-medium">Leaderboard</CardTitle>
                 </CardHeader>
                 <CardContent>
                   <CompetitorLeaderboard data={competitorData.brands} />
@@ -2049,8 +1932,7 @@ export default function InsightsPage() {
                     <PieChart className="h-4 w-4" />
                     Share of Voice by Platform
                   </CardTitle>
-                  {sovData.overallSovChange !== null &&
-                    sovData.overallSovChange !== 0 && (
+                  {sovData.overallSovChange !== null && sovData.overallSovChange !== 0 && (
                       <DeltaBadge
                         delta={sovData.overallSovChange}
                         suffix=" pts"

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -34,11 +34,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { 
-  Table, 
-  TableBody, 
-  TableCell, 
-  TableRow, 
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
 } from '@/components/ui/table';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -221,9 +221,7 @@ function VisibilityBar({ score, max = 100 }: { score: number; max?: number }) {
           style={{ width: `${pct}%` }}
         />
       </div>
-      <span className="text-sm font-medium tabular-nums">
-        {Math.round(score)}
-      </span>
+      <span className="text-sm font-medium tabular-nums">{Math.round(score)}</span>
     </div>
   );
 }
@@ -315,7 +313,7 @@ interface PromptGroup {
   totalCitations: number;
 }
 
-function groupResultsByPlatform( items: PromptResultWithText[]): PlatformGroup[] {
+function groupResultsByPlatform(items: PromptResultWithText[]): PlatformGroup[] {
   const map = new Map<string, PromptResultWithText[]>();
   for (const r of items) {
     const key = `${r.platform}|${r.modelUsed ?? ''}`;
@@ -542,6 +540,7 @@ function KpiCard({
   );
 }
 
+
 // ─── Run Single Prompt Dialog ─────────────────────────────────────────────────
 
 function RunSinglePromptDialog({
@@ -730,15 +729,13 @@ function FilterBar({
           </label>
           <Select
             value={filters.topic || null}
-            onValueChange={(v) =>
-              set({ topic: !v || v === '__all__' ? '' : v })
-            }
+            onValueChange={(v) => set({ topic: !v || v === '__all__' ? '' : v })}
           >
             <SelectTrigger className="h-8 w-40 text-xs">
               <SelectValue placeholder="All Topics">
                 {(value) =>
                   value && value !== '__all__'
-                    ? (availableTopics.find((t) => t.id === value)?.name ?? 'All Topics')
+                    ? availableTopics.find((t) => t.id === value)?.name ?? 'All Topics'
                     : 'All Topics'
                 }
               </SelectValue>
@@ -839,16 +836,16 @@ function InsightsSkeleton() {
               <Skeleton className="h-4 w-24" />
               <Skeleton className="h-8 w-16" />
               <Skeleton className="h-3 w-32" />
-            </CardContent>
-          </Card>
+          </CardContent>
+        </Card>
         ))}
       </div>
-      <Card>
+    <Card>
         <CardContent className="pt-6">
           <Skeleton className="h-48 w-full" />
-        </CardContent>
-      </Card>
-    </div>
+      </CardContent>
+    </Card>
+  </div>
   );
 }
 
@@ -1129,7 +1126,7 @@ function PlatformSubGroup({
                             size="icon"
                             className="h-6 w-6"
                             title="View detail"
-                            onClick={(e) => { e.stopPropagation();onViewResult(r); }}
+                            onClick={(e) => { e.stopPropagation(); onViewResult(r); }}
                           >
                             <Eye className="h-3 w-3" />
                           </Button>
@@ -1141,7 +1138,7 @@ function PlatformSubGroup({
               </div>
               {hasMoreHistory && (
                 <p className="text-[10px] text-muted-foreground mt-1">
-                  Showing latest {HISTORY_LIMIT} of {group.results.length - 1}{' '} previous runs.
+                  Showing latest {HISTORY_LIMIT} of {group.results.length - 1} previous runs.
                 </p>
               )}
             </div>
@@ -1182,7 +1179,7 @@ function PromptSubGroup({
         }}
         className="flex w-full items-center gap-3 px-4 py-2.5 text-left hover:bg-muted/50 transition-colors cursor-pointer select-none"
       >
-        <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', !expanded && '-rotate-90')}/>
+        <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', !expanded && '-rotate-90')} />
         <div className="flex-1 min-w-0">
           <p className="text-sm line-clamp-1">{group.promptText}</p>
           <span className="text-[11px] text-muted-foreground">
@@ -1487,7 +1484,8 @@ export default function InsightsPage() {
         );
         setAvailableModels((prev) =>
           [...new Set([...prev, ...models])].sort((a, b) => 
-            a.localeCompare(b)),
+            a.localeCompare(b)
+          ),
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : '';
@@ -1933,10 +1931,7 @@ export default function InsightsPage() {
                     Share of Voice by Platform
                   </CardTitle>
                   {sovData.overallSovChange !== null && sovData.overallSovChange !== 0 && (
-                      <DeltaBadge
-                        delta={sovData.overallSovChange}
-                        suffix=" pts"
-                      />
+                      <DeltaBadge delta={sovData.overallSovChange} suffix=" pts" />
                     )}
                 </CardHeader>
                 <CardContent>

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -4,7 +4,12 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from '@/i18n/navigation';
 import { useSearchParams } from 'next/navigation';
 import { createPortal } from 'react-dom';
-import { CompetitorChart, CompetitorLeaderboard, ShareOfVoicePlatformChart, ShareOfVoiceTrendChart } from './_charts';
+import {
+  CompetitorChart,
+  CompetitorLeaderboard,
+  ShareOfVoicePlatformChart,
+  ShareOfVoiceTrendChart,
+} from './_charts';
 import { MetricBreakdownSheet } from './_metric-breakdown-sheet';
 import { useBrandStore } from '@/stores/use-brand-store';
 import {
@@ -34,12 +39,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableRow,
-} from '@/components/ui/table';
+import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   BarChart3,
@@ -61,6 +61,7 @@ import {
   StopCircle,
   Tag,
   ArrowUpRight,
+  Download,
 } from 'lucide-react';
 import {
   Select,
@@ -100,6 +101,21 @@ const DEFAULT_FILTERS: InsightsFilters = {
   model: '',
   topic: '',
 };
+
+const INSIGHT_EXPORT_HEADERS = [
+  'created_at',
+  'prompt',
+  'topic',
+  'platform',
+  'model',
+  'region',
+  'mention_count',
+  'citation_count',
+  'visibility_score',
+  'sentiment',
+  'citation_urls',
+  'competitor_mentions',
+];
 
 /** Max rows loaded for the grouped Prompt Results table (newest first).
  *  Sized to show several recent runs per (prompt × platform) pair so the
@@ -205,7 +221,9 @@ function VisibilityBar({ score, max = 100 }: { score: number; max?: number }) {
           style={{ width: `${pct}%` }}
         />
       </div>
-      <span className="text-sm font-medium tabular-nums">{Math.round(score)}</span>
+      <span className="text-sm font-medium tabular-nums">
+        {Math.round(score)}
+      </span>
     </div>
   );
 }
@@ -297,7 +315,9 @@ interface PromptGroup {
   totalCitations: number;
 }
 
-function groupResultsByPlatform(items: PromptResultWithText[]): PlatformGroup[] {
+function groupResultsByPlatform(
+  items: PromptResultWithText[],
+): PlatformGroup[] {
   const map = new Map<string, PromptResultWithText[]>();
   for (const r of items) {
     const key = `${r.platform}|${r.modelUsed ?? ''}`;
@@ -309,7 +329,8 @@ function groupResultsByPlatform(items: PromptResultWithText[]): PlatformGroup[] 
   return Array.from(map.entries())
     .map(([key, arr]) => {
       const sorted = [...arr].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
       );
       const latest = sorted[0];
       return {
@@ -322,7 +343,9 @@ function groupResultsByPlatform(items: PromptResultWithText[]): PlatformGroup[] 
         latestScore: latest.visibilityScore,
         avgScore:
           Math.round(
-            (sorted.reduce((s, r) => s + r.visibilityScore, 0) / sorted.length) * 10,
+            (sorted.reduce((s, r) => s + r.visibilityScore, 0) /
+              sorted.length) *
+              10,
           ) / 10,
         totalMentions: sorted.reduce((s, r) => s + r.mentionCount, 0),
         totalCitations: sorted.reduce((s, r) => s + r.citationCount, 0),
@@ -331,7 +354,10 @@ function groupResultsByPlatform(items: PromptResultWithText[]): PlatformGroup[] 
     .sort((a, b) => b.latestScore - a.latestScore);
 }
 
-function computePromptGroup(promptId: string, items: PromptResultWithText[]): PromptGroup {
+function computePromptGroup(
+  promptId: string,
+  items: PromptResultWithText[],
+): PromptGroup {
   const sorted = [...items].sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   );
@@ -393,7 +419,8 @@ function groupResultsByTopic(results: PromptResultWithText[]): TopicGroup[] {
       );
       return {
         topicId: items[0].topicId ?? `__cat_${topicName}`,
-        topicName: topicName === '__uncategorized__' ? 'Uncategorized' : topicName,
+        topicName:
+          topicName === '__uncategorized__' ? 'Uncategorized' : topicName,
         prompts,
         avgScore: Math.round(
           items.reduce((s, r) => s + r.visibilityScore, 0) / items.length,
@@ -523,7 +550,6 @@ function KpiCard({
     </Card>
   );
 }
-
 
 // ─── Run Single Prompt Dialog ─────────────────────────────────────────────────
 
@@ -713,13 +739,16 @@ function FilterBar({
           </label>
           <Select
             value={filters.topic || null}
-            onValueChange={(v) => set({ topic: !v || v === '__all__' ? '' : v })}
+            onValueChange={(v) =>
+              set({ topic: !v || v === '__all__' ? '' : v })
+            }
           >
             <SelectTrigger className="h-8 w-40 text-xs">
               <SelectValue placeholder="All Topics">
                 {(value) =>
                   value && value !== '__all__'
-                    ? availableTopics.find((t) => t.id === value)?.name ?? 'All Topics'
+                    ? (availableTopics.find((t) => t.id === value)?.name ??
+                      'All Topics')
                     : 'All Topics'
                 }
               </SelectValue>
@@ -820,16 +849,16 @@ function InsightsSkeleton() {
               <Skeleton className="h-4 w-24" />
               <Skeleton className="h-8 w-16" />
               <Skeleton className="h-3 w-32" />
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
         ))}
       </div>
-        <Card>
+      <Card>
         <CardContent className="pt-6">
           <Skeleton className="h-48 w-full" />
-          </CardContent>
-        </Card>
-      </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 
@@ -904,7 +933,12 @@ function NoDataForPeriod({
 
 // ─── Tracking Progress ────────────────────────────────────────────────────────
 
-import { saveTrackingJob, loadTrackingJob, clearTrackingJob } from '@/lib/tracking-job-store';
+import {
+  saveTrackingJob,
+  loadTrackingJob,
+  clearTrackingJob,
+} from '@/lib/tracking-job-store';
+import { toCsv } from '@/lib/csv';
 
 function TrackingProgressBanner({
   jobStatus,
@@ -1017,18 +1051,28 @@ function PlatformSubGroup({
         tabIndex={0}
         onClick={onToggle}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); }
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+          }
         }}
         className="flex w-full items-center gap-3 px-3 py-2 hover:bg-muted/40 transition-colors cursor-pointer select-none"
       >
-        <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', !expanded && '-rotate-90')} />
+        <ChevronDown
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+            !expanded && '-rotate-90',
+          )}
+        />
         <div className="flex-1 min-w-0 flex items-center gap-2">
           <ModelBadge
             model={latest.modelUsed ?? latest.platform}
             platform={latest.platform}
           />
           {latest.region && (
-            <Badge variant="outline" className="text-[10px]">{latest.region}</Badge>
+            <Badge variant="outline" className="text-[10px]">
+              {latest.region}
+            </Badge>
           )}
           <span className="text-[10px] text-muted-foreground tabular-nums ml-1">
             {group.results.length} run{group.results.length !== 1 ? 's' : ''}
@@ -1037,11 +1081,15 @@ function PlatformSubGroup({
         <div className="flex items-center gap-4 shrink-0">
           <div className="hidden sm:block text-right">
             <p className="text-[10px] text-muted-foreground">Mentions</p>
-            <p className="text-xs font-semibold tabular-nums">{latest.mentionCount}</p>
+            <p className="text-xs font-semibold tabular-nums">
+              {latest.mentionCount}
+            </p>
           </div>
           <div className="hidden sm:block text-right">
             <p className="text-[10px] text-muted-foreground">Citations</p>
-            <p className="text-xs font-semibold tabular-nums">{latest.citationCount}</p>
+            <p className="text-xs font-semibold tabular-nums">
+              {latest.citationCount}
+            </p>
           </div>
           <SentimentBadge sentiment={latest.sentiment} />
           <div className="w-[100px] sm:w-[140px]">
@@ -1061,7 +1109,10 @@ function PlatformSubGroup({
                 variant="ghost"
                 size="sm"
                 className="h-6 gap-1.5 text-[11px]"
-                onClick={(e) => { e.stopPropagation(); onViewResult(latest); }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onViewResult(latest);
+                }}
               >
                 <Eye className="h-3 w-3" />
                 Full detail
@@ -1086,15 +1137,21 @@ function PlatformSubGroup({
                           {formatTimestamp(r.createdAt)}
                         </TableCell>
                         <TableCell className="text-center py-1.5 text-xs tabular-nums w-[110px]">
-                          <span className="font-semibold">{r.mentionCount}</span>
+                          <span className="font-semibold">
+                            {r.mentionCount}
+                          </span>
                           <span className="text-muted-foreground">
-                            {' '}mention{r.mentionCount !== 1 ? 's' : ''}
+                            {' '}
+                            mention{r.mentionCount !== 1 ? 's' : ''}
                           </span>
                         </TableCell>
                         <TableCell className="text-center py-1.5 text-xs tabular-nums w-[110px]">
-                          <span className="font-semibold">{r.citationCount}</span>
+                          <span className="font-semibold">
+                            {r.citationCount}
+                          </span>
                           <span className="text-muted-foreground">
-                            {' '}citation{r.citationCount !== 1 ? 's' : ''}
+                            {' '}
+                            citation{r.citationCount !== 1 ? 's' : ''}
                           </span>
                         </TableCell>
                         <TableCell className="text-center py-1.5 w-[100px]">
@@ -1109,7 +1166,10 @@ function PlatformSubGroup({
                             size="icon"
                             className="h-6 w-6"
                             title="View detail"
-                            onClick={(e) => { e.stopPropagation(); onViewResult(r); }}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onViewResult(r);
+                            }}
                           >
                             <Eye className="h-3 w-3" />
                           </Button>
@@ -1121,7 +1181,8 @@ function PlatformSubGroup({
               </div>
               {hasMoreHistory && (
                 <p className="text-[10px] text-muted-foreground mt-1">
-                  Showing latest {HISTORY_LIMIT} of {group.results.length - 1} previous runs.
+                  Showing latest {HISTORY_LIMIT} of {group.results.length - 1}{' '}
+                  previous runs.
                 </p>
               )}
             </div>
@@ -1158,15 +1219,24 @@ function PromptSubGroup({
         tabIndex={0}
         onClick={onToggle}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); }
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+          }
         }}
         className="flex w-full items-center gap-3 px-4 py-2.5 text-left hover:bg-muted/50 transition-colors cursor-pointer select-none"
       >
-        <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', !expanded && '-rotate-90')} />
+        <ChevronDown
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+            !expanded && '-rotate-90',
+          )}
+        />
         <div className="flex-1 min-w-0">
           <p className="text-sm line-clamp-1">{group.promptText}</p>
           <span className="text-[11px] text-muted-foreground">
-            {group.platformGroups.length} platform{group.platformGroups.length !== 1 ? 's' : ''}
+            {group.platformGroups.length} platform
+            {group.platformGroups.length !== 1 ? 's' : ''}
             {' · '}
             {group.results.length} result{group.results.length !== 1 ? 's' : ''}
           </span>
@@ -1174,15 +1244,21 @@ function PromptSubGroup({
         <div className="flex items-center gap-4 shrink-0">
           <div className="text-right">
             <p className="text-[10px] text-muted-foreground">Score</p>
-            <p className="text-xs font-semibold tabular-nums">{group.avgScore}</p>
+            <p className="text-xs font-semibold tabular-nums">
+              {group.avgScore}
+            </p>
           </div>
           <div className="text-right">
             <p className="text-[10px] text-muted-foreground">Mentions</p>
-            <p className="text-xs font-semibold tabular-nums">{group.totalMentions}</p>
+            <p className="text-xs font-semibold tabular-nums">
+              {group.totalMentions}
+            </p>
           </div>
           <div className="text-right">
             <p className="text-[10px] text-muted-foreground">Citations</p>
-            <p className="text-xs font-semibold tabular-nums">{group.totalCitations}</p>
+            <p className="text-xs font-semibold tabular-nums">
+              {group.totalCitations}
+            </p>
           </div>
           <Button
             variant="ghost"
@@ -1190,7 +1266,10 @@ function PromptSubGroup({
             className="h-6 w-6"
             title="Refresh results"
             disabled={refreshingId !== null}
-            onClick={(e) => { e.stopPropagation(); onRefresh(group.promptId); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRefresh(group.promptId);
+            }}
           >
             {refreshingId === group.promptId ? (
               <Loader2 className="h-3 w-3 animate-spin" />
@@ -1236,34 +1315,45 @@ function PromptResultsGrouped({
 }) {
   const topicGroups = groupResultsByTopic(results);
   const [expandedTopics, setExpandedTopics] = useState<Set<string>>(new Set());
-  const [expandedPrompts, setExpandedPrompts] = useState<Set<string>>(new Set());
-  const [expandedPlatforms, setExpandedPlatforms] = useState<Set<string>>(new Set());
+  const [expandedPrompts, setExpandedPrompts] = useState<Set<string>>(
+    new Set(),
+  );
+  const [expandedPlatforms, setExpandedPlatforms] = useState<Set<string>>(
+    new Set(),
+  );
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
 
   const toggleTopic = (id: string) =>
     setExpandedTopics((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id); else next.add(id);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
 
   const togglePrompt = (id: string) =>
     setExpandedPrompts((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id); else next.add(id);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
 
   const togglePlatform = (id: string) =>
     setExpandedPlatforms((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id); else next.add(id);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
 
   const handleRefresh = async (promptId: string) => {
     setRefreshingId(promptId);
-    try { await onRefreshPrompt(promptId); } finally { setRefreshingId(null); }
+    try {
+      await onRefreshPrompt(promptId);
+    } finally {
+      setRefreshingId(null);
+    }
   };
 
   const truncated = totalRowCount > loadedRowCount && loadedRowCount > 0;
@@ -1272,7 +1362,9 @@ function PromptResultsGrouped({
     <Card>
       <CardHeader className="pb-2">
         <div className="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
-          <CardTitle className="text-sm font-medium">Prompt Results by Topic</CardTitle>
+          <CardTitle className="text-sm font-medium">
+            Prompt Results by Topic
+          </CardTitle>
           {truncated && (
             <p className="text-xs text-muted-foreground font-normal">
               Showing {loadedRowCount} of {totalRowCount} rows (newest first).
@@ -1292,36 +1384,56 @@ function PromptResultsGrouped({
           {topicGroups.map((topic) => {
             const isTopicOpen = expandedTopics.has(topic.topicId);
             return (
-              <div key={topic.topicId + topic.topicName} className="rounded-lg border overflow-hidden">
+              <div
+                key={topic.topicId + topic.topicName}
+                className="rounded-lg border overflow-hidden"
+              >
                 <div
                   role="button"
                   tabIndex={0}
                   onClick={() => toggleTopic(topic.topicId)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleTopic(topic.topicId); }
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      toggleTopic(topic.topicId);
+                    }
                   }}
                   className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/50 transition-colors cursor-pointer select-none"
                 >
-                  <ChevronDown className={cn('h-4 w-4 shrink-0 text-muted-foreground transition-transform', !isTopicOpen && '-rotate-90')} />
+                  <ChevronDown
+                    className={cn(
+                      'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
+                      !isTopicOpen && '-rotate-90',
+                    )}
+                  />
                   <Tag className="h-4 w-4 shrink-0 text-muted-foreground" />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium">{topic.topicName}</p>
                     <span className="text-[11px] text-muted-foreground">
-                      {topic.prompts.length} prompt{topic.prompts.length !== 1 ? 's' : ''} · {topic.totalResults} result{topic.totalResults !== 1 ? 's' : ''}
+                      {topic.prompts.length} prompt
+                      {topic.prompts.length !== 1 ? 's' : ''} ·{' '}
+                      {topic.totalResults} result
+                      {topic.totalResults !== 1 ? 's' : ''}
                     </span>
                   </div>
                   <div className="flex items-center gap-4 shrink-0">
                     <div className="text-right">
                       <p className="text-xs text-muted-foreground">Avg Score</p>
-                      <p className="text-sm font-semibold tabular-nums">{topic.avgScore}</p>
+                      <p className="text-sm font-semibold tabular-nums">
+                        {topic.avgScore}
+                      </p>
                     </div>
                     <div className="text-right">
                       <p className="text-xs text-muted-foreground">Mentions</p>
-                      <p className="text-sm font-semibold tabular-nums">{topic.totalMentions}</p>
+                      <p className="text-sm font-semibold tabular-nums">
+                        {topic.totalMentions}
+                      </p>
                     </div>
                     <div className="text-right">
                       <p className="text-xs text-muted-foreground">Citations</p>
-                      <p className="text-sm font-semibold tabular-nums">{topic.totalCitations}</p>
+                      <p className="text-sm font-semibold tabular-nums">
+                        {topic.totalCitations}
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -1374,7 +1486,8 @@ export default function InsightsPage() {
   const [competitorData, setCompetitorData] =
     useState<CompetitorComparisonData | null>(null);
   const [sovData, setSovData] = useState<ShareOfVoiceData | null>(null);
-  const [breakdownMetric, setBreakdownMetric] = useState<BreakdownMetric | null>(null);
+  const [breakdownMetric, setBreakdownMetric] =
+    useState<BreakdownMetric | null>(null);
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
 
@@ -1396,7 +1509,8 @@ export default function InsightsPage() {
           dateTo,
         };
 
-        const hasFilters = f.datePreset !== 'all' || f.model || f.region || f.topic;
+        const hasFilters =
+          f.datePreset !== 'all' || f.model || f.region || f.topic;
 
         const promises: [
           Promise<InsightsSummary>,
@@ -1413,11 +1527,14 @@ export default function InsightsPage() {
           getCompetitorComparison(brand.id, filterOpts),
           getShareOfVoiceData(brand.id, filterOpts),
           hasFilters
-            ? getPromptResults(brand.id, { limit: 1 }).then(({ total }) => ({ total }))
+            ? getPromptResults(brand.id, { limit: 1 }).then(({ total }) => ({
+                total,
+              }))
             : Promise.resolve(null),
         ];
 
-        const [summaryData, resultsData, compData, sovResult, unfilteredCheck] = await Promise.all(promises);
+        const [summaryData, resultsData, compData, sovResult, unfilteredCheck] =
+          await Promise.all(promises);
         setSummary(summaryData);
         setResults(resultsData.results);
         setTotalResults(resultsData.total);
@@ -1466,9 +1583,7 @@ export default function InsightsPage() {
           ),
         );
         setAvailableModels((prev) =>
-          [...new Set([...prev, ...models])].sort((a, b) =>
-            a.localeCompare(b),
-          ),
+          [...new Set([...prev, ...models])].sort((a, b) => a.localeCompare(b)),
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : '';
@@ -1503,7 +1618,9 @@ export default function InsightsPage() {
     const next = { ...filtersRef.current, region: '', model: '', topic: '' };
     filtersRef.current = next;
     setFilters(next);
-    getTopics(brand.id).then(setAvailableTopics).catch(() => {});
+    getTopics(brand.id)
+      .then(setAvailableTopics)
+      .catch(() => {});
   }, [brand?.id]);
 
   useEffect(() => {
@@ -1517,7 +1634,11 @@ export default function InsightsPage() {
 
     const urlJobId = searchParams.get('jobId');
     if (urlJobId) {
-      saveTrackingJob({ jobId: urlJobId, brandId: brand.id, startedAt: Date.now() });
+      saveTrackingJob({
+        jobId: urlJobId,
+        brandId: brand.id,
+        startedAt: Date.now(),
+      });
       setActiveJobId(urlJobId);
       setIsRunning(true);
       window.history.replaceState({}, '', window.location.pathname);
@@ -1660,9 +1781,44 @@ export default function InsightsPage() {
       });
       toast.success('Results refreshed');
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to refresh results');
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to refresh results',
+      );
     }
   };
+
+  const handleExportCsv = useCallback(() => {
+    const rows = results.map((r) => ({
+      created_at: r.createdAt,
+      prompt: r.promptText,
+      topic: r.topicName ?? '',
+      platform: r.platform,
+      model: r.modelUsed ?? '',
+      region: r.region ?? '',
+      mention_count: r.mentionCount,
+      citation_count: r.citationCount,
+      visibility_score: r.visibilityScore,
+      sentiment: r.sentiment,
+      citation_urls: r.citations.map((c) => c.url).join(', '),
+      competitor_mentions:
+        r.competitorMentions
+          ?.map((c) => `${c.name}:${c.mention_count}`)
+          .join(', ') ?? '',
+    }));
+
+    const csv = toCsv(rows, INSIGHT_EXPORT_HEADERS);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const date = new Date().toISOString().slice(0, 10);
+    const slug = brand?.slug ?? 'brand';
+
+    link.href = url;
+    link.download = `ansvisor_${slug}_insights_${date}.csv`;
+    link.click();
+
+    URL.revokeObjectURL(url);
+  }, [brand?.slug, results]);
 
   if (!brand || (isLoading && !summary)) return <InsightsSkeleton />;
 
@@ -1682,7 +1838,11 @@ export default function InsightsPage() {
           jobStatus={jobStatus}
           onStop={handleStopTracking}
         />
-        <EmptyState onRunPrompts={handleRunPrompts} isRunning={isRunning} isCloud={isCloud} />
+        <EmptyState
+          onRunPrompts={handleRunPrompts}
+          isRunning={isRunning}
+          isCloud={isCloud}
+        />
         {!isCloud && (
           <div className="flex justify-center">
             <Button
@@ -1723,34 +1883,46 @@ export default function InsightsPage() {
           <h1 className="text-2xl font-bold tracking-tight">
             Answer Engine Insights
           </h1>
+
           <p className="text-muted-foreground text-sm">
             {brand.name} · Last run: {lastCheckedLabel} · {totalResults} results
           </p>
         </div>
-        {!isCloud && (
-          <div className="flex items-center gap-2 shrink-0">
-            <Button
-              variant="outline"
-              onClick={() => setShowSinglePrompt(true)}
-              className="gap-2"
-            >
-              <FlaskConical className="h-4 w-4" />
-              Test Single Prompt
-            </Button>
-            <Button
-              onClick={handleRunPrompts}
-              disabled={isRunning}
-              className="gap-2"
-            >
-              {isRunning ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Play className="h-4 w-4" />
-              )}
-              Run All
-            </Button>
-          </div>
-        )}
+
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Always visible */}
+          <Button variant="outline" className="gap-2" onClick={handleExportCsv}>
+            <Download className="h-4 w-4" />
+            Export CSV
+          </Button>
+
+          {/* Self-host only */}
+          {!isCloud && (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => setShowSinglePrompt(true)}
+                className="gap-2"
+              >
+                <FlaskConical className="h-4 w-4" />
+                Test Single Prompt
+              </Button>
+
+              <Button
+                onClick={handleRunPrompts}
+                disabled={isRunning}
+                className="gap-2"
+              >
+                {isRunning ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="h-4 w-4" />
+                )}
+                Run All
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
       {/* Filter Bar */}
@@ -1782,9 +1954,12 @@ export default function InsightsPage() {
               tooltip="A composite score (0–100) reflecting how prominently your brand appears across AI engine responses. Combines mentions, citations, and sentiment."
               icon={BarChart3}
               value={summary!.avgVisibilityScore}
-              sub={<DeltaBadge delta={summary!.visibilityChange} suffix=" pts" />}
+              sub={
+                <DeltaBadge delta={summary!.visibilityChange} suffix=" pts" />
+              }
               subVariant={
-                summary!.visibilityChange !== null && summary!.visibilityChange > 0
+                summary!.visibilityChange !== null &&
+                summary!.visibilityChange > 0
                   ? 'positive'
                   : 'muted'
               }
@@ -1810,7 +1985,8 @@ export default function InsightsPage() {
               value={summary!.totalCitations}
               sub={<DeltaBadge delta={summary!.citationsChange} />}
               subVariant={
-                summary!.citationsChange !== null && summary!.citationsChange > 0
+                summary!.citationsChange !== null &&
+                summary!.citationsChange > 0
                   ? 'positive'
                   : 'muted'
               }
@@ -1821,9 +1997,12 @@ export default function InsightsPage() {
               tooltip="Percentage of AI responses that described your brand in a positive context."
               icon={AlertCircle}
               value={`${summary!.positiveSentimentPct}%`}
-              sub={<DeltaBadge delta={summary!.sentimentChange} suffix=" pts" />}
+              sub={
+                <DeltaBadge delta={summary!.sentimentChange} suffix=" pts" />
+              }
               subVariant={
-                summary!.sentimentChange !== null && summary!.sentimentChange > 0
+                summary!.sentimentChange !== null &&
+                summary!.sentimentChange > 0
                   ? 'positive'
                   : 'muted'
               }
@@ -1845,17 +2024,19 @@ export default function InsightsPage() {
                     providerRows={competitorData.providerRows}
                     brands={competitorData.brands}
                   />
-            </CardContent>
+                </CardContent>
               </Card>
 
               <Card className="lg:col-span-2">
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-sm font-medium">Leaderboard</CardTitle>
+                  <CardTitle className="text-sm font-medium">
+                    Leaderboard
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <CompetitorLeaderboard data={competitorData.brands} />
                 </CardContent>
-      </Card>
+              </Card>
             </div>
           )}
 
@@ -1868,9 +2049,13 @@ export default function InsightsPage() {
                     <PieChart className="h-4 w-4" />
                     Share of Voice by Platform
                   </CardTitle>
-                  {sovData.overallSovChange !== null && sovData.overallSovChange !== 0 && (
-                    <DeltaBadge delta={sovData.overallSovChange} suffix=" pts" />
-                  )}
+                  {sovData.overallSovChange !== null &&
+                    sovData.overallSovChange !== 0 && (
+                      <DeltaBadge
+                        delta={sovData.overallSovChange}
+                        suffix=" pts"
+                      />
+                    )}
                 </CardHeader>
                 <CardContent>
                   <ShareOfVoicePlatformChart


### PR DESCRIPTION
### What changed and why

- Added an `Export CSV` button to the Insights page header.
- The export button is now always visible in both cloud and self-host modes.
- Refactored the action button cluster so `Test Single Prompt` and `Run All` remain self-host-only while `Export CSV` is shared across environments.
- Added a lightweight CSV helper utility to generate properly escaped CSV output without introducing a new dependency.
- Export uses the already-loaded `results` state, so active filters (date range, region, model, topic, etc.) are automatically reflected in the downloaded file.
- Added disabled handling for empty/loading states to prevent exporting invalid datasets.

### How to test the change

1. Open `/dashboard/insights` with a brand that has prompt results.
2. Verify the `Export CSV` button appears in the top-right header area.
3. Click the button and confirm a CSV file downloads with the format:
   `ansvisor_<brand-slug>_results_<YYYY-MM-DD>.csv`
4. Open the CSV in Excel or Google Sheets and verify:

   * columns are aligned correctly
   * rows are not broken
   * citations and competitor mentions are flattened properly
5. Apply filters (date range, region, model, topic) and re-export.
6. Confirm the exported rows match the currently visible filtered dataset.
7. Verify the button is disabled when:

   * results are empty
   * the page is loading
8. Verify cloud mode only shows `Export CSV`, while self-host mode still shows:

   * `Test Single Prompt`
   * `Run All`
   
### Screenshot
<img width="1911" height="905" alt="image" src="https://github.com/user-attachments/assets/17f7fcc5-b816-41dc-b8b9-61b78c6c73b4" />

This closes issue #38 