### PR TITLE
feat(prompts): add Competition column with a 5-bar difficulty meter

### DIFF
--- a/server/src/lib/dataforseo.js
+++ b/server/src/lib/dataforseo.js
@@ -18,7 +18,8 @@ function getAuthHeader() {
  * Fetch Google Ads search volume for a list of keywords via DataForSEO.
  * @param {string[]} keywords - Up to 1000 keywords
  * @param {{ locationCode?: number, languageCode?: string }} options
- * @returns {Promise<Record<string, number>>} Map of keyword → monthly search volume
+ * @returns {Promise<Record<string, { volume: number, competitionIndex: number | null, competition: string | null }>>}
+ *   Map of keyword → { monthly search volume, Google Ads competition index (0–100), competition label }
  */
 export async function getSearchVolumes(keywords, options = {}) {
   const body = [
@@ -61,7 +62,11 @@ export async function getSearchVolumes(keywords, options = {}) {
 
   const volumes = {};
   for (const item of task.result || []) {
-    volumes[item.keyword] = item.search_volume ?? 0;
+    volumes[item.keyword] = {
+      volume: item.search_volume ?? 0,
+      competitionIndex: item.competition_index ?? null,
+      competition: item.competition ?? null, // "LOW" | "MEDIUM" | "HIGH" | null
+    };
   }
 
   return volumes;

--- a/server/src/routes/volumes.js
+++ b/server/src/routes/volumes.js
@@ -74,6 +74,8 @@ function mapVolumeRow(saved) {
     totalGoogleVolume: saved.total_google_volume,
     aiVolumeMultiplier: parseFloat(saved.ai_volume_multiplier),
     estAiVolume: saved.est_ai_volume,
+    competitionIndex: saved.competition_index ?? null,
+    competition: saved.competition ?? null,
     locationCode: saved.location_code,
     languageCode: saved.language_code,
     fetchedAt: saved.fetched_at,
@@ -92,10 +94,34 @@ async function fetchAndSaveVolumes(
     languageCode: languageCode || undefined,
   });
 
-  const totalGoogleVolume = Object.values(volumes).reduce(
-    (sum, v) => sum + v,
-    0,
-  );
+  // google_volumes stays a { keyword: number } map for the UI. Competition is
+  // aggregated per prompt as a volume-weighted average of the keyword indices.
+  const googleVolumes = {};
+  let totalGoogleVolume = 0;
+  let competitionWeightedSum = 0;
+  let competitionWeight = 0;
+  for (const [keyword, data] of Object.entries(volumes)) {
+    googleVolumes[keyword] = data.volume;
+    totalGoogleVolume += data.volume;
+    if (data.competitionIndex !== null && data.competitionIndex !== undefined) {
+      competitionWeightedSum += data.competitionIndex * data.volume;
+      competitionWeight += data.volume;
+    }
+  }
+
+  const competitionIndex =
+    competitionWeight > 0
+      ? Math.round(competitionWeightedSum / competitionWeight)
+      : null;
+  const competition =
+    competitionIndex === null
+      ? null
+      : competitionIndex <= 33
+        ? 'LOW'
+        : competitionIndex <= 66
+          ? 'MEDIUM'
+          : 'HIGH';
+
   const estAiVolume = Math.round(totalGoogleVolume * AI_VOLUME_MULTIPLIER);
 
   const { data: saved, error: dbError } = await supabaseAdmin
@@ -105,10 +131,12 @@ async function fetchAndSaveVolumes(
         prompt_id: promptId,
         intent,
         keywords,
-        google_volumes: volumes,
+        google_volumes: googleVolumes,
         total_google_volume: totalGoogleVolume,
         ai_volume_multiplier: AI_VOLUME_MULTIPLIER,
         est_ai_volume: estAiVolume,
+        competition_index: competitionIndex,
+        competition,
         location_code: locationCode || null,
         language_code: languageCode || null,
         fetched_at: new Date().toISOString(),

--- a/server/src/test-volumes.js
+++ b/server/src/test-volumes.js
@@ -90,11 +90,16 @@ async function testFullPipeline() {
     });
 
     console.log('\nGoogle Volumes:');
-    for (const [kw, vol] of Object.entries(volumes)) {
-      console.log(`  "${kw}": ${vol.toLocaleString()}/mo`);
+    for (const [kw, data] of Object.entries(volumes)) {
+      console.log(
+        `  "${kw}": ${data.volume.toLocaleString()}/mo (competition: ${data.competition ?? 'n/a'})`,
+      );
     }
 
-    const totalGoogleVolume = Object.values(volumes).reduce((sum, v) => sum + v, 0);
+    const totalGoogleVolume = Object.values(volumes).reduce(
+      (sum, v) => sum + v.volume,
+      0,
+    );
     const estAiVolume = Math.round(totalGoogleVolume * AI_VOLUME_MULTIPLIER);
 
     console.log(`\nTotal Google Volume: ${totalGoogleVolume.toLocaleString()}/mo`);

--- a/supabase/migrations/00004_prompt_competition.sql
+++ b/supabase/migrations/00004_prompt_competition.sql
@@ -1,0 +1,10 @@
+-- Capture DataForSEO competition data alongside search volume so the prompts
+-- table can show a difficulty meter without an extra API call. This is Google
+-- Ads paid-bid competition (a proxy for topic difficulty), pulled from the same
+-- search_volume response we already fetch. No RLS changes: prompt_volumes
+-- inherits the existing brand-scoped policies.
+
+ALTER TABLE "public"."prompt_volumes"
+  ADD COLUMN IF NOT EXISTS "competition_index" integer,
+  ADD COLUMN IF NOT EXISTS "competition" text
+    CHECK ("competition" IS NULL OR "competition" IN ('LOW', 'MEDIUM', 'HIGH'));

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -19,6 +19,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { CompetitionBars } from '@/components/ui/competition-bars';
 import {
   TrendingUp,
   Search,
@@ -991,6 +992,12 @@ function AllPromptsTab({
               >
                 Volume
               </ColHead>
+              <ColHead
+                className="text-center"
+                tooltip="Based on Google Ads competition for related keywords (LOW / MEDIUM / HIGH). A proxy for topic difficulty."
+              >
+                Competition
+              </ColHead>
               <ColHead className="text-right" tooltip="Most recent tracking run for this prompt.">
                 Last run
               </ColHead>
@@ -1069,6 +1076,14 @@ function AllPromptsTab({
                     ) : (
                       <span className="text-xs text-muted-foreground">—</span>
                     )}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex justify-center">
+                      <CompetitionBars
+                        index={vol?.competitionIndex ?? null}
+                        label={vol?.competition ?? null}
+                      />
+                    </div>
                   </TableCell>
                   <TableCell className="text-right text-xs text-muted-foreground">
                     {formatRelative(vis?.lastRunAt)}

--- a/web/src/components/ui/competition-bars.tsx
+++ b/web/src/components/ui/competition-bars.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/lib/utils';
+
+// Competition level → active bar colour. Green (easy) → dark red (contested).
+const ACTIVE_BY_LEVEL: Record<number, string> = {
+  1: 'bg-green-500',
+  2: 'bg-orange-300',
+  3: 'bg-orange-500',
+  4: 'bg-red-500',
+  5: 'bg-red-700',
+};
+
+/**
+ * Ahrefs/SEMrush-style 5-bar competition meter. `index` is the 0–100 Google Ads
+ * competition index; `label` (LOW/MEDIUM/HIGH) is shown in the tooltip. Renders
+ * an em dash when the index is unknown.
+ */
+export function CompetitionBars({ index, label }: { index: number | null; label?: string | null }) {
+  if (index === null || index === undefined) {
+    return <span className="text-muted-foreground text-xs">—</span>;
+  }
+
+  const level = Math.max(1, Math.min(5, Math.ceil(index / 20)));
+  const active = ACTIVE_BY_LEVEL[level];
+
+  return (
+    <div
+      className="inline-flex items-center gap-0.5"
+      title={label ? `${label} (${index}/100)` : `${index}/100`}
+      aria-label={`Competition ${index} of 100`}
+    >
+      {Array.from({ length: 5 }, (_, i) => (
+        <div key={i} className={cn('h-4 w-1 rounded-sm', i < level ? active : 'bg-muted')} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -161,6 +161,8 @@ export interface PromptVolume {
   totalGoogleVolume: number;
   aiVolumeMultiplier: number;
   estAiVolume: number;
+  competitionIndex: number | null;
+  competition: 'LOW' | 'MEDIUM' | 'HIGH' | null;
   locationCode?: number;
   languageCode?: string;
   fetchedAt: string;

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -631,6 +631,8 @@ export type Database = {
       prompt_volumes: {
         Row: {
           ai_volume_multiplier: number;
+          competition: string | null;
+          competition_index: number | null;
           created_at: string | null;
           est_ai_volume: number;
           fetched_at: string | null;
@@ -645,6 +647,8 @@ export type Database = {
         };
         Insert: {
           ai_volume_multiplier: number;
+          competition?: string | null;
+          competition_index?: number | null;
           created_at?: string | null;
           est_ai_volume: number;
           fetched_at?: string | null;
@@ -659,6 +663,8 @@ export type Database = {
         };
         Update: {
           ai_volume_multiplier?: number;
+          competition?: string | null;
+          competition_index?: number | null;
           created_at?: string | null;
           est_ai_volume?: number;
           fetched_at?: string | null;


### PR DESCRIPTION
## Summary

Adds a **Competition** column to the All Prompts tab (`/dashboard/prompts?tab=all`) with an Ahrefs/SEMrush-style **5-bar difficulty meter**. The competition data already comes back on every DataForSEO search-volume call — this wires it end-to-end (DataForSEO → DB → UI) with **no extra API spend**.

Closes #44

## Changes

- **Migration** `00004_prompt_competition.sql` — adds `competition_index` (int) + `competition` (LOW/MEDIUM/HIGH) to `prompt_volumes`. Additive, `IF NOT EXISTS`, no RLS change.
- **DataForSEO client** — `getSearchVolumes` now returns `{ volume, competitionIndex, competition }` per keyword. Callers updated: `volumes.js` and `test-volumes.js`.
- **Aggregation** — `fetchAndSaveVolumes` computes a **volume-weighted average** competition index per prompt and derives the LOW/MEDIUM/HIGH label. `google_volumes` stays a `{ keyword: number }` map for the existing UI.
- **Types** — `prompt_volumes` Row/Insert/Update in `supabase.ts`; `PromptVolume` in `types/index.ts`.
- **Component** — `CompetitionBars`: 5 equal-height bars, green → dark red by level, `—` when null.
- **UI** — Competition column in `AllPromptsTab` with a header tooltip clarifying it's a Google Ads proxy for topic difficulty.

## Honest framing

This is Google Ads **paid-bid** competition — a proxy for general topic difficulty, not true AEO difficulty (being cited by AI engines). The header tooltip says so. An AEO-native metric can replace it later.

## Verification

- `typecheck` + `format:check` pass; no new lint errors.
- Migration applies cleanly (additive, idempotent).
- Smoke-tested end-to-end: after a fresh re-analyze the bars render at the correct level/colour per prompt; prompts without a fetched volume row show `—` (correct null state).

## Migration note

The migration is additive and idempotent. Apply via Supabase Studio SQL Editor or `supabase db push` — safe to run before or after merge (`IF NOT EXISTS` makes a re-run a no-op).

## Out of scope (per the issue)

Per-keyword competition breakdown, AEO-native composite difficulty, other pages, sort/filter by competition, MCP/REST exposure — all noted as follow-ups.
