### PR TITLE
docs(introduction): rewrite "What is Ansvisor?" around AI search visibility / GEO / AEO

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -16,9 +16,20 @@ description: 'Track how AI search engines mention your brand and turn AI visibil
 
 ## What is Ansvisor?
 
-Ansvisor is an open-source **Answer Engine Optimization** (AEO) platform. It tells you exactly how often ChatGPT, Google AI Overview, Google AI Mode, Google Gemini, Perplexity, Microsoft Copilot, Grok, and Claude name your brand when users ask buying-intent questions — and what to publish to get cited more often than your competitors.
+Ansvisor is an open-source, cloud-ready **AI Search Visibility, GEO, & AEO** platform that helps brands measure and improve their visibility across AI-powered search and answer engines.
 
-Classical SEO measures rankings on a results page. AEO measures something different: whether an AI assistant chooses your brand to answer a question. That's the new frontier of organic discovery, and Ansvisor is the instrumentation layer for it.
+Track prompt visibility, citations, rankings, competitor benchmarks, and brand performance across ChatGPT, Claude, Gemini, Perplexity, Grok, Microsoft Copilot, Google AI Mode, and Google AI Overviews.
+
+Ansvisor enables teams to turn AI search into a measurable growth channel with optimization insights, visibility reporting, competitive intelligence, and data-driven content workflows powered by MCP Server.
+
+### What can you do with Ansvisor?
+
+- Learn growth opportunities in one click.
+- Discover Prompt Volumes and get new Prompt and Topic suggestions.
+- Monitor visibility and citations across major AI engines.
+- Benchmark competitors and track AI search performance.
+- Generate GEO & AEO optimization insights and briefs.
+- Create high-value, data-driven content and build long-term authority across AI search ecosystems.
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -29,7 +29,7 @@ Ansvisor enables teams to turn AI search into a measurable growth channel with o
 - Monitor visibility and citations across major AI engines.
 - Benchmark competitors and track AI search performance.
 - Generate GEO & AEO optimization insights and briefs.
-- Create high-value, data-driven content and build long-term authority across AI search ecosystems.
+- Build long-term authority across AI search ecosystems.
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">


### PR DESCRIPTION
## Summary

Rewrites the **What is Ansvisor?** section on the docs introduction page (`docs/introduction.mdx`) to position the product as an **AI Search Visibility, GEO & AEO** platform, list the tracked engines, and add a **"What can you do with Ansvisor?"** capabilities list.

## Change

- Replaces the two intro paragraphs with three: positioning → tracked engines → growth-channel framing (MCP Server).
- Adds a `### What can you do with Ansvisor?` list (growth opportunities, prompt volumes/suggestions, visibility & citations, competitor benchmarks, GEO/AEO briefs, data-driven content).
- Keeps the existing Quickstart `CardGroup` untouched.

Scoped diff (+13/−2), only the "What is Ansvisor?" block.

## Note

The last capability line from the source copy was garbled ("...data-driven **cont-term** authority...") — reconstructed as **"Create high-value, data-driven content and build long-term authority across AI search ecosystems."** Adjust if a different phrasing was intended.
