### PR TITLE
fix(onboarding): align prompts to selected plan's engine set on Stripe success

### DIFF
--- a/web/src/app/api/stripe/success/route.ts
+++ b/web/src/app/api/stripe/success/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { stripe } from '@/lib/stripe';
 import { supabaseAdmin } from '@/lib/supabase/admin';
+import { getActiveEngineIdsForPlan } from '@/lib/plan-engines';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -49,6 +50,57 @@ export async function GET(req: NextRequest) {
           console.error('[stripe/success] DB update error:', updateError);
         } else {
           console.log('[stripe/success] DB updated for org:', orgId);
+
+          // Align onboarding-created prompts to the just-confirmed plan's
+          // engine set. Onboarding saves prompts at step 4 with whatever
+          // engines the *current* (pre-checkout, default Starter) plan
+          // allows — 2 scrapers. Without this, a user who picks Growth at
+          // step 6 still ends up tracking only those 2 engines instead of
+          // the 8 Growth allows. Issue #78.
+          //
+          // This runs only on the initial checkout-success redirect (i.e.
+          // onboarding's plan step). Plan changes / upgrades for existing
+          // orgs flow through the Stripe subscription update path and are
+          // tracked separately.
+          try {
+            const { platforms, models } = getActiveEngineIdsForPlan(planId || 'starter');
+
+            const { data: orgBrands } = await supabaseAdmin
+              .from('brands')
+              .select('id')
+              .eq('organization_id', orgId);
+
+            const brandIds = (orgBrands ?? []).map((b) => b.id);
+
+            if (brandIds.length > 0) {
+              const { data: promptSets } = await supabaseAdmin
+                .from('prompt_sets')
+                .select('id')
+                .in('brand_id', brandIds);
+
+              const promptSetIds = (promptSets ?? []).map((p) => p.id);
+
+              if (promptSetIds.length > 0) {
+                const { error: alignError } = await supabaseAdmin
+                  .from('prompts')
+                  .update({ platforms, models })
+                  .in('prompt_set_id', promptSetIds);
+
+                if (alignError) {
+                  console.error(
+                    '[stripe/success] Failed to align prompts to plan engines:',
+                    alignError,
+                  );
+                } else {
+                  console.log(
+                    `[stripe/success] Aligned prompts to plan=${planId || 'starter'} engines (${platforms.length} scrapers, ${models.length} models) for org ${orgId}`,
+                  );
+                }
+              }
+            }
+          } catch (alignErr) {
+            console.error('[stripe/success] Plan-engine alignment threw:', alignErr);
+          }
 
           // Find first brand and trigger tracking via aeo-server
           const { data: brand } = await supabaseAdmin

--- a/web/src/lib/plan-engines.ts
+++ b/web/src/lib/plan-engines.ts
@@ -1,0 +1,36 @@
+import { getPlan, type PlanId } from '@/config/plans';
+import { ALL_MODELS, ALL_SCRAPERS } from '@/config/prompt-options';
+
+/**
+ * Resolve the scraper + model id sets a plan currently allows.
+ *
+ * Mirrors the gating logic in the onboarding wizard
+ * (`(onboarding)/dashboard/onboarding/page.tsx`): if `allowedScrapers` /
+ * `allowedModels` is **absent** on the plan, every engine / model is allowed
+ * (Growth, Enterprise, Self-hosted). If it's an **array** — even an empty
+ * one — only the listed ids are allowed (Starter ships
+ * `allowedScrapers: ['chatgpt-web', 'perplexity-web']` and
+ * `allowedModels: []`).
+ *
+ * Used by the Stripe success route to align onboarding-created prompts to
+ * the plan the user actually picks at step 6 — without this, a Growth
+ * trial-er ends up tracking only the 2 Starter engines (issue #78).
+ */
+export function getActiveEngineIdsForPlan(planId: PlanId | string | null | undefined): {
+  platforms: string[];
+  models: string[];
+} {
+  const plan = getPlan((planId ?? 'starter') as PlanId);
+
+  const allowedScrapers = plan.limits.allowedScrapers;
+  const platforms = allowedScrapers
+    ? ALL_SCRAPERS.filter((s) => allowedScrapers.includes(s.id)).map((s) => s.id)
+    : ALL_SCRAPERS.map((s) => s.id);
+
+  const allowedModels = plan.limits.allowedModels;
+  const models = allowedModels
+    ? ALL_MODELS.filter((m) => allowedModels.includes(m.id)).map((m) => m.id)
+    : ALL_MODELS.map((m) => m.id);
+
+  return { platforms, models };
+}


### PR DESCRIPTION
## Bug

Onboarding step order is:

\`1. brand_setup → 2. brand_details → 3. topics → 4. prompts → 5. competitors → 6. plan\`

Prompts are saved at step 4 but the plan is only chosen at step 6, so at step 4 the org is still on its \`'free'\` default (which falls back to Starter limits) and prompts get \`platforms: ['chatgpt-web', 'perplexity-web']\` baked in. A user who picks a Growth trial at step 6 still ends up tracking only 2 engines instead of the 8 Growth allows.

## Fix

In \`/api/stripe/success\`, right after the org's \`plan\` / \`subscription_status\` is confirmed and before the first tracking run is triggered, walk every prompt in the org's brands and rewrite its \`platforms\` + \`models\` arrays to match the just-confirmed plan's \`allowedScrapers\` + \`allowedModels\`. Same gating logic the onboarding wizard uses, extracted into a small reusable helper.

### Files

| File | Change |
|---|---|
| \`web/src/lib/plan-engines.ts\` | New \`getActiveEngineIdsForPlan(planId)\` — mirrors the wizard's \`allowedScrapers ? filter : ALL\` logic for both scrapers and models. \`undefined\` allowedScrapers (Growth / Enterprise / Self-hosted) → all 8; explicit array (Starter) → restricted set |
| \`web/src/app/api/stripe/success/route.ts\` | After the org plan update succeeds, derive engine ids from \`getActiveEngineIdsForPlan(planId \|\| 'starter')\`, fetch all brand ids in the org, all prompt_set ids in those brands, and bulk-update the prompts. Wrapped in a try/catch so a realignment failure doesn't block the redirect or the tracking trigger that follows |

### Why a helper, not inline

The same gating shape will be needed for the **plan-upgrade engine-expansion gap** (separate issue referenced in #78's footer — existing Starter org upgrades to Growth, prompts stay on 2 engines). Centralizing the logic now means that issue is just \"call the helper from the subscription-update path\" rather than re-deriving the gating in a second place.

## Scope guardrails

- **Runs only on \`/api/stripe/success\`** — the initial checkout-success redirect after onboarding. Plan changes / upgrades for existing orgs flow through the subscription update path and stay out of scope for #78
- **Starter onboarding is unaffected** — for that plan, the new platforms set equals the old one, so the UPDATE is a no-op
- **No-op safe** — alignment errors are logged but don't block the redirect or the trigger-tracking call that follows
- **Self-host is unrestricted today** — \`self_hosted\` has no \`allowedScrapers\`, so all 8 engines apply (consistent with existing policy)

## How verified

Local e2e against cloud Stripe test mode:

1. Reset test account → fresh onboarding state (\`onboarding_completed=false\`, no org / brand)
2. Sign-in → step 1 → completed all 6 onboarding steps, selected **Growth** trial at step 6
3. Stripe test card → redirected back to \`/dashboard/insights\`
4. Server logs:
   \`\`\`
   [stripe/success] DB updated for org: ...
   [stripe/success] Aligned prompts to plan=growth engines (8 scrapers, N models) for org ...
   \`\`\`
5. \`prompts.platforms\` in DB → 8 engine ids; \`prompts.models\` → Growth's allowed set
6. \`/dashboard/prompts\` UI → all 8 platforms shown per prompt
7. \`yarn typecheck\` + \`yarn format:check\` clean

## Acceptance (from #78)

- [x] After completing onboarding with a Growth trial, the created prompts track the engines Growth allows (up to 8), not just 2
- [x] Starter onboarding behavior is unchanged (2 engines)

Closes #78.