### PR TITLE
feat(tracking): capture Microsoft Copilot shoppingCards into prompt_results

### DIFF
--- a/server/src/lib/cloro-scraper.js
+++ b/server/src/lib/cloro-scraper.js
@@ -109,7 +109,11 @@ export function parseScraperResponse(result, scraperId) {
     text,
     citations,
     model,
-    shopping_cards: result.shopping_cards ?? [],
+    // Perplexity returns snake_case `shopping_cards`; Copilot returns
+    // camelCase `shoppingCards`. Both write into the same prompt_results
+    // .shopping_cards column raw, in their own provider shape — downstream
+    // branches on `platform` to interpret. Other providers have neither key.
+    shopping_cards: result.shopping_cards ?? result.shoppingCards ?? [],
   };
 }
 


### PR DESCRIPTION
## Summary

Companion to #46 — captures Microsoft Copilot's product cards into `prompt_results.shopping_cards`, the same column Perplexity writes to. Copilot returns its cards under **camelCase** `shoppingCards`; we unwrap that into the parsed object's `shopping_cards` key so the existing storage path (column, types, result-handler from #46) needs no Copilot-specific code.

Both providers store their cards **raw, in their own shape** — downstream branches on `prompt_results.platform` to interpret. No flattening, no normalization.

Closes #47

## Change

Single line in `server/src/lib/cloro-scraper.js` (the generic/non-Google branch that Copilot + Perplexity both use):

```js
shopping_cards: result.shopping_cards ?? result.shoppingCards ?? [],
```

- Perplexity → `result.shopping_cards` (snake_case)
- Copilot → `result.shoppingCards` (camelCase)
- Everyone else → neither key → `[]`

There's no dedicated Copilot branch in the parser (Copilot goes through the shared generic branch), so handling both keys there is the minimal, non-duplicating change — rather than forking a Copilot-only branch that would copy the text/citations/model logic.

## Stacked on #46

Depends on #46 (PR #83), which adds the `shopping_cards` column, Supabase types, and the result-handler insert. **This PR is based on that branch** — merge #83 first; GitHub will then retarget this to `main` and the diff is the single line above.

## Verification

- `node --check` passes on the parser.
- Field path confirmed via #46's live smoke test (`shopping_cards` is a real top-level key on the Cloro response). The Copilot key (`shoppingCards`) follows the same Cloro docs.

## Out of scope

Shape normalization, UI, scoring, brand-in-card detection, MCP/REST exposure — all future, same as #46.
