### PR TITLE
feat(tracking): capture Google AI Mode shopping cards into prompt_results

### DIFF
--- a/server/src/lib/cloro-scraper.js
+++ b/server/src/lib/cloro-scraper.js
@@ -93,7 +93,16 @@ export function parseScraperResponse(result, scraperId) {
       endIndex: idx * 100 + 50,
     }));
 
-    return { text, citations, model: 'google-aimode', shopping_cards: [] };
+    // AI Mode returns its product cards under camelCase `shoppingCards`
+    // (like Copilot — verified against the live response; not snake_case).
+    // Unwrap into the snake_case parsed key shared by all providers. Its
+    // separate `inlineProducts` array is a different surface, out of scope.
+    return {
+      text,
+      citations,
+      model: 'google-aimode',
+      shopping_cards: aiMode.shoppingCards ?? [],
+    };
   }
 
   const text = result.markdown || result.text || '';


### PR DESCRIPTION
## Summary

Third companion to #46 (Perplexity) and #47 (Copilot) — captures Google AI Mode's product cards into `prompt_results.shopping_cards`, the same column, stored raw. Single-line-ish change in the AI Mode branch of `cloro-scraper.js`.

Closes #49

## ⚠️ Spec correction: AI Mode uses **camelCase** `shoppingCards`, not snake_case

The issue says AI Mode returns snake_case `result.shopping_cards` (like Perplexity). Against the **live Cloro response** that's not the case — AI Mode returns camelCase `shoppingCards` (like Copilot). The issue's suggested `result.shopping_cards ?? []` would always yield `[]`.

Verified live (`google-aimode`, "best wireless headphones under $200"):

```
response top-level keys: [ text, sources, citationPills, shoppingCards, inlineProducts, markdown ]
shoppingCards: array(5)   shopping_cards: undefined
```

A real populated card:

```json
{
  "title": "Sony ULT WEAR Wireless Noise Canceling Headphones",
  "productLink": "https://www.google.com/search?...",
  "price": { "value": 148, "currency": "$", "raw": "$148.00. Was $248" },
  "store": "Best Buy & more",
  "rating": 4.7,
  "reviews": "5.2K",
  "oldPrice": { "value": 248, "currency": "$", "raw": "$248" }
}
```

So the product shape is also camelCase (`productLink`, `oldPrice`, `price.raw`), not the snake_case the issue table listed. We store **verbatim** regardless — the future UI should branch on `platform === 'google-aimode'` and expect this shape.

## Change

`server/src/lib/cloro-scraper.js`, AI Mode branch:

```js
shopping_cards: aiMode.shoppingCards ?? [],
```

(`aiMode = result.result || result`; live response is flat so `aiMode === result`. Using `aiMode` keeps it consistent with how `text`/`sources` are read in the same branch.)

The separate **`inlineProducts`** array (also present, camelCase) is a different surface — left out of scope per the issue.

## Verification

- `node --check` passes.
- Live smoke caught a populated `shoppingCards` array (above); the camelCase key + shape are confirmed against the real response.

## Notes

- Depends on #46 (column/types/handler) — already merged, so this branches off `main` cleanly.
- Independent of #47 (different branch in the same file; no conflict).
