### PR TITLE
docs(readme): replace intro with a build-in-public manifesto

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@
 
 </div>
 
-Track how your brand appears in answers from ChatGPT, Gemini, Perplexity, Claude, and Copilot. Ansvisor turns AI search into a measurable channel — visibility scores, competitor benchmarks, content optimization briefs, and AI-referral analytics in one self-hostable platform.
+The search landscape is transforming fast. Buyers are moving from traditional search engines to AI platforms like ChatGPT, Claude, Gemini, Google AI Mode, etc.
+
+At Ansvisor, we are building the open future of AI Visibility and AI Search Optimization (AEO/GEO) to help brands claim their spot in AI-generated answers.
+
+What excites us most about Ansvisor is our commitment to a build-in-public and transparent approach.
+
+We believe the future of AI visibility shouldn't be a black box. This field really needs an open platform.
+
+We're incredibly excited to shape what's next alongside our amazing community.
 
 <div align="center">
 


### PR DESCRIPTION
## Summary

Replaces the README's single-line intro with a short **build-in-public manifesto** that frames the project around AI visibility / AI search optimization (AEO/GEO) and its open, transparent stance.

## Change

`README.md` — the intro paragraph just under the hero:

- removes the old one-line feature summary
- adds 5 short paragraphs (the landscape shift → what we're building → build-in-public → open platform → community)

Clean, scoped diff (+9/−1) — only the intro changed; no other sections touched.

## Notes

- Independent of #89 (tagline + `mint.json`): that edits the hero tagline line; this edits the paragraph below it — different hunks, no conflict. Reads well together once both land.
- Editor-introduced markdown table re-alignment from the local draft was intentionally left out to keep this diff focused.
