### PR TITLE
chore: rename aeohub/ansvisor → ansvisor/ansvisor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Both `web/` and `server/` are independent packages with their own `package.json`
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/aeohub/ansvisor.git
+git clone https://github.com/ansvisor/ansvisor.git
 cd ansvisor
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![🚀 Try the Cloud — ansvisor.com](https://img.shields.io/badge/🚀_Try_the_Cloud-ansvisor.com-6366f1?style=for-the-badge&logoColor=white&logo=vercel)](https://ansvisor.com)
 [![📚 Docs](https://img.shields.io/badge/📚_Docs-docs.ansvisor.com-10b981?style=for-the-badge&logoColor=white&logo=readthedocs)](https://docs.ansvisor.com)
 
-[![Star on GitHub](https://img.shields.io/github/stars/aeohub/ansvisor?style=for-the-badge&logo=github&color=gold)](https://github.com/aeohub/ansvisor)
+[![Star on GitHub](https://img.shields.io/github/stars/ansvisor/ansvisor?style=for-the-badge&logo=github&color=gold)](https://github.com/ansvisor/ansvisor)
 [![MIT License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Built%20with-Claude%20Code-green?style=for-the-badge&logo=anthropic)](https://claude.com/claude-code)
 
@@ -29,8 +29,8 @@ We're incredibly excited to shape what's next alongside our amazing community.
 
 _Star us to follow along as we ship 👇_
 
-<a href="https://github.com/aeohub/ansvisor">
-  <img src="https://img.shields.io/github/stars/aeohub/ansvisor?style=social&label=Star" alt="Star Ansvisor on GitHub">
+<a href="https://github.com/ansvisor/ansvisor">
+  <img src="https://img.shields.io/github/stars/ansvisor/ansvisor?style=social&label=Star" alt="Star Ansvisor on GitHub">
 </a>
 
 </div>
@@ -79,7 +79,7 @@ _Star us to follow along as we ship 👇_
 #### 1. Clone and configure
 
 ```bash
-git clone https://github.com/aeohub/ansvisor.git
+git clone https://github.com/ansvisor/ansvisor.git
 cd ansvisor
 
 cp web/.env.example web/.env.local
@@ -174,7 +174,7 @@ What we're planning to build next. React with 👍 on the linked issue (or open 
 - [ ] **BYO LLM keys** — bring your own OpenAI / Anthropic / Gemini API key for tracking and content generation, so you control cost and data handling
 - [ ] **Webhook recipe library** — one-click Notion / Linear / Asana / Slack templates so a Content Brief can land in your editorial workflow with zero glue code
 
-See an idea missing? Check the [Ideas discussions](https://github.com/aeohub/ansvisor/discussions/categories/ideas) — upvote an existing one or open a new thread.
+See an idea missing? Check the [Ideas discussions](https://github.com/ansvisor/ansvisor/discussions/categories/ideas) — upvote an existing one or open a new thread.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/aeohub/ansvisor/web:0.1.0
+    image: ghcr.io/ansvisor/ansvisor/web:0.1.0
     build: ./web
     ports:
       - "3000:3000"
@@ -11,7 +11,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: ghcr.io/aeohub/ansvisor/server:0.1.0
+    image: ghcr.io/ansvisor/ansvisor/server:0.1.0
     build: ./server
     ports:
       - "80:80"

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -5,7 +5,7 @@ description: "Common questions about Ansvisor."
 
 <AccordionGroup>
   <Accordion title="Is Ansvisor really fully open source?">
-    Yes. Every line of code that powers ansvisor.com is in the [public repo](https://github.com/aeohub/ansvisor) under MIT. No paywalled features in the self-hosted build — the cloud service is just a hosted convenience.
+    Yes. Every line of code that powers ansvisor.com is in the [public repo](https://github.com/ansvisor/ansvisor) under MIT. No paywalled features in the self-hosted build — the cloud service is just a hosted convenience.
   </Accordion>
 
   <Accordion title="What's the cost difference between cloud and self-hosted?">
@@ -31,8 +31,8 @@ description: "Common questions about Ansvisor."
   </Accordion>
 
   <Accordion title="How do I get help?">
-    - **Bugs / feature requests**: [GitHub Issues](https://github.com/aeohub/ansvisor/issues)
-    - **Discussion**: [GitHub Discussions](https://github.com/aeohub/ansvisor/discussions)
+    - **Bugs / feature requests**: [GitHub Issues](https://github.com/ansvisor/ansvisor/issues)
+    - **Discussion**: [GitHub Discussions](https://github.com/ansvisor/ansvisor/discussions)
     - **Cloud customers**: support email in your dashboard footer
   </Accordion>
 
@@ -45,6 +45,6 @@ description: "Common questions about Ansvisor."
   </Accordion>
 
   <Accordion title="How do I contribute?">
-    Read [CONTRIBUTING.md](https://github.com/aeohub/ansvisor/blob/main/CONTRIBUTING.md) in the repo. We welcome PRs for: new AI engine adapters, additional citation classifiers, language packs, UI polish, and bug fixes. For larger features, open an issue first to align.
+    Read [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md) in the repo. We welcome PRs for: new AI engine adapters, additional citation classifiers, language packs, UI polish, and bug fixes. For larger features, open an issue first to align.
   </Accordion>
 </AccordionGroup>

--- a/docs/guides/mcp-server.mdx
+++ b/docs/guides/mcp-server.mdx
@@ -58,7 +58,7 @@ instead.
 | `list_topics` | List the topics on a brand with a prompt count per topic. Use for coverage audits (empty / over-concentrated topics). |
 | `list_prompts` | List the prompts tracked on a brand, optionally filtered by topic, active status, or capped via `limit`. Returns the prompt text, topic, platforms, models, regions, and active flag. |
 
-More tools land regularly — check the [project roadmap](https://github.com/aeohub/ansvisor#whats-next).
+More tools land regularly — check the [project roadmap](https://github.com/ansvisor/ansvisor#whats-next).
 
 ## Try it
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -85,4 +85,4 @@ Ansvisor enables teams to turn AI search into a measurable growth channel with o
 
 ## Open-source and self-hostable
 
-Ansvisor is MIT-licensed. Every feature available on the cloud is unlocked when you self-host — no feature gating, no telemetry. The repo lives at [github.com/aeohub/ansvisor](https://github.com/aeohub/ansvisor).
+Ansvisor is MIT-licensed. Every feature available on the cloud is unlocked when you self-host — no feature gating, no telemetry. The repo lives at [github.com/ansvisor/ansvisor](https://github.com/ansvisor/ansvisor).

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -26,7 +26,7 @@
   "topbarLinks": [
     {
       "name": "GitHub",
-      "url": "https://github.com/aeohub/ansvisor"
+      "url": "https://github.com/ansvisor/ansvisor"
     }
   ],
   "topbarCtaButton": {
@@ -37,12 +37,12 @@
     {
       "name": "GitHub",
       "icon": "github",
-      "url": "https://github.com/aeohub/ansvisor"
+      "url": "https://github.com/ansvisor/ansvisor"
     },
     {
       "name": "Changelog",
       "icon": "list",
-      "url": "https://github.com/aeohub/ansvisor/releases"
+      "url": "https://github.com/ansvisor/ansvisor/releases"
     }
   ],
   "tabs": [
@@ -110,7 +110,7 @@
     }
   ],
   "footerSocials": {
-    "github": "https://github.com/aeohub/ansvisor",
+    "github": "https://github.com/ansvisor/ansvisor",
     "website": "https://ansvisor.com"
   }
 }

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -33,7 +33,7 @@ For teams who want full control and zero per-seat pricing.
 <Steps>
   <Step title="Clone the repo and prepare env files">
     ```bash
-    git clone https://github.com/aeohub/ansvisor.git
+    git clone https://github.com/ansvisor/ansvisor.git
     cd ansvisor
     cp web/.env.example web/.env
     cp server/.env.example server/.env
@@ -82,5 +82,5 @@ After your first tracking run completes, the dashboard fills with data. The most
 </CardGroup>
 
 <Tip>
-**Got stuck?** Open an issue at [github.com/aeohub/ansvisor/issues](https://github.com/aeohub/ansvisor/issues) — we read every report.
+**Got stuck?** Open an issue at [github.com/ansvisor/ansvisor/issues](https://github.com/ansvisor/ansvisor/issues) — we read every report.
 </Tip>

--- a/docs/self-host/docker-compose.mdx
+++ b/docs/self-host/docker-compose.mdx
@@ -25,7 +25,7 @@ Plus an external dependency:
 <Steps>
   <Step title="Clone the repo">
     ```bash
-    git clone https://github.com/aeohub/ansvisor.git
+    git clone https://github.com/ansvisor/ansvisor.git
     cd ansvisor
     ```
   </Step>

--- a/docs/self-host/upgrading.mdx
+++ b/docs/self-host/upgrading.mdx
@@ -34,7 +34,7 @@ Always run migrations **before** restarting containers — new code may expect n
 
 ## Major version upgrades
 
-When jumping a major version (e.g. v1 → v2), check the release notes on [GitHub Releases](https://github.com/aeohub/ansvisor/releases) for breaking changes. Common scenarios:
+When jumping a major version (e.g. v1 → v2), check the release notes on [GitHub Releases](https://github.com/ansvisor/ansvisor/releases) for breaking changes. Common scenarios:
 
 - Renamed env variables — update `web/.env` and `server/.env`
 - Migration that requires manual data backfill — release notes will spell it out
@@ -58,4 +58,4 @@ Database migrations are **not** automatically reversed. If a new migration intro
 
 ## Watching the changelog
 
-Subscribe to release notifications on the GitHub repo: [aeohub/ansvisor → Watch → Releases only](https://github.com/aeohub/ansvisor). You'll get an email for each new release with the full changelog.
+Subscribe to release notifications on the GitHub repo: [ansvisor/ansvisor → Watch → Releases only](https://github.com/ansvisor/ansvisor). You'll get an email for each new release with the full changelog.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "description": "Open source AI Engine Optimization platform",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aeohub/ansvisor.git"
+    "url": "https://github.com/ansvisor/ansvisor.git"
   },
-  "homepage": "https://github.com/aeohub/ansvisor",
+  "homepage": "https://github.com/ansvisor/ansvisor",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20
 ARG VERSION=0.1.0
 LABEL org.opencontainers.image.title="Ansvisor Server"
 LABEL org.opencontainers.image.version=$VERSION
-LABEL org.opencontainers.image.source="https://github.com/aeohub/ansvisor"
+LABEL org.opencontainers.image.source="https://github.com/ansvisor/ansvisor"
 LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /ansvisor-server

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@aeohub/ansvisor-server",
+  "name": "@ansvisor/ansvisor-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@aeohub/ansvisor-server",
+      "name": "@ansvisor/ansvisor-server",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@aeohub/ansvisor-server",
+  "name": "@ansvisor/ansvisor-server",
   "version": "0.1.1",
   "description": "Ansvisor - AI Engine Optimization Server",
   "main": "src/server.js",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aeohub/ansvisor.git",
+    "url": "https://github.com/ansvisor/ansvisor.git",
     "directory": "server"
   },
-  "homepage": "https://github.com/aeohub/ansvisor",
+  "homepage": "https://github.com/ansvisor/ansvisor",
   "scripts": {
     "dev": "NODE_ENV=development nodemon src/server.js",
     "start": "NODE_ENV=production pm2 start src/server.js --max-restarts 10000"

--- a/skills/README.md
+++ b/skills/README.md
@@ -69,7 +69,7 @@ itself.
 ### Claude Code / Claude Desktop
 
 ```bash
-git clone https://github.com/aeohub/ansvisor.git
+git clone https://github.com/ansvisor/ansvisor.git
 cp -r ansvisor/skills/ansvisor-aeo-coach ~/.claude/skills/   # MCP flavour
 # or
 cp -r ansvisor/skills/ansvisor-aeo-coach-standalone ~/.claude/skills/
@@ -123,4 +123,4 @@ conventions, and PR workflow.
 
 ## License
 
-[MIT](../LICENSE) — part of [Ansvisor](https://github.com/aeohub/ansvisor).
+[MIT](../LICENSE) — part of [Ansvisor](https://github.com/ansvisor/ansvisor).

--- a/skills/ansvisor-aeo-coach/SKILL.md
+++ b/skills/ansvisor-aeo-coach/SKILL.md
@@ -38,7 +38,7 @@ Activate this skill when the user asks anything in the shape of:
 
 If you don't see the Ansvisor MCP tools listed below in your available
 tools, the user hasn't connected the MCP server yet. Point them at the
-[MCP setup guide](https://github.com/aeohub/ansvisor/blob/main/docs/guides/mcp-server.mdx)
+[MCP setup guide](https://github.com/ansvisor/ansvisor/blob/main/docs/guides/mcp-server.mdx)
 and stop — do not invent numbers, and do not attempt to call the REST
 API directly from this skill (that's a different skill).
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS base
 ARG VERSION=0.1.0
 LABEL org.opencontainers.image.title="Ansvisor Web"
 LABEL org.opencontainers.image.version=$VERSION
-LABEL org.opencontainers.image.source="https://github.com/aeohub/ansvisor"
+LABEL org.opencontainers.image.source="https://github.com/ansvisor/ansvisor"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Install dependencies

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@aeohub/ansvisor-web",
+  "name": "@ansvisor/ansvisor-web",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@aeohub/ansvisor-web",
+      "name": "@ansvisor/ansvisor-web",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@aeohub/ansvisor-web",
+  "name": "@ansvisor/ansvisor-web",
   "version": "0.1.1",
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/aeohub/ansvisor.git",
+    "url": "https://github.com/ansvisor/ansvisor.git",
     "directory": "web"
   },
-  "homepage": "https://github.com/aeohub/ansvisor",
+  "homepage": "https://github.com/ansvisor/ansvisor",
   "license": "MIT",
   "scripts": {
     "dev": "next dev",

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -7,7 +7,7 @@ export function MarketingFooter() {
         <p className="text-sm text-muted-foreground">
           &copy; {new Date().getFullYear()} {siteConfig.name}. Open source under{' '}
           <a
-            href="https://github.com/aeohub/ansvisor/blob/main/LICENSE"
+            href="https://github.com/ansvisor/ansvisor/blob/main/LICENSE"
             target="_blank"
             rel="noopener noreferrer"
             className="underline hover:text-foreground transition-colors"

--- a/web/src/components/settings/api-keys-section.tsx
+++ b/web/src/components/settings/api-keys-section.tsx
@@ -155,7 +155,7 @@ export function ApiKeysSection() {
           <p className="text-muted-foreground">
             Paste this URL + a key below into Claude Desktop / Claude Code / Cursor. See the{' '}
             <a
-              href="https://github.com/aeohub/ansvisor#whats-next"
+              href="https://github.com/ansvisor/ansvisor#whats-next"
               target="_blank"
               rel="noreferrer"
               className="underline"

--- a/web/src/config/site.ts
+++ b/web/src/config/site.ts
@@ -5,7 +5,7 @@ export const siteConfig = {
   url: 'https://ansvisor.com',
   ogImage: 'https://app.ansvisor.com/opengraph-image',
   links: {
-    github: 'https://github.com/aeohub/ansvisor',
+    github: 'https://github.com/ansvisor/ansvisor',
     docs: 'https://docs.ansvisor.com',
   },
   legal: {


### PR DESCRIPTION
The org was renamed from \`aeohub\` to \`ansvisor\` on GitHub. GitHub redirects keep the old paths resolving for now, but every canonical reference in code/docs/package metadata still says \`aeohub/ansvisor\`. This sweep makes the canonical names match the live org so PR bodies, issue links, package-lock paths, ghcr image tags, and docs links all point at the right place going forward.

## Scope

Pure string replacement across **22 files / 43 lines** — no logic touched.

- \`README.md\`, \`CONTRIBUTING.md\` — clone URL, badge URLs, ideas-discussions link
- \`docs/\` — \`introduction.mdx\`, \`quickstart.mdx\`, \`faq.mdx\`, \`mint.json\`, \`guides/mcp-server.mdx\`, \`self-host/docker-compose.mdx\`, \`self-host/upgrading.mdx\`, \`skills/README.md\`, \`skills/ansvisor-aeo-coach/SKILL.md\`
- \`package.json\` × 3 (root + web + server) — \`name\`, \`repository.url\`, \`homepage\`
- \`web/package-lock.json\`, \`server/package-lock.json\` — top-level \`name\` field
- \`docker-compose.yml\`, \`web/Dockerfile\`, \`server/Dockerfile\` — \`ghcr.io/aeohub/...\` → \`ghcr.io/ansvisor/...\` + OCI source label
- \`web/src/config/site.ts\`, \`web/src/components/marketing/marketing-footer.tsx\`, \`web/src/components/settings/api-keys-section.tsx\` — UI links

## Replacement rules

\`\`\`
aeohub/ansvisor   →  ansvisor/ansvisor
@aeohub/          →  @ansvisor/
ghcr.io/aeohub    →  ghcr.io/ansvisor
\`\`\`

Verified with \`grep -rn aeohub .\` afterwards — zero hits.

## After merge

GHCR images under \`ghcr.io/aeohub/ansvisor/*\` won't auto-redirect for container pulls; the **next release build** will publish to \`ghcr.io/ansvisor/ansvisor/*\` from the new compose tags. Existing self-hosters running v0.1.x stay on their pulled image until they upgrade.