### PR TITLE
feat(mcp): expose update_opportunity_status tool for workflow transitions

### DIFF
--- a/web/src/app/api/mcp/content-opportunities/[id]/status/route.ts
+++ b/web/src/app/api/mcp/content-opportunities/[id]/status/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { authenticateMcpRequest } from '@/lib/mcp-auth';
+import {
+  CONTENT_OPPORTUNITY_STATUSES,
+  updateOpportunityStatusFor,
+  type ContentOpportunityStatus,
+} from '@/lib/mcp/data';
+
+/**
+ * PATCH /api/mcp/content-opportunities/[id]/status
+ *
+ * Parallel REST surface for the `update_opportunity_status` MCP tool —
+ * same data-layer function, same ownership guarantee, same enum validation.
+ * Body: `{ "status": "in_progress" }` (one of new | sent | in_progress | done | dismissed).
+ */
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authenticateMcpRequest(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const resolvedParams = await params;
+  const opportunityId = resolvedParams.id;
+  if (!opportunityId) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  }
+
+  let body: { status?: unknown };
+  try {
+    body = (await req.json()) as { status?: unknown };
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const status = body.status;
+  if (
+    typeof status !== 'string' ||
+    !(CONTENT_OPPORTUNITY_STATUSES as readonly string[]).includes(status)
+  ) {
+    return NextResponse.json(
+      {
+        error: `status is required and must be one of: ${CONTENT_OPPORTUNITY_STATUSES.join(', ')}`,
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const updated = await updateOpportunityStatusFor(
+      auth,
+      opportunityId,
+      status as ContentOpportunityStatus,
+    );
+    if (!updated) {
+      return NextResponse.json({ error: 'Content opportunity not found' }, { status: 404 });
+    }
+    return NextResponse.json(updated);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/lib/mcp/data.ts
+++ b/web/src/lib/mcp/data.ts
@@ -554,3 +554,64 @@ export async function getContentOpportunityFor(
     updated_at: r.updated_at ?? '',
   };
 }
+
+export const CONTENT_OPPORTUNITY_STATUSES = [
+  'new',
+  'sent',
+  'in_progress',
+  'done',
+  'dismissed',
+] as const;
+
+export type ContentOpportunityStatus = (typeof CONTENT_OPPORTUNITY_STATUSES)[number];
+
+export interface UpdatedOpportunityStatus {
+  id: string;
+  status: ContentOpportunityStatus;
+  updated_at: string;
+}
+
+/**
+ * Move a content opportunity between workflow states (`new` → `sent` →
+ * `in_progress` → `done`, or `dismissed`). Closes the loop for MCP-driven
+ * content workflows — without this, the user analyses an opportunity in
+ * Claude and still has to click through the dashboard to mark progress.
+ *
+ * Ownership-check-first: the update only runs after we've verified the
+ * opportunity's brand belongs to the caller's org. Wrong-org or missing
+ * id returns null (→ 404) with no DB write.
+ */
+export async function updateOpportunityStatusFor(
+  auth: McpAuthContext,
+  opportunityId: string,
+  status: ContentOpportunityStatus,
+): Promise<UpdatedOpportunityStatus | null> {
+  if (!auth.organizationId) return null;
+
+  // Ownership check via the same brands!inner join used by the read tools.
+  // A wrong-org id misses here and we return null *before* any update.
+  const { data: ownership } = await supabaseAdmin
+    .from('content_opportunities')
+    .select('id, brands!inner(organization_id)')
+    .eq('id', opportunityId)
+    .eq('brands.organization_id', auth.organizationId)
+    .maybeSingle();
+  if (!ownership) return null;
+
+  const updatedAt = new Date().toISOString();
+
+  const { data, error } = await supabaseAdmin
+    .from('content_opportunities')
+    .update({ status, updated_at: updatedAt })
+    .eq('id', opportunityId)
+    .select('id, status, updated_at')
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  return {
+    id: data.id,
+    status: data.status as ContentOpportunityStatus,
+    updated_at: data.updated_at ?? updatedAt,
+  };
+}

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import type { McpAuthContext } from '@/lib/mcp-auth';
 import {
+  CONTENT_OPPORTUNITY_STATUSES,
   generateBriefFor,
   getContentOpportunityFor,
   getVisibilitySummaryFor,
@@ -10,6 +11,7 @@ import {
   listContentOpportunitiesFor,
   listPromptsFor,
   listTopicsFor,
+  updateOpportunityStatusFor,
 } from './data';
 
 /**
@@ -246,6 +248,35 @@ export function createMcpServer(auth: McpAuthContext): McpServer {
       }
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'update_opportunity_status',
+    {
+      description:
+        'Move a content opportunity between workflow states. Valid statuses are: "new" (just generated), "sent" (delivered to a CMS / writer via webhook), "in_progress" (someone is actively writing), "done" (published), "dismissed" (intentionally skipped). Use this to close the loop on the content backlog from inside an MCP conversation — e.g. "mark that opportunity as in_progress" once the user starts writing, or "dismiss this one, we already cover it." This is a write — only fire on explicit user intent for a specific opportunity, never as part of an exploratory query.',
+      inputSchema: {
+        opportunity_id: z
+          .string()
+          .uuid()
+          .describe('Content opportunity UUID, from list_content_opportunities.'),
+        status: z
+          .enum(CONTENT_OPPORTUNITY_STATUSES)
+          .describe('New workflow state. One of: new, sent, in_progress, done, dismissed.'),
+      },
+    },
+    async (args) => {
+      const updated = await updateOpportunityStatusFor(auth, args.opportunity_id, args.status);
+      if (!updated) {
+        return {
+          content: [{ type: 'text', text: 'Content opportunity not found' }],
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }],
       };
     },
   );


### PR DESCRIPTION
Implements #67 to spec. Fourth and final content-opportunity MCP tool after #74 (list / get) and #109 (generate_brief), closing the read → analyse → act → mark-progress loop for MCP-driven content workflows.

## What

- New MCP tool: \`update_opportunity_status(opportunity_id, status)\` → \`{ id, status, updated_at }\`
- New REST endpoint: \`PATCH /api/mcp/content-opportunities/[id]/status\` with body \`{ "status": "..." }\`
- Status enum: \`new\` | \`sent\` | \`in_progress\` | \`done\` | \`dismissed\`

## Auth + safety (per pattern from #109)

Ownership check **first** in the web data layer — same \`brands!inner(organization_id)\` join used by all the other content-opportunity functions:

\`\`\`ts
const { data: ownership } = await supabaseAdmin
  .from('content_opportunities')
  .select('id, brands!inner(organization_id)')
  .eq('id', opportunityId)
  .eq('brands.organization_id', auth.organizationId)
  .maybeSingle();
if (!ownership) return null;
\`\`\`

Wrong-org or missing id returns null (→ 404) with **no UPDATE issued** — an attacker can't probe ids and can't flip rows they don't own. No external services, no LLM, so no upstream cost concern either.

## Shared enum

The valid statuses live as a single exported tuple in \`web/src/lib/mcp/data.ts\`:

\`\`\`ts
export const CONTENT_OPPORTUNITY_STATUSES = ['new', 'sent', 'in_progress', 'done', 'dismissed'] as const;
\`\`\`

Both the MCP zod schema and the REST handler's manual validation read from this tuple, so the two surfaces can't drift — adding a new status later is a one-line change.

## Files

| File | Change |
|---|---|
| \`web/src/lib/mcp/data.ts\` | New \`updateOpportunityStatusFor(auth, id, status)\` + exported \`CONTENT_OPPORTUNITY_STATUSES\` + \`ContentOpportunityStatus\` type |
| \`web/src/lib/mcp/server.ts\` | Registers \`update_opportunity_status\` with zod enum + per-status description so the model knows valid values without guessing |
| \`web/src/app/api/mcp/content-opportunities/[id]/status/route.ts\` | PATCH handler sharing the same data function; invalid status returns 400 with the valid list |

## How verified

Local smoke test against running web + local Supabase, with an \`ans_\` API key and a demo content opportunity from \`supabase/seed.sql\`:

- ✅ Valid update → 200 with new status, \`content_opportunities.status\` + \`updated_at\` refreshed
- ✅ Invalid status (\`"wat"\`) → 400 with the valid list in the error message, **no UPDATE issued**
- ✅ Wrong-org \`opportunity_id\` → 404, no UPDATE
- ✅ Missing API key → 401 from \`authenticateMcpRequest\`
- ✅ Missing / non-JSON body → 400
- ✅ Dashboard Content Opportunities page picks up the change on next load
- ✅ \`yarn typecheck\` + \`yarn format:check\` clean

## Conflict note

This branches off \`main\`, not off #109's branch. If #109 lands first, this PR has trivial textual conflicts in \`web/src/lib/mcp/data.ts\` (both add new exports near the end) and \`web/src/lib/mcp/server.ts\` (both add a tool registration before the \`return server\` line). Either order works — the imports/tool registrations are additive and don't touch each other's code paths.

## Out of scope (per #67)

- Bulk status updates (single-row only)
- Webhook firing on status changes (the dashboard's \`/bulk/send-webhook\` flow stays separate; this tool only flips the status field)
- Audit-log / note on transitions (future enhancement)

Closes #67.