### PR TITLE
feat(tracking): capture Microsoft Copilot shoppingCards into prompt_results

### DIFF
--- a/server/src/lib/cloro-scraper.js
+++ b/server/src/lib/cloro-scraper.js
@@ -109,7 +109,11 @@ export function parseScraperResponse(result, scraperId) {
     text,
     citations,
     model,
-    shopping_cards: result.shopping_cards ?? [],
+    // Perplexity returns snake_case `shopping_cards`; Copilot returns
+    // camelCase `shoppingCards`. Both write into the same prompt_results
+    // .shopping_cards column raw, in their own provider shape — downstream
+    // branches on `platform` to interpret. Other providers have neither key.
+    shopping_cards: result.shopping_cards ?? result.shoppingCards ?? [],
   };
 }
 


### PR DESCRIPTION
## Summary

Captures Microsoft Copilot's product cards into `prompt_results.shopping_cards` (the column added in #46, already on `main`). One-line change in the generic/non-Google parser branch that Copilot and Perplexity share.

Closes #47

## Why this is a re-do

The original PR (#85) was stacked on the Perplexity branch (`feat/tracking-shopping-cards`) and ended up **merged into that branch, not `main`** — so the change never reached `main` (and #47 got auto-closed prematurely). This PR targets `main` directly, branched off the merged #46.

## Change

`server/src/lib/cloro-scraper.js`:

```js
shopping_cards: result.shopping_cards ?? result.shoppingCards ?? [],
```

- Perplexity → `result.shopping_cards` (snake_case)
- Copilot → `result.shoppingCards` (camelCase)
- Everyone else → neither key → `[]`

Stored verbatim in Copilot's shape; downstream branches on `prompt_results.platform`.

## Verification

- `node --check` passes.
- **Live smoke caught a populated Copilot card** ("best wireless headphones to buy" → 3 cards / 6 products), confirming `shoppingCards` is a real top-level key with the documented shape (`name`, `price.amount`, `seller`, `brandName`, `rating`, `url`).

## Cleanup note

The stale `feat/tracking-shopping-cards` branch (already squash-merged via #46, but still on the remote and now also holding the stranded Copilot commit) can be deleted.
