### PR TITLE
feat(tracking): capture Perplexity shopping_cards into prompt_results

### DIFF
--- a/server/src/lib/cloro-result-handler.js
+++ b/server/src/lib/cloro-result-handler.js
@@ -18,7 +18,7 @@ import { parseResponse, countBrandMentions } from './response-parser.js';
 
 /**
  * @param {object} args
- * @param {{ text: string, citations: Array, model: string }} args.aiResponse
+ * @param {{ text: string, citations: Array, model: string, shopping_cards: Array }} args.aiResponse
  *   Already parsed via parseScraperResponse (cloro-scraper.js)
  * @param {string} args.scraperId           Cloro scraper id (e.g. 'chatgpt-web')
  * @param {string} args.promptId
@@ -63,6 +63,7 @@ export async function handleScraperResult({
     model_used: aiResponse.model,
     region: region ?? null,
     competitor_mentions: metrics.competitorMentions,
+    shopping_cards: aiResponse.shopping_cards ?? [],
   });
 
   if (error) {

--- a/server/src/lib/cloro-scraper.js
+++ b/server/src/lib/cloro-scraper.js
@@ -80,7 +80,7 @@ export function parseScraperResponse(result, scraperId) {
       endIndex: idx * 100 + 50,
     }));
 
-    return { text, citations, model: 'google-aio' };
+    return { text, citations, model: 'google-aio', shopping_cards: [] };
   }
 
   if (scraperId === 'google-aimode') {
@@ -93,7 +93,7 @@ export function parseScraperResponse(result, scraperId) {
       endIndex: idx * 100 + 50,
     }));
 
-    return { text, citations, model: 'google-aimode' };
+    return { text, citations, model: 'google-aimode', shopping_cards: [] };
   }
 
   const text = result.markdown || result.text || '';
@@ -105,7 +105,12 @@ export function parseScraperResponse(result, scraperId) {
     endIndex: idx * 100 + 50,
   }));
 
-  return { text, citations, model };
+  return {
+    text,
+    citations,
+    model,
+    shopping_cards: result.shopping_cards ?? [],
+  };
 }
 
 /**
@@ -173,7 +178,7 @@ export async function submitScraperTask(promptText, scraperId, region, opts = {}
  * @param {string} taskId
  * @param {string} scraperId - needed to parse the response correctly
  * @param {{ maxWaitMs?: number, pollIntervalMs?: number }} [opts]
- * @returns {Promise<{ text: string, citations: Array, model: string }>}
+ * @returns {Promise<{ text: string, citations: Array, model: string, shopping_cards: Array }>}
  */
 export async function pollScraperResult(taskId, scraperId, opts = {}) {
   const maxWait = opts.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
@@ -248,7 +253,7 @@ export async function pollScraperResult(taskId, scraperId, opts = {}) {
  * @param {string} promptText
  * @param {string} scraperId
  * @param {string} [region]
- * @returns {Promise<{ text: string, citations: Array<{ url: string, title: string, startIndex: number, endIndex: number }>, model: string }>}
+ * @returns {Promise<{ text: string, citations: Array<{ url: string, title: string, startIndex: number, endIndex: number }>, model: string, shopping_cards: Array }>}
  */
 export async function runScraperPrompt(promptText, scraperId, region) {
   const { taskId } = await submitScraperTask(promptText, scraperId, region);

--- a/supabase/migrations/00005_prompt_results_shopping_cards.sql
+++ b/supabase/migrations/00005_prompt_results_shopping_cards.sql
@@ -1,0 +1,8 @@
+-- Capture Perplexity shopping cards alongside text + citations so the
+-- commerce-intent signal isn't lost. Other AI providers leave this empty;
+-- only Perplexity populates it today. Mirrors the citations /
+-- competitor_mentions columns on the same table (jsonb NOT NULL DEFAULT '[]').
+
+ALTER TABLE "public"."prompt_results"
+  ADD COLUMN IF NOT EXISTS "shopping_cards" jsonb
+    NOT NULL DEFAULT '[]'::jsonb;

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -472,6 +472,7 @@ export type Database = {
           region: string | null;
           response: string;
           sentiment: string;
+          shopping_cards: Json;
           visibility_score: number;
         };
         Insert: {
@@ -488,6 +489,7 @@ export type Database = {
           region?: string | null;
           response?: string;
           sentiment?: string;
+          shopping_cards?: Json;
           visibility_score?: number;
         };
         Update: {
@@ -504,6 +506,7 @@ export type Database = {
           region?: string | null;
           response?: string;
           sentiment?: string;
+          shopping_cards?: Json;
           visibility_score?: number;
         };
         Relationships: [


### PR DESCRIPTION
## Summary

Perplexity returns a structured `shopping_cards` array on shopping-intent prompts (alongside text + sources). We were discarding it. This captures it end-to-end (Cloro → parser → DB) so the highest-commercial-intent visibility signal is recorded from now on — by the time a Shopping UI lands, there's historical data behind it.

**Data-capture only** — no UI, no scoring change, no brand-in-card detection (all deliberately out of scope, per the issue).

Closes #46

## Changes

- **Migration** `00005_prompt_results_shopping_cards.sql` — `shopping_cards jsonb NOT NULL DEFAULT '[]'` on `prompt_results` (mirrors `citations` / `competitor_mentions`).
- **`cloro-scraper.js`** — parsed object now carries `shopping_cards`: the generic/Perplexity branch passes `result.shopping_cards ?? []`; the AI Overview / AI Mode branches return `[]` so the field is always present. JSDoc updated.
- **`cloro-result-handler.js`** — writes `shopping_cards: aiResponse.shopping_cards ?? []` on the `prompt_results` insert.
- **`supabase.ts`** — `prompt_results` Row/Insert/Update gain `shopping_cards: Json`.

The whole array is stored verbatim as JSONB — no flattening, every field preserved for future analysis without another schema change.

## Verification

- `typecheck`, `format:check`, server `node --check`, and lint-parity all pass.
- **Live smoke test against Cloro Perplexity:** confirmed `shopping_cards` is a real top-level key in the response (`text, sources, citationPills, shopping_cards, related_queries, videos, search_model_queries, markdown`) — exactly the path the parser reads. The empty-state (`[]`) is captured correctly.
- Note: across ~16 shopping-intent prompts (US + GB) Perplexity returned `shopping_cards: []` every time during testing — it isn't surfacing cards right now. The field path and capture are verified; populated cards will be recorded automatically whenever Perplexity returns them.

## Migration note

Additive, idempotent default backfill (`'[]'`), no RLS change. Already applied to the production project; safe to run again (`db push` is a no-op given the default). Existing rows read fine with the `'[]'` backfill.

## Out of scope (future)

Shopping UI, visibility-score bonus, brand-in-card detection, aggregated insights, MCP/REST exposure.
