### PR TITLE
chore(release): v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-26
+
+### Added
+- MCP server with API keys + `list_brands` and `get_visibility_summary` tools, exposed at `/api/mcp` (#20)
+- MCP: `list_prompts` / `get_prompt` and `list_topics` / `get_topic` tools, plus parallel REST endpoints (#35)
+- MCP: `list_content_opportunities` / `get_content_opportunity` tools + REST endpoints (#74)
+- Anthropic Skills: Ansvisor AEO Coach ships in two flavours — MCP tool for Claude Desktop / Code / Cursor / Zed, and standalone REST for claude.ai web (#23)
+- Analytics: PostHog + Vercel Analytics with self-host opt-in posture (#13)
+- Analytics: universal user identification and onboarding-funnel instrumentation (#30)
+- CSV export buttons on Topics (#53), Prompts (#54), and Answer Engine Insights (#73)
+- Citations: searchable prompt combobox filter (#55)
+- Sidebar: user profile chip (avatar + name) linking to settings (#52)
+- Prompts: Competition column with a 5-bar difficulty meter (#82)
+- Tracking: capture Perplexity `shopping_cards` into `prompt_results` (#83)
+- Tracking: capture Google AI Mode `shoppingCards` into `prompt_results` (#86)
+- Tracking: capture Microsoft Copilot `shoppingCards` into `prompt_results` (#87)
+- DX: `supabase/seed.sql` ships a populated local dashboard (one demo org, brand, prompts, ~120 prompt results, competitors, content opportunities, AI traffic logs) — `demo@ansvisor.local` / `demo123` (#75)
+- Tooling: Prettier configuration + CI workflow (format check & typecheck) (#80)
+
+### Changed
+- README: replaced the intro with a build-in-public manifesto (#90)
+- README / docs metadata: tagline updated to "AI Visibility & AI Search Optimization" (#89)
+- Docs: rewrote "What is Ansvisor?" around AI Search Visibility / GEO / AEO (#92)
+- README: stargazers CTA above "Why Ansvisor?" (#77)
+- Onboarding: signout button in the bottom-right corner (#68)
+- Settings: contact-us CTA opens the contact page (#81)
+- CI: auto-welcome first-time contributors on PRs only (#34, #59)
+
+### Fixed
+- Billing: block tracking + features for orgs without an active subscription (#56)
+- Citations: group raw model slugs under display names in the Platforms filter (#48)
+- Insights: adaptive Y-axis on the Brand vs Competitors chart (#37)
+- Insights: silence navigation-cancellation toast (#70)
+- MCP: use the app URL for the MCP endpoint (#33)
+- UI: ComboboxTrigger overflow — respect caller width and clip long values (#91)
+- Onboarding: preserve pending content opportunities (#63)
+- UI: sign-in / sign-up header logo points at the marketing site (#57)
+- UI: remove unused dashboard layout header (#36)
+- Refresh stale package-lock metadata (#51)
+
 ## [0.1.0] - 2026-04-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ansvisor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Open source AI Engine Optimization platform",
   "repository": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeohub/ansvisor-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ansvisor - AI Engine Optimization Server",
   "main": "src/server.js",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeohub/ansvisor-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
First release after v0.1.0 (2026-04-09) — 7 weeks, 62 commits on \`main\`.

## What's in 0.1.1

**Added (17)**
- MCP server with API keys + \`list_brands\` / \`get_visibility_summary\` (#20)
- MCP: prompts / topics tools + REST endpoints (#35)
- MCP: content opportunities tools + REST endpoints (#74)
- Anthropic Skills: Ansvisor AEO Coach (MCP + standalone REST) (#23)
- PostHog + Vercel Analytics, self-host opt-in (#13)
- Universal user identification + onboarding-funnel instrumentation (#30)
- CSV export — Topics (#53), Prompts (#54), Insights (#73)
- Citations: searchable prompt filter (#55)
- Sidebar: user profile chip → settings (#52)
- Prompts: Competition column + 5-bar meter (#82)
- Tracking: capture \`shopping_cards\` — Perplexity (#83), AI Mode (#86), Copilot (#87)
- DX: \`supabase/seed.sql\` for a populated local dashboard (#75)
- Tooling: Prettier + CI (format check & typecheck) (#80)

**Changed (8)** — README manifesto (#90), tagline (#89), \`introduction.mdx\` rewrite (#92), stargazers CTA (#77), onboarding sign-out (#68), contact CTA (#81), first-time-contributor CI (#34, #59)

**Fixed (10)** — billing gate (#56), citations platform grouping (#48), insights Y-axis (#37) & toast silence (#70), MCP app URL (#33), Combobox overflow (#91), pending opportunities (#63), sign-in/up logo (#57), unused layout header (#36), stale package-lock (#51)

Full list in \`CHANGELOG.md\`.

## What this PR touches

- \`package.json\`, \`web/package.json\`, \`server/package.json\` — all bumped to \`0.1.1\` via \`scripts/version-bump.js patch\`
- \`CHANGELOG.md\` — \`[Unreleased]\` → \`[0.1.1] - 2026-05-26\` populated

## After merge

1. \`git tag -a v0.1.1 -m "v0.1.1" <merge-sha>\` and \`git push --tags\`
2. \`gh release create v0.1.1 --title "v0.1.1" --notes-from-tag\` (or paste the changelog section)