### PR TITLE
fix(settings): changed behavior of contact us cta in setting to open contact us page in a new browser tab

### DIFF
--- a/web/src/components/settings/plan-switcher.tsx
+++ b/web/src/components/settings/plan-switcher.tsx
@@ -238,7 +238,9 @@ export function PlanSwitcher({ subscription, onUpdate }: PlanSwitcherProps) {
           </p>
         </div>
         <a
-          href="mailto:support@ansvisor.com"
+          href="https://www.ansvisor.com/contact-us"
+          target="_blank"
+          rel="noopener noreferrer"
           className="inline-flex shrink-0 items-center justify-center rounded-md border bg-background px-5 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
         >
           <Mail className="mr-2 h-4 w-4" />


### PR DESCRIPTION
### What changed and why

Updated the “Contact Us” CTA link from a mailto: action to the Ansvisor contact page URL (https://www.ansvisor.com/contact-us) so users are redirected to the website contact form instead of opening their default email client.

Also added:

target="_blank" to open the page in a new browser tab
rel="noopener noreferrer" for security best practices when opening external links

### How to test the change

1. Open the page containing the “Contact Us” button
2. Click the button
3. Verify that:
* A new browser tab opens
* The tab navigates to https://www.ansvisor.com/contact-us
* The current application tab remains unchanged
4. Confirm the button styling and icon remain the same after the change

This closes issue #76 