### PR TITLE
perf(insights): aggregate insights data in Postgres instead of pulling rows into Node

### DIFF
--- a/supabase/migrations/00006_insights_aggregates.sql
+++ b/supabase/migrations/00006_insights_aggregates.sql
@@ -1,0 +1,347 @@
+-- Phase-1 perf fix for /dashboard/insights (#93)
+--
+-- Today the insights server actions in web/src/lib/actions/tracking.ts pull
+-- `SELECT *` from prompt_results and aggregate in JS. Each row carries the
+-- full AI response text (kilobytes) + JSONB citations/competitor_mentions,
+-- and for a brand with thousands of results the page transfers hundreds of
+-- MB on every load + does big reducers in Node memory.
+--
+-- This migration:
+--   1. Adds a composite (brand_id, created_at DESC) index — the exact shape
+--      every insights filter needs but the only existing indexes are
+--      single-column.
+--   2. Adds three RPC functions that perform the aggregation server-side and
+--      return only the totals + small grouped slices. Callers can compute
+--      the same final numbers from these outputs with bit-for-bit parity
+--      against the existing JS reducers (parity test in
+--      scripts/parity-check-insights.ts).
+--
+-- Functions intentionally return RAW SUMS + COUNTS (not pre-divided averages)
+-- so the final round happens in JS exactly as it does today — guarantees the
+-- displayed dashboard numbers don't drift by even ±1 from a `Math.round`
+-- half-rule mismatch between JS and Postgres.
+--
+-- Security model matches the existing get_latest_prompt_results functions:
+-- SECURITY DEFINER — server actions verify brand-belongs-to-org access at
+-- the route layer before calling. Adding a defensive org check inside the
+-- function is a separate hygiene task tracked elsewhere.
+
+-- ── Index ─────────────────────────────────────────────────────────────────
+-- Composite covers WHERE brand_id = ? AND created_at BETWEEN ? AND ?
+-- ORDER BY created_at DESC — single seek + sequential index walk instead of
+-- index scan + heap filter + sort. ~11k rows in prod today; CREATE INDEX
+-- without CONCURRENTLY locks writes for milliseconds. CONCURRENTLY would
+-- avoid the lock but cannot run inside a transaction, and Supabase wraps
+-- migrations in one. Plain CREATE is the right call at this row count.
+CREATE INDEX IF NOT EXISTS idx_prompt_results_brand_created
+  ON public.prompt_results USING btree (brand_id, created_at DESC);
+
+
+-- ── insights_summary ──────────────────────────────────────────────────────
+-- Replaces getInsightsSummary's `select('*') + JS reduce` over the filtered
+-- row set. Returns one JSONB object with raw sums + counts + the per-model
+-- breakdown shape the page needs.
+CREATE OR REPLACE FUNCTION public.insights_aggregates(
+  p_brand_id   uuid,
+  p_platform   text         DEFAULT NULL,
+  p_models     text[]       DEFAULT NULL,
+  p_region     text         DEFAULT NULL,
+  p_date_from  timestamptz  DEFAULT NULL,
+  p_date_to    timestamptz  DEFAULT NULL,
+  p_prompt_id  uuid         DEFAULT NULL,
+  p_topic_id   uuid         DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH filtered AS (
+    SELECT pr.visibility_score, pr.mention_count, pr.citation_count,
+           pr.sentiment, pr.model_used, pr.created_at
+    FROM public.prompt_results pr
+    WHERE pr.brand_id = p_brand_id
+      AND (p_platform  IS NULL OR pr.platform    = p_platform)
+      AND (p_models    IS NULL OR pr.model_used  = ANY (p_models))
+      AND (p_region    IS NULL OR pr.region      = p_region)
+      AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR pr.created_at <= p_date_to)
+      AND (p_prompt_id IS NULL OR pr.prompt_id   = p_prompt_id)
+      AND (p_topic_id  IS NULL OR EXISTS (
+             SELECT 1 FROM public.prompts p
+             WHERE p.id = pr.prompt_id AND p.topic_id = p_topic_id))
+  ),
+  totals AS (
+    SELECT
+      COUNT(*)                                                AS total_results,
+      COALESCE(SUM(visibility_score), 0)                      AS sum_visibility,
+      COALESCE(SUM(mention_count), 0)                         AS total_mentions,
+      COALESCE(SUM(citation_count), 0)                        AS total_citations,
+      COUNT(*) FILTER (WHERE sentiment = 'positive')          AS positive_count,
+      MAX(created_at)                                         AS last_checked_at
+    FROM filtered
+  ),
+  by_model AS (
+    SELECT
+      COALESCE(model_used, 'unknown') AS model_used,
+      SUM(visibility_score)           AS sum_visibility,
+      COUNT(*)                        AS result_count
+    FROM filtered
+    GROUP BY COALESCE(model_used, 'unknown')
+  )
+  SELECT jsonb_build_object(
+    'total_results',     t.total_results,
+    'sum_visibility',    t.sum_visibility,
+    'total_mentions',    t.total_mentions,
+    'total_citations',   t.total_citations,
+    'positive_count',    t.positive_count,
+    'last_checked_at',   t.last_checked_at,
+    'by_model', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',     bm.model_used,
+                'sum_visibility', bm.sum_visibility,
+                'result_count',   bm.result_count))
+       FROM by_model bm),
+      '[]'::jsonb)
+  )
+  FROM totals t;
+$$;
+
+
+-- ── competitor_aggregates ─────────────────────────────────────────────────
+-- Replaces getCompetitorComparison's `select('*') + JS reduce`. Unwraps the
+-- competitor_mentions JSONB once via LATERAL, then groups four ways:
+--   * brand totals    — overall vis/mentions/citations
+--   * by_competitor   — per-competitor flat row
+--   * by_brand_provider     — brand vis grouped by (model_used, platform)
+--   * by_competitor_provider — competitor vis grouped by (model_used, platform, competitor)
+-- The provider mapping (resolveProvider) stays in JS so we don't ship a
+-- duplicate lookup table in SQL that has to be kept in sync.
+CREATE OR REPLACE FUNCTION public.competitor_aggregates(
+  p_brand_id   uuid,
+  p_platform   text         DEFAULT NULL,
+  p_models     text[]       DEFAULT NULL,
+  p_region     text         DEFAULT NULL,
+  p_date_from  timestamptz  DEFAULT NULL,
+  p_date_to    timestamptz  DEFAULT NULL,
+  p_prompt_id  uuid         DEFAULT NULL,
+  p_topic_id   uuid         DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH filtered AS (
+    SELECT pr.visibility_score, pr.mention_count, pr.citation_count,
+           pr.model_used, pr.platform, pr.competitor_mentions
+    FROM public.prompt_results pr
+    WHERE pr.brand_id = p_brand_id
+      AND (p_platform  IS NULL OR pr.platform    = p_platform)
+      AND (p_models    IS NULL OR pr.model_used  = ANY (p_models))
+      AND (p_region    IS NULL OR pr.region      = p_region)
+      AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR pr.created_at <= p_date_to)
+      AND (p_prompt_id IS NULL OR pr.prompt_id   = p_prompt_id)
+      AND (p_topic_id  IS NULL OR EXISTS (
+             SELECT 1 FROM public.prompts p
+             WHERE p.id = pr.prompt_id AND p.topic_id = p_topic_id))
+  ),
+  brand_totals AS (
+    SELECT
+      COUNT(*)                                          AS row_count,
+      COALESCE(SUM(visibility_score), 0)                AS sum_visibility,
+      COALESCE(SUM(mention_count), 0)::bigint           AS total_mentions,
+      COALESCE(SUM(citation_count), 0)::bigint          AS total_citations
+    FROM filtered
+  ),
+  by_brand_provider AS (
+    SELECT
+      model_used,
+      platform,
+      SUM(visibility_score)  AS sum_visibility,
+      COUNT(*)               AS row_count
+    FROM filtered
+    GROUP BY model_used, platform
+  ),
+  mentions_flat AS (
+    SELECT
+      f.model_used,
+      f.platform,
+      cm.value->>'competitor_id'                       AS competitor_id,
+      cm.value->>'name'                                AS competitor_name,
+      (cm.value->>'visibility_score')::numeric         AS cm_visibility,
+      COALESCE((cm.value->>'mention_count')::int, 0)   AS cm_mention_count,
+      COALESCE((cm.value->>'citation_count')::int, 0)  AS cm_citation_count
+    FROM filtered f,
+         LATERAL jsonb_array_elements(
+           COALESCE(f.competitor_mentions, '[]'::jsonb)) cm
+    WHERE cm.value ? 'competitor_id'
+  ),
+  by_competitor AS (
+    SELECT
+      competitor_id,
+      MAX(competitor_name)                  AS name,
+      SUM(cm_visibility)                    AS sum_visibility,
+      COUNT(*)                              AS row_count,
+      SUM(cm_mention_count)::bigint         AS total_mentions,
+      SUM(cm_citation_count)::bigint        AS total_citations
+    FROM mentions_flat
+    GROUP BY competitor_id
+  ),
+  by_competitor_provider AS (
+    SELECT
+      model_used,
+      platform,
+      competitor_id,
+      MAX(competitor_name)   AS competitor_name,
+      SUM(cm_visibility)     AS sum_visibility,
+      COUNT(*)               AS row_count
+    FROM mentions_flat
+    GROUP BY model_used, platform, competitor_id
+  )
+  SELECT jsonb_build_object(
+    'brand_row_count',       b.row_count,
+    'brand_sum_visibility',  b.sum_visibility,
+    'brand_total_mentions',  b.total_mentions,
+    'brand_total_citations', b.total_citations,
+    'by_competitor', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'competitor_id',    bc.competitor_id,
+                'name',             bc.name,
+                'sum_visibility',   bc.sum_visibility,
+                'row_count',        bc.row_count,
+                'total_mentions',   bc.total_mentions,
+                'total_citations',  bc.total_citations))
+       FROM by_competitor bc),
+      '[]'::jsonb),
+    'by_brand_provider', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',      bbp.model_used,
+                'platform',        bbp.platform,
+                'sum_visibility',  bbp.sum_visibility,
+                'row_count',       bbp.row_count))
+       FROM by_brand_provider bbp),
+      '[]'::jsonb),
+    'by_competitor_provider', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',       bcp.model_used,
+                'platform',         bcp.platform,
+                'competitor_id',    bcp.competitor_id,
+                'competitor_name',  bcp.competitor_name,
+                'sum_visibility',   bcp.sum_visibility,
+                'row_count',        bcp.row_count))
+       FROM by_competitor_provider bcp),
+      '[]'::jsonb)
+  )
+  FROM brand_totals b;
+$$;
+
+
+-- ── share_of_voice_aggregates ─────────────────────────────────────────────
+-- Replaces getShareOfVoiceData's `select('*') + JS reduce`. Returns totals
+-- plus per (model_used, platform) and per-day slices. The provider mapping
+-- (resolveProvider) stays in JS so we don't have to keep a SQL copy of that
+-- lookup in sync as new engines land.
+CREATE OR REPLACE FUNCTION public.share_of_voice_aggregates(
+  p_brand_id   uuid,
+  p_platform   text         DEFAULT NULL,
+  p_models     text[]       DEFAULT NULL,
+  p_region     text         DEFAULT NULL,
+  p_date_from  timestamptz  DEFAULT NULL,
+  p_date_to    timestamptz  DEFAULT NULL,
+  p_prompt_id  uuid         DEFAULT NULL,
+  p_topic_id   uuid         DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH filtered AS (
+    SELECT
+      pr.mention_count,
+      pr.model_used,
+      pr.platform,
+      pr.created_at,
+      pr.competitor_mentions,
+      -- Pre-sum the competitor mention counts for each row so we don't
+      -- re-unwrap the JSONB array three times below.
+      COALESCE((
+        SELECT SUM((cm.value->>'mention_count')::int)
+        FROM jsonb_array_elements(
+               COALESCE(pr.competitor_mentions, '[]'::jsonb)) cm
+      ), 0)::int AS row_competitor_mentions
+    FROM public.prompt_results pr
+    WHERE pr.brand_id = p_brand_id
+      AND (p_platform  IS NULL OR pr.platform    = p_platform)
+      AND (p_models    IS NULL OR pr.model_used  = ANY (p_models))
+      AND (p_region    IS NULL OR pr.region      = p_region)
+      AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR pr.created_at <= p_date_to)
+      AND (p_prompt_id IS NULL OR pr.prompt_id   = p_prompt_id)
+      AND (p_topic_id  IS NULL OR EXISTS (
+             SELECT 1 FROM public.prompts p
+             WHERE p.id = pr.prompt_id AND p.topic_id = p_topic_id))
+  ),
+  totals AS (
+    SELECT
+      COALESCE(SUM(mention_count), 0)::bigint            AS total_brand_mentions,
+      COALESCE(SUM(row_competitor_mentions), 0)::bigint  AS total_competitor_mentions
+    FROM filtered
+  ),
+  by_platform AS (
+    SELECT
+      model_used,
+      platform,
+      COALESCE(SUM(mention_count), 0)::bigint            AS brand_mentions,
+      COALESCE(SUM(row_competitor_mentions), 0)::bigint  AS competitor_mentions
+    FROM filtered
+    GROUP BY model_used, platform
+  ),
+  by_day AS (
+    SELECT
+      -- JS does `created_at.slice(0,10)` on the ISO string, which yields the
+      -- UTC date. Mirror that exactly so trend buckets line up.
+      to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD')  AS day,
+      COALESCE(SUM(mention_count), 0)::bigint               AS brand_mentions,
+      COALESCE(SUM(row_competitor_mentions), 0)::bigint     AS competitor_mentions
+    FROM filtered
+    GROUP BY to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD')
+  )
+  SELECT jsonb_build_object(
+    'total_brand_mentions',      t.total_brand_mentions,
+    'total_competitor_mentions', t.total_competitor_mentions,
+    'by_platform', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',          bp.model_used,
+                'platform',            bp.platform,
+                'brand_mentions',      bp.brand_mentions,
+                'competitor_mentions', bp.competitor_mentions))
+       FROM by_platform bp),
+      '[]'::jsonb),
+    'by_day', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'day',                 bd.day,
+                'brand_mentions',      bd.brand_mentions,
+                'competitor_mentions', bd.competitor_mentions)
+              ORDER BY bd.day)
+       FROM by_day bd),
+      '[]'::jsonb)
+  )
+  FROM totals t;
+$$;
+
+
+-- ── Grants ────────────────────────────────────────────────────────────────
+-- Match the existing get_latest_prompt_results pattern: authenticated +
+-- service_role can execute. Anon stays out (no anon access to insights).
+GRANT EXECUTE ON FUNCTION public.insights_aggregates(uuid, text, text[], text, timestamptz, timestamptz, uuid, uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.competitor_aggregates(uuid, text, text[], text, timestamptz, timestamptz, uuid, uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.share_of_voice_aggregates(uuid, text, text[], text, timestamptz, timestamptz, uuid, uuid)
+  TO authenticated, service_role;

--- a/supabase/migrations/00006_insights_aggregates.sql
+++ b/supabase/migrations/00006_insights_aggregates.sql
@@ -97,11 +97,16 @@ AS $$
     'total_citations',   t.total_citations,
     'positive_count',    t.positive_count,
     'last_checked_at',   t.last_checked_at,
+    -- ORDER BY inside jsonb_agg keeps the response stable across calls so the
+    -- platform list / chart doesn't jitter. jsonb_agg is otherwise free to
+    -- return rows in any order. Same rationale for the other jsonb_aggs
+    -- below.
     'by_model', COALESCE(
       (SELECT jsonb_agg(jsonb_build_object(
                 'model_used',     bm.model_used,
                 'sum_visibility', bm.sum_visibility,
-                'result_count',   bm.result_count))
+                'result_count',   bm.result_count)
+              ORDER BY bm.result_count DESC, bm.model_used)
        FROM by_model bm),
       '[]'::jsonb)
   )
@@ -214,7 +219,8 @@ AS $$
                 'sum_visibility',   bc.sum_visibility,
                 'row_count',        bc.row_count,
                 'total_mentions',   bc.total_mentions,
-                'total_citations',  bc.total_citations))
+                'total_citations',  bc.total_citations)
+              ORDER BY bc.row_count DESC, bc.competitor_id)
        FROM by_competitor bc),
       '[]'::jsonb),
     'by_brand_provider', COALESCE(
@@ -222,7 +228,8 @@ AS $$
                 'model_used',      bbp.model_used,
                 'platform',        bbp.platform,
                 'sum_visibility',  bbp.sum_visibility,
-                'row_count',       bbp.row_count))
+                'row_count',       bbp.row_count)
+              ORDER BY bbp.platform NULLS LAST, bbp.model_used NULLS LAST)
        FROM by_brand_provider bbp),
       '[]'::jsonb),
     'by_competitor_provider', COALESCE(
@@ -232,7 +239,8 @@ AS $$
                 'competitor_id',    bcp.competitor_id,
                 'competitor_name',  bcp.competitor_name,
                 'sum_visibility',   bcp.sum_visibility,
-                'row_count',        bcp.row_count))
+                'row_count',        bcp.row_count)
+              ORDER BY bcp.platform NULLS LAST, bcp.model_used NULLS LAST, bcp.competitor_id)
        FROM by_competitor_provider bcp),
       '[]'::jsonb)
   )
@@ -320,7 +328,8 @@ AS $$
                 'model_used',          bp.model_used,
                 'platform',            bp.platform,
                 'brand_mentions',      bp.brand_mentions,
-                'competitor_mentions', bp.competitor_mentions))
+                'competitor_mentions', bp.competitor_mentions)
+              ORDER BY bp.platform NULLS LAST, bp.model_used NULLS LAST)
        FROM by_platform bp),
       '[]'::jsonb),
     'by_day', COALESCE(

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -88,6 +88,82 @@ export interface InsightsSummary {
 }
 
 /**
+ * Convert the comma-separated `model` filter string the UI passes around
+ * into the `text[]` shape the aggregate RPCs accept. Matches the parsing
+ * applyModelFilter does for the buildResultsQuery path so the two callers
+ * stay equivalent.
+ */
+function modelFilterArray(model: string | undefined): string[] | null {
+  if (!model) return null;
+  const list = model
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.length > 0 ? list : null;
+}
+
+// ── RPC return shapes (mirror supabase/migrations/00006_insights_aggregates.sql) ─
+
+interface InsightsAggregates {
+  total_results: number;
+  sum_visibility: number;
+  total_mentions: number;
+  total_citations: number;
+  positive_count: number;
+  last_checked_at: string | null;
+  by_model: Array<{
+    model_used: string;
+    sum_visibility: number;
+    result_count: number;
+  }>;
+}
+
+interface CompetitorAggregatesRow {
+  brand_row_count: number;
+  brand_sum_visibility: number;
+  brand_total_mentions: number;
+  brand_total_citations: number;
+  by_competitor: Array<{
+    competitor_id: string;
+    name: string | null;
+    sum_visibility: number;
+    row_count: number;
+    total_mentions: number;
+    total_citations: number;
+  }>;
+  by_brand_provider: Array<{
+    model_used: string | null;
+    platform: string | null;
+    sum_visibility: number;
+    row_count: number;
+  }>;
+  by_competitor_provider: Array<{
+    model_used: string | null;
+    platform: string | null;
+    competitor_id: string;
+    competitor_name: string | null;
+    sum_visibility: number;
+    row_count: number;
+  }>;
+}
+
+interface ShareOfVoiceAggregatesRow {
+  total_brand_mentions: number;
+  total_competitor_mentions: number;
+  by_platform: Array<{
+    model_used: string | null;
+    platform: string | null;
+    brand_mentions: number;
+    competitor_mentions: number;
+  }>;
+  by_day: Array<{
+    day: string;
+    brand_mentions: number;
+    competitor_mentions: number;
+  }>;
+}
+
+/**
  * Build a filtered query on prompt_results for a brand.
  */
 async function buildResultsQuery(
@@ -349,14 +425,31 @@ export async function getInsightsSummary(
     topicId?: string;
   },
 ): Promise<InsightsSummary> {
-  const { query } = await buildResultsQuery(brandId, opts);
+  const supabase = await createClient();
+  const p_models = modelFilterArray(opts?.model);
 
-  const { data: results, error } = await query;
+  // Sums + counts come from Postgres in one round trip; we still do the
+  // final divide + round in JS so the displayed numbers track the old
+  // reducer math exactly (verified by the parity test in 00006).
+  const baseArgs = {
+    p_brand_id: brandId,
+    p_platform: null as string | null,
+    p_models,
+    p_region: opts?.region ?? null,
+    p_prompt_id: null as string | null,
+    p_topic_id: opts?.topicId ?? null,
+  };
+
+  const { data: curData, error } = await supabase.rpc('insights_aggregates', {
+    ...baseArgs,
+    p_date_from: opts?.dateFrom ?? null,
+    p_date_to: opts?.dateTo ?? null,
+  });
   if (error) throw new Error(error.message);
 
-  const rows = (results ?? []) as Record<string, unknown>[];
+  const cur = curData as unknown as InsightsAggregates;
 
-  if (rows.length === 0) {
+  if (cur.total_results === 0) {
     return {
       avgVisibilityScore: 0,
       totalMentions: 0,
@@ -372,34 +465,17 @@ export async function getInsightsSummary(
     };
   }
 
-  const totalResults = rows.length;
-  const avgVisibilityScore = Math.round(
-    rows.reduce((s, r) => s + (r.visibility_score as number), 0) / totalResults,
-  );
-  const totalMentions = rows.reduce((s, r) => s + (r.mention_count as number), 0);
-  const totalCitations = rows.reduce((s, r) => s + (r.citation_count as number), 0);
-  const positiveCount = rows.filter((r) => r.sentiment === 'positive').length;
-  const positiveSentimentPct = Math.round((positiveCount / totalResults) * 100);
+  const totalResults = cur.total_results;
+  const avgVisibilityScore = Math.round(cur.sum_visibility / totalResults);
+  const totalMentions = cur.total_mentions;
+  const totalCitations = cur.total_citations;
+  const positiveSentimentPct = Math.round((cur.positive_count / totalResults) * 100);
+  const lastCheckedAt = cur.last_checked_at;
 
-  const lastCheckedAt =
-    rows
-      .map((r) => r.created_at as string)
-      .sort()
-      .pop() ?? null;
-
-  const modelMap = new Map<string, { totalScore: number; count: number }>();
-  for (const r of rows) {
-    const m = (r.model_used as string) || 'unknown';
-    const existing = modelMap.get(m) ?? { totalScore: 0, count: 0 };
-    existing.totalScore += r.visibility_score as number;
-    existing.count += 1;
-    modelMap.set(m, existing);
-  }
-
-  const platformBreakdown = Array.from(modelMap.entries()).map(([model, data]) => ({
-    platform: model,
-    avgScore: Math.round(data.totalScore / data.count),
-    resultCount: data.count,
+  const platformBreakdown = cur.by_model.map((m) => ({
+    platform: m.model_used,
+    avgScore: m.result_count > 0 ? Math.round(m.sum_visibility / m.result_count) : 0,
+    resultCount: m.result_count,
   }));
 
   // --- Previous period comparison ---
@@ -424,41 +500,36 @@ export async function getInsightsSummary(
     const duration = currentTo.getTime() - currentFrom.getTime();
     const prevFrom = new Date(currentFrom.getTime() - duration);
 
-    const currentFilterOpts = opts?.dateFrom
-      ? opts
-      : { ...opts, dateFrom: currentFrom.toISOString() };
+    // Current-window aggregate: when no dateFrom was passed, the top-level
+    // call above is unbounded — for the delta math we need the same
+    // explicit "last 7 days" window the JS code used so the comparison
+    // stays anchored to recent momentum.
+    const [{ data: curWinData }, { data: prevWinData }] = await Promise.all([
+      supabase.rpc('insights_aggregates', {
+        ...baseArgs,
+        p_date_from: opts?.dateFrom ?? currentFrom.toISOString(),
+        p_date_to: opts?.dateTo ?? null,
+      }),
+      supabase.rpc('insights_aggregates', {
+        ...baseArgs,
+        p_date_from: prevFrom.toISOString(),
+        p_date_to: currentFrom.toISOString(),
+      }),
+    ]);
 
-    const { query: curQuery } = await buildResultsQuery(brandId, currentFilterOpts);
-    const { data: curResults } = await curQuery;
-    const curRows = (curResults ?? []) as Record<string, unknown>[];
+    const curWin = curWinData as unknown as InsightsAggregates | null;
+    const prevWin = prevWinData as unknown as InsightsAggregates | null;
 
-    const { query: prevQuery } = await buildResultsQuery(brandId, {
-      ...opts,
-      dateFrom: prevFrom.toISOString(),
-      dateTo: currentFrom.toISOString(),
-    });
+    if (curWin && prevWin && curWin.total_results > 0 && prevWin.total_results > 0) {
+      const curAvgVis = Math.round(curWin.sum_visibility / curWin.total_results);
+      const curMentions = curWin.total_mentions;
+      const curCitations = curWin.total_citations;
+      const curSentimentPct = Math.round((curWin.positive_count / curWin.total_results) * 100);
 
-    const { data: prevResults } = await prevQuery;
-    const prevRows = (prevResults ?? []) as Record<string, unknown>[];
-
-    if (curRows.length > 0 && prevRows.length > 0) {
-      const curTotal = curRows.length;
-      const curAvgVis = Math.round(
-        curRows.reduce((s, r) => s + (r.visibility_score as number), 0) / curTotal,
-      );
-      const curMentions = curRows.reduce((s, r) => s + (r.mention_count as number), 0);
-      const curCitations = curRows.reduce((s, r) => s + (r.citation_count as number), 0);
-      const curPositive = curRows.filter((r) => r.sentiment === 'positive').length;
-      const curSentimentPct = Math.round((curPositive / curTotal) * 100);
-
-      const prevTotal = prevRows.length;
-      const prevAvgVis = Math.round(
-        prevRows.reduce((s, r) => s + (r.visibility_score as number), 0) / prevTotal,
-      );
-      const prevMentions = prevRows.reduce((s, r) => s + (r.mention_count as number), 0);
-      const prevCitations = prevRows.reduce((s, r) => s + (r.citation_count as number), 0);
-      const prevPositive = prevRows.filter((r) => r.sentiment === 'positive').length;
-      const prevSentimentPct = Math.round((prevPositive / prevTotal) * 100);
+      const prevAvgVis = Math.round(prevWin.sum_visibility / prevWin.total_results);
+      const prevMentions = prevWin.total_mentions;
+      const prevCitations = prevWin.total_citations;
+      const prevSentimentPct = Math.round((prevWin.positive_count / prevWin.total_results) * 100);
 
       visibilityChange = curAvgVis - prevAvgVis;
       mentionsChange =
@@ -776,6 +847,10 @@ function resolveProvider(modelUsed: string | null | undefined, platform?: string
 /**
  * Aggregate competitor comparison data from prompt results.
  * Returns both flat brand scores and per-provider breakdown.
+ *
+ * Server-side aggregation lives in the competitor_aggregates RPC
+ * (supabase/migrations/00006). This function only does the resolveProvider
+ * fold + final divide/round — the heavy `select(*) + reduce` loop is gone.
  */
 export async function getCompetitorComparison(
   brandId: string,
@@ -788,116 +863,88 @@ export async function getCompetitorComparison(
   },
 ): Promise<CompetitorComparisonData> {
   const supabase = await createClient();
+  const p_models = modelFilterArray(opts?.model);
 
-  const { data: brand } = await supabase.from('brands').select('name').eq('id', brandId).single();
+  const baseArgs = {
+    p_brand_id: brandId,
+    p_platform: null as string | null,
+    p_models,
+    p_region: opts?.region ?? null,
+    p_prompt_id: null as string | null,
+    p_topic_id: opts?.topicId ?? null,
+  };
 
-  const { query } = await buildResultsQuery(brandId, opts);
-  const { data: results, error } = await query;
-  if (error) throw new Error(error.message);
+  // Brand name + the displayed-period aggregate fire in parallel — both
+  // are needed before we can shape the response.
+  const [{ data: brand }, { data: aggDisplay, error: aggErr }] = await Promise.all([
+    supabase.from('brands').select('name').eq('id', brandId).single(),
+    supabase.rpc('competitor_aggregates', {
+      ...baseArgs,
+      p_date_from: opts?.dateFrom ?? null,
+      p_date_to: opts?.dateTo ?? null,
+    }),
+  ]);
+  if (aggErr) throw new Error(aggErr.message);
 
-  const rows = (results ?? []) as Record<string, unknown>[];
-  if (rows.length === 0) return { brands: [], providerRows: [] };
+  const agg = aggDisplay as unknown as CompetitorAggregatesRow;
+  if (agg.brand_row_count === 0) return { brands: [], providerRows: [] };
 
   // --- Current vs previous period for change calculation ---
-  // The displayed avg/totals come from `rows` (respects the selected preset),
+  // The displayed avg/totals come from `agg` (respects the selected preset),
   // but the ↑/↓ delta always compares a fixed "current" window to the window
   // immediately before it so the arrow reflects recent momentum (mirrors
   // getInsightsSummary's KPI change logic).
-  let curBrandAvg: number | null = null;
-  let prevBrandAvg: number | null = null;
+  let currentFrom: Date;
+  let currentTo: Date;
+
+  if (opts?.dateFrom) {
+    currentFrom = new Date(opts.dateFrom);
+    currentTo = opts.dateTo ? new Date(opts.dateTo) : new Date();
+  } else {
+    currentTo = new Date();
+    currentFrom = new Date();
+    currentFrom.setDate(currentFrom.getDate() - 7);
+  }
+
+  const duration = currentTo.getTime() - currentFrom.getTime();
+  const prevFrom = new Date(currentFrom.getTime() - duration);
+
+  const [{ data: curWinData }, { data: prevWinData }] = await Promise.all([
+    supabase.rpc('competitor_aggregates', {
+      ...baseArgs,
+      p_date_from: opts?.dateFrom ?? currentFrom.toISOString(),
+      p_date_to: opts?.dateTo ?? null,
+    }),
+    supabase.rpc('competitor_aggregates', {
+      ...baseArgs,
+      p_date_from: prevFrom.toISOString(),
+      p_date_to: currentFrom.toISOString(),
+    }),
+  ]);
+
+  const curWin = curWinData as unknown as CompetitorAggregatesRow | null;
+  const prevWin = prevWinData as unknown as CompetitorAggregatesRow | null;
+
+  const curBrandAvg =
+    curWin && curWin.brand_row_count > 0
+      ? curWin.brand_sum_visibility / curWin.brand_row_count
+      : null;
+  const prevBrandAvg =
+    prevWin && prevWin.brand_row_count > 0
+      ? prevWin.brand_sum_visibility / prevWin.brand_row_count
+      : null;
+
   const curCompAvg = new Map<string, number>();
+  for (const c of curWin?.by_competitor ?? []) {
+    if (c.row_count > 0) curCompAvg.set(c.competitor_id, c.sum_visibility / c.row_count);
+  }
   const prevCompAvg = new Map<string, number>();
-
-  {
-    let currentFrom: Date;
-    let currentTo: Date;
-
-    if (opts?.dateFrom) {
-      currentFrom = new Date(opts.dateFrom);
-      currentTo = opts.dateTo ? new Date(opts.dateTo) : new Date();
-    } else {
-      currentTo = new Date();
-      currentFrom = new Date();
-      currentFrom.setDate(currentFrom.getDate() - 7);
-    }
-
-    const duration = currentTo.getTime() - currentFrom.getTime();
-    const prevFrom = new Date(currentFrom.getTime() - duration);
-
-    const currentFilterOpts = opts?.dateFrom
-      ? opts
-      : { ...opts, dateFrom: currentFrom.toISOString() };
-
-    const [curRes, prevRes] = await Promise.all([
-      (async () => {
-        const { query: curQuery } = await buildResultsQuery(brandId, currentFilterOpts);
-        return curQuery;
-      })(),
-      (async () => {
-        const { query: prevQuery } = await buildResultsQuery(brandId, {
-          ...opts,
-          dateFrom: prevFrom.toISOString(),
-          dateTo: currentFrom.toISOString(),
-        });
-        return prevQuery;
-      })(),
-    ]);
-
-    const curRows = (curRes.data ?? []) as Record<string, unknown>[];
-    const prevRows = (prevRes.data ?? []) as Record<string, unknown>[];
-
-    if (curRows.length > 0) {
-      const curTotal = curRows.reduce((s, r) => s + (r.visibility_score as number), 0);
-      curBrandAvg = curTotal / curRows.length;
-
-      const curCompMap = new Map<string, { totalScore: number; count: number }>();
-      for (const row of curRows) {
-        const mentions = (row.competitor_mentions as CompetitorMention[] | null) ?? [];
-        for (const cm of mentions) {
-          const ex = curCompMap.get(cm.competitor_id) ?? {
-            totalScore: 0,
-            count: 0,
-          };
-          ex.totalScore += cm.visibility_score;
-          ex.count += 1;
-          curCompMap.set(cm.competitor_id, ex);
-        }
-      }
-      for (const [id, d] of curCompMap) {
-        curCompAvg.set(id, d.totalScore / d.count);
-      }
-    }
-
-    if (prevRows.length > 0) {
-      const prevTotal = prevRows.reduce((s, r) => s + (r.visibility_score as number), 0);
-      prevBrandAvg = prevTotal / prevRows.length;
-
-      const prevCompMap = new Map<string, { totalScore: number; count: number }>();
-      for (const row of prevRows) {
-        const mentions = (row.competitor_mentions as CompetitorMention[] | null) ?? [];
-        for (const cm of mentions) {
-          const ex = prevCompMap.get(cm.competitor_id) ?? {
-            totalScore: 0,
-            count: 0,
-          };
-          ex.totalScore += cm.visibility_score;
-          ex.count += 1;
-          prevCompMap.set(cm.competitor_id, ex);
-        }
-      }
-      for (const [id, d] of prevCompMap) {
-        prevCompAvg.set(id, d.totalScore / d.count);
-      }
-    }
+  for (const c of prevWin?.by_competitor ?? []) {
+    if (c.row_count > 0) prevCompAvg.set(c.competitor_id, c.sum_visibility / c.row_count);
   }
 
   const brandName = (brand?.name as string) ?? 'Your Brand';
-
-  // --- Flat brand-level aggregates ---
-  const brandTotalScore = rows.reduce((s, r) => s + (r.visibility_score as number), 0);
-  const brandTotalMentions = rows.reduce((s, r) => s + (r.mention_count as number), 0);
-  const brandTotalCitations = rows.reduce((s, r) => s + (r.citation_count as number), 0);
-  const brandAvg = Math.round(brandTotalScore / rows.length);
+  const brandAvg = Math.round(agg.brand_sum_visibility / agg.brand_row_count);
 
   // Percentage change relative to the previous-period value.
   // Null when no comparable previous value exists (or growth from 0 → x is undefined).
@@ -912,55 +959,25 @@ export async function getCompetitorComparison(
       name: brandName,
       avgVisibilityScore: brandAvg,
       change: pctChange(curBrandAvg, prevBrandAvg),
-      totalMentions: brandTotalMentions,
-      totalCitations: brandTotalCitations,
-      resultCount: rows.length,
+      totalMentions: agg.brand_total_mentions,
+      totalCitations: agg.brand_total_citations,
+      resultCount: agg.brand_row_count,
       isOwnBrand: true,
     },
   ];
 
-  const compMap = new Map<
-    string,
-    {
-      id: string;
-      name: string;
-      totalScore: number;
-      totalMentions: number;
-      totalCitations: number;
-      count: number;
-    }
-  >();
-
-  for (const row of rows) {
-    const mentions = (row.competitor_mentions as CompetitorMention[] | null) ?? [];
-    for (const cm of mentions) {
-      const existing = compMap.get(cm.competitor_id) ?? {
-        id: cm.competitor_id,
-        name: cm.name,
-        totalScore: 0,
-        totalMentions: 0,
-        totalCitations: 0,
-        count: 0,
-      };
-      existing.totalScore += cm.visibility_score;
-      existing.totalMentions += cm.mention_count;
-      existing.totalCitations += cm.citation_count;
-      existing.count += 1;
-      compMap.set(cm.competitor_id, existing);
-    }
-  }
-
-  for (const [, data] of compMap) {
-    const avg = Math.round(data.totalScore / data.count);
-    const cur = curCompAvg.get(data.id);
-    const prev = prevCompAvg.get(data.id);
+  for (const c of agg.by_competitor) {
+    const avg = c.row_count > 0 ? Math.round(c.sum_visibility / c.row_count) : 0;
     entries.push({
-      name: data.name,
+      name: c.name ?? '',
       avgVisibilityScore: avg,
-      change: pctChange(cur ?? null, prev ?? null),
-      totalMentions: data.totalMentions,
-      totalCitations: data.totalCitations,
-      resultCount: data.count,
+      change: pctChange(
+        curCompAvg.get(c.competitor_id) ?? null,
+        prevCompAvg.get(c.competitor_id) ?? null,
+      ),
+      totalMentions: c.total_mentions,
+      totalCitations: c.total_citations,
+      resultCount: c.row_count,
       isOwnBrand: false,
     });
   }
@@ -968,32 +985,32 @@ export async function getCompetitorComparison(
   entries.sort((a, b) => b.avgVisibilityScore - a.avgVisibilityScore);
 
   // --- Per-provider breakdown ---
-  // brand: { provider -> { totalScore, count } }
+  // resolveProvider stays in JS so we don't keep a SQL copy of the mapping
+  // table in sync — fold the (model_used, platform) groups into provider
+  // buckets here.
   type Agg = { totalScore: number; count: number };
   const brandByProvider = new Map<string, Agg>();
-  const compByProvider = new Map<string, Map<string, Agg>>(); // compName -> provider -> agg
+  for (const bp of agg.by_brand_provider) {
+    const provider = resolveProvider(bp.model_used, bp.platform);
+    const ex = brandByProvider.get(provider) ?? { totalScore: 0, count: 0 };
+    ex.totalScore += Number(bp.sum_visibility);
+    ex.count += bp.row_count;
+    brandByProvider.set(provider, ex);
+  }
 
-  for (const row of rows) {
-    const provider = resolveProvider(
-      row.model_used as string | null,
-      row.platform as string | null,
-    );
-    const score = row.visibility_score as number;
-
-    const bp = brandByProvider.get(provider) ?? { totalScore: 0, count: 0 };
-    bp.totalScore += score;
-    bp.count += 1;
-    brandByProvider.set(provider, bp);
-
-    const mentions = (row.competitor_mentions as CompetitorMention[] | null) ?? [];
-    for (const cm of mentions) {
-      if (!compByProvider.has(cm.name)) compByProvider.set(cm.name, new Map());
-      const pm = compByProvider.get(cm.name)!;
-      const cp = pm.get(provider) ?? { totalScore: 0, count: 0 };
-      cp.totalScore += cm.visibility_score;
-      cp.count += 1;
-      pm.set(provider, cp);
-    }
+  // compName -> provider -> agg (JS key by display name to match the old
+  // shape exactly, since the provider row columns are keyed by competitor
+  // name).
+  const compByProvider = new Map<string, Map<string, Agg>>();
+  for (const cp of agg.by_competitor_provider) {
+    const provider = resolveProvider(cp.model_used, cp.platform);
+    const name = cp.competitor_name ?? '';
+    if (!compByProvider.has(name)) compByProvider.set(name, new Map());
+    const pm = compByProvider.get(name)!;
+    const ex = pm.get(provider) ?? { totalScore: 0, count: 0 };
+    ex.totalScore += Number(cp.sum_visibility);
+    ex.count += cp.row_count;
+    pm.set(provider, ex);
   }
 
   const allProviders = new Set<string>();
@@ -1004,15 +1021,12 @@ export async function getCompetitorComparison(
 
   const providerRows: ProviderComparisonRow[] = [...allProviders].sort().map((provider) => {
     const row: ProviderComparisonRow = { provider };
-
     const bp = brandByProvider.get(provider);
-    row[brandName] = bp ? Math.round(bp.totalScore / bp.count) : 0;
-
+    row[brandName] = bp && bp.count > 0 ? Math.round(bp.totalScore / bp.count) : 0;
     for (const [compName, pm] of compByProvider) {
       const cp = pm.get(provider);
-      row[compName] = cp ? Math.round(cp.totalScore / cp.count) : 0;
+      row[compName] = cp && cp.count > 0 ? Math.round(cp.totalScore / cp.count) : 0;
     }
-
     return row;
   });
 
@@ -1051,61 +1065,75 @@ export async function getShareOfVoiceData(
     topicId?: string;
   },
 ): Promise<ShareOfVoiceData> {
-  const { query } = await buildResultsQuery(brandId, opts);
-  const { data: results, error } = await query;
-  if (error) throw new Error(error.message);
+  const supabase = await createClient();
+  const p_models = modelFilterArray(opts?.model);
 
-  const rows = (results ?? []) as Record<string, unknown>[];
+  const baseArgs = {
+    p_brand_id: brandId,
+    p_platform: null as string | null,
+    p_models,
+    p_region: opts?.region ?? null,
+    p_prompt_id: null as string | null,
+    p_topic_id: opts?.topicId ?? null,
+  };
 
-  if (rows.length === 0) {
-    return { overallSov: 0, overallSovChange: null, byPlatform: [], trend: [] };
+  // Current-period aggregate + previous-period aggregate run in parallel —
+  // both server-side, no row transfer or JS reduce. The previous-period
+  // window always anchors to "last 7 days" when the caller hasn't picked an
+  // explicit dateFrom (matches the original delta logic for SoV).
+  let currentFrom: Date;
+  let currentTo: Date;
+  if (opts?.dateFrom) {
+    currentFrom = new Date(opts.dateFrom);
+    currentTo = opts.dateTo ? new Date(opts.dateTo) : new Date();
+  } else {
+    currentTo = new Date();
+    currentFrom = new Date();
+    currentFrom.setDate(currentFrom.getDate() - 7);
   }
+  const duration = currentTo.getTime() - currentFrom.getTime();
+  const prevFrom = new Date(currentFrom.getTime() - duration);
 
-  // --- Overall + by-platform aggregation ---
-  let totalBrandMentions = 0;
-  let totalCompMentions = 0;
+  const [{ data: curData, error: curErr }, { data: prevData }] = await Promise.all([
+    supabase.rpc('share_of_voice_aggregates', {
+      ...baseArgs,
+      p_date_from: opts?.dateFrom ?? null,
+      p_date_to: opts?.dateTo ?? null,
+    }),
+    supabase.rpc('share_of_voice_aggregates', {
+      ...baseArgs,
+      p_date_from: prevFrom.toISOString(),
+      p_date_to: currentFrom.toISOString(),
+    }),
+  ]);
+  if (curErr) throw new Error(curErr.message);
 
-  type ProviderAgg = { brandMentions: number; competitorMentions: number };
-  const providerMap = new Map<string, ProviderAgg>();
+  const cur = curData as unknown as ShareOfVoiceAggregatesRow;
+  const prev = prevData as unknown as ShareOfVoiceAggregatesRow | null;
 
-  type DayAgg = { brandMentions: number; competitorMentions: number };
-  const dayMap = new Map<string, DayAgg>();
+  const totalBrandMentions = Number(cur.total_brand_mentions);
+  const totalCompMentions = Number(cur.total_competitor_mentions);
 
-  for (const row of rows) {
-    const provider = resolveProvider(
-      row.model_used as string | null,
-      row.platform as string | null,
-    );
-    const brandM = row.mention_count as number;
-    totalBrandMentions += brandM;
-
-    const pa = providerMap.get(provider) ?? {
-      brandMentions: 0,
-      competitorMentions: 0,
-    };
-    pa.brandMentions += brandM;
-
-    const mentions = (row.competitor_mentions as CompetitorMention[] | null) ?? [];
-    let rowCompMentions = 0;
-    for (const cm of mentions) {
-      rowCompMentions += cm.mention_count;
-    }
-    totalCompMentions += rowCompMentions;
-    pa.competitorMentions += rowCompMentions;
-    providerMap.set(provider, pa);
-
-    // Daily aggregation
-    const day = (row.created_at as string).slice(0, 10);
-    const da = dayMap.get(day) ?? { brandMentions: 0, competitorMentions: 0 };
-    da.brandMentions += brandM;
-    da.competitorMentions += rowCompMentions;
-    dayMap.set(day, da);
+  if (totalBrandMentions === 0 && totalCompMentions === 0) {
+    return { overallSov: 0, overallSovChange: null, byPlatform: [], trend: [] };
   }
 
   const totalAll = totalBrandMentions + totalCompMentions;
   const overallSov = totalAll > 0 ? Math.round((totalBrandMentions / totalAll) * 1000) / 10 : 0;
 
-  // --- By platform ---
+  // --- By provider ---
+  // resolveProvider stays in JS so the SQL doesn't carry a duplicate of the
+  // model/platform → provider mapping table.
+  type ProviderAgg = { brandMentions: number; competitorMentions: number };
+  const providerMap = new Map<string, ProviderAgg>();
+  for (const bp of cur.by_platform) {
+    const provider = resolveProvider(bp.model_used, bp.platform);
+    const ex = providerMap.get(provider) ?? { brandMentions: 0, competitorMentions: 0 };
+    ex.brandMentions += Number(bp.brand_mentions);
+    ex.competitorMentions += Number(bp.competitor_mentions);
+    providerMap.set(provider, ex);
+  }
+
   const byPlatform: SoVByPlatform[] = [...providerMap.entries()]
     .map(([provider, agg]) => {
       const total = agg.brandMentions + agg.competitorMentions;
@@ -1119,56 +1147,29 @@ export async function getShareOfVoiceData(
     .sort((a, b) => b.sov - a.sov);
 
   // --- Trend ---
-  const sortedDays = [...dayMap.keys()].sort();
-  const trend: SoVTrendPoint[] = sortedDays.map((day) => {
-    const d = dayMap.get(day)!;
-    const total = d.brandMentions + d.competitorMentions;
-    const brandSov = total > 0 ? Math.round((d.brandMentions / total) * 1000) / 10 : 0;
-    const competitorSov = total > 0 ? Math.round((d.competitorMentions / total) * 1000) / 10 : 0;
-    const dateObj = new Date(day + 'T00:00:00');
-    const label = dateObj.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
+  // RPC already returns by_day ordered by date ascending, but be defensive.
+  const trend: SoVTrendPoint[] = [...cur.by_day]
+    .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0))
+    .map((d) => {
+      const brand = Number(d.brand_mentions);
+      const comp = Number(d.competitor_mentions);
+      const total = brand + comp;
+      const brandSov = total > 0 ? Math.round((brand / total) * 1000) / 10 : 0;
+      const competitorSov = total > 0 ? Math.round((comp / total) * 1000) / 10 : 0;
+      const dateObj = new Date(d.day + 'T00:00:00');
+      const label = dateObj.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      });
+      return { date: label, brandSov, competitorSov };
     });
-    return { date: label, brandSov, competitorSov };
-  });
 
-  // --- Previous period delta ---
+  // --- Previous period delta (overall SoV only) ---
   let overallSovChange: number | null = null;
-
-  {
-    let currentFrom: Date;
-    let currentTo: Date;
-
-    if (opts?.dateFrom) {
-      currentFrom = new Date(opts.dateFrom);
-      currentTo = opts.dateTo ? new Date(opts.dateTo) : new Date();
-    } else {
-      currentTo = new Date();
-      currentFrom = new Date();
-      currentFrom.setDate(currentFrom.getDate() - 7);
-    }
-
-    const duration = currentTo.getTime() - currentFrom.getTime();
-    const prevFrom = new Date(currentFrom.getTime() - duration);
-
-    const { query: prevQuery } = await buildResultsQuery(brandId, {
-      ...opts,
-      dateFrom: prevFrom.toISOString(),
-      dateTo: currentFrom.toISOString(),
-    });
-
-    const { data: prevResults } = await prevQuery;
-    const prevRows = (prevResults ?? []) as Record<string, unknown>[];
-
-    if (prevRows.length > 0) {
-      let prevBrandM = 0;
-      let prevCompM = 0;
-      for (const row of prevRows) {
-        prevBrandM += row.mention_count as number;
-        const cms = (row.competitor_mentions as CompetitorMention[] | null) ?? [];
-        for (const cm of cms) prevCompM += cm.mention_count;
-      }
+  if (prev) {
+    const prevBrandM = Number(prev.total_brand_mentions);
+    const prevCompM = Number(prev.total_competitor_mentions);
+    if (prevBrandM + prevCompM > 0) {
       const prevTotal = prevBrandM + prevCompM;
       const prevSov = prevTotal > 0 ? Math.round((prevBrandM / prevTotal) * 1000) / 10 : 0;
       overallSovChange = Math.round((overallSov - prevSov) * 10) / 10;

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -504,7 +504,7 @@ export async function getInsightsSummary(
     // call above is unbounded — for the delta math we need the same
     // explicit "last 7 days" window the JS code used so the comparison
     // stays anchored to recent momentum.
-    const [{ data: curWinData }, { data: prevWinData }] = await Promise.all([
+    const [curRes, prevRes] = await Promise.all([
       supabase.rpc('insights_aggregates', {
         ...baseArgs,
         p_date_from: opts?.dateFrom ?? currentFrom.toISOString(),
@@ -516,9 +516,13 @@ export async function getInsightsSummary(
         p_date_to: currentFrom.toISOString(),
       }),
     ]);
+    // Surface RPC failures rather than silently emit null deltas — masking
+    // server-side errors here would hide real outages behind "no change."
+    if (curRes.error) throw new Error(curRes.error.message);
+    if (prevRes.error) throw new Error(prevRes.error.message);
 
-    const curWin = curWinData as unknown as InsightsAggregates | null;
-    const prevWin = prevWinData as unknown as InsightsAggregates | null;
+    const curWin = curRes.data as unknown as InsightsAggregates | null;
+    const prevWin = prevRes.data as unknown as InsightsAggregates | null;
 
     if (curWin && prevWin && curWin.total_results > 0 && prevWin.total_results > 0) {
       const curAvgVis = Math.round(curWin.sum_visibility / curWin.total_results);
@@ -909,7 +913,7 @@ export async function getCompetitorComparison(
   const duration = currentTo.getTime() - currentFrom.getTime();
   const prevFrom = new Date(currentFrom.getTime() - duration);
 
-  const [{ data: curWinData }, { data: prevWinData }] = await Promise.all([
+  const [curRes, prevRes] = await Promise.all([
     supabase.rpc('competitor_aggregates', {
       ...baseArgs,
       p_date_from: opts?.dateFrom ?? currentFrom.toISOString(),
@@ -921,9 +925,11 @@ export async function getCompetitorComparison(
       p_date_to: currentFrom.toISOString(),
     }),
   ]);
+  if (curRes.error) throw new Error(curRes.error.message);
+  if (prevRes.error) throw new Error(prevRes.error.message);
 
-  const curWin = curWinData as unknown as CompetitorAggregatesRow | null;
-  const prevWin = prevWinData as unknown as CompetitorAggregatesRow | null;
+  const curWin = curRes.data as unknown as CompetitorAggregatesRow | null;
+  const prevWin = prevRes.data as unknown as CompetitorAggregatesRow | null;
 
   const curBrandAvg =
     curWin && curWin.brand_row_count > 0
@@ -954,6 +960,13 @@ export async function getCompetitorComparison(
     return Math.round(((cur - prev) / prev) * 1000) / 10;
   };
 
+  // Falls back to the competitor id when the name is null/empty so two
+  // unnamed competitors don't collide under the same empty-string key in
+  // compByProvider below. Applied consistently to the entries[] name field
+  // so the providerRows column header matches the table row label.
+  const competitorDisplayName = (name: string | null | undefined, id: string): string =>
+    name && name.trim() !== '' ? name : id;
+
   const entries: CompetitorComparisonEntry[] = [
     {
       name: brandName,
@@ -969,7 +982,7 @@ export async function getCompetitorComparison(
   for (const c of agg.by_competitor) {
     const avg = c.row_count > 0 ? Math.round(c.sum_visibility / c.row_count) : 0;
     entries.push({
-      name: c.name ?? '',
+      name: competitorDisplayName(c.name, c.competitor_id),
       avgVisibilityScore: avg,
       change: pctChange(
         curCompAvg.get(c.competitor_id) ?? null,
@@ -998,13 +1011,13 @@ export async function getCompetitorComparison(
     brandByProvider.set(provider, ex);
   }
 
-  // compName -> provider -> agg (JS key by display name to match the old
-  // shape exactly, since the provider row columns are keyed by competitor
-  // name).
+  // compName -> provider -> agg. Keyed by the same display name used in
+  // entries[] above so the providerRows column headers line up with the
+  // table rows (empty/null names fall back to competitor_id).
   const compByProvider = new Map<string, Map<string, Agg>>();
   for (const cp of agg.by_competitor_provider) {
     const provider = resolveProvider(cp.model_used, cp.platform);
-    const name = cp.competitor_name ?? '';
+    const name = competitorDisplayName(cp.competitor_name, cp.competitor_id);
     if (!compByProvider.has(name)) compByProvider.set(name, new Map());
     const pm = compByProvider.get(name)!;
     const ex = pm.get(provider) ?? { totalScore: 0, count: 0 };
@@ -1094,7 +1107,7 @@ export async function getShareOfVoiceData(
   const duration = currentTo.getTime() - currentFrom.getTime();
   const prevFrom = new Date(currentFrom.getTime() - duration);
 
-  const [{ data: curData, error: curErr }, { data: prevData }] = await Promise.all([
+  const [{ data: curData, error: curErr }, { data: prevData, error: prevErr }] = await Promise.all([
     supabase.rpc('share_of_voice_aggregates', {
       ...baseArgs,
       p_date_from: opts?.dateFrom ?? null,
@@ -1107,6 +1120,7 @@ export async function getShareOfVoiceData(
     }),
   ]);
   if (curErr) throw new Error(curErr.message);
+  if (prevErr) throw new Error(prevErr.message);
 
   const cur = curData as unknown as ShareOfVoiceAggregatesRow;
   const prev = prevData as unknown as ShareOfVoiceAggregatesRow | null;

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -873,6 +873,45 @@ export type Database = {
               isSetofReturn: true;
             };
           };
+      insights_aggregates: {
+        Args: {
+          p_brand_id: string;
+          p_platform?: string | null;
+          p_models?: string[] | null;
+          p_region?: string | null;
+          p_date_from?: string | null;
+          p_date_to?: string | null;
+          p_prompt_id?: string | null;
+          p_topic_id?: string | null;
+        };
+        Returns: Json;
+      };
+      competitor_aggregates: {
+        Args: {
+          p_brand_id: string;
+          p_platform?: string | null;
+          p_models?: string[] | null;
+          p_region?: string | null;
+          p_date_from?: string | null;
+          p_date_to?: string | null;
+          p_prompt_id?: string | null;
+          p_topic_id?: string | null;
+        };
+        Returns: Json;
+      };
+      share_of_voice_aggregates: {
+        Args: {
+          p_brand_id: string;
+          p_platform?: string | null;
+          p_models?: string[] | null;
+          p_region?: string | null;
+          p_date_from?: string | null;
+          p_date_to?: string | null;
+          p_prompt_id?: string | null;
+          p_topic_id?: string | null;
+        };
+        Returns: Json;
+      };
     };
     Enums: {
       invitation_status: 'pending' | 'accepted' | 'expired' | 'revoked';


### PR DESCRIPTION
Implements phase 1 of #93. The largest, no-tradeoff lever from the issue: move the three insights server-action reducers out of Node and into Postgres without introducing any TTL-bound cache that would delay on-demand refresh updates.

## The shape of the bug

\`getInsightsSummary\`, \`getShareOfVoiceData\`, and \`getCompetitorComparison\` all followed the same pattern: \`select('*')\` from \`prompt_results\` for the brand + filter set, then \`reduce\`/\`Map\`/\`for…of\` the rows in JS. Each row carries the **full AI response text** (kilobytes), \`citations\` jsonb, and \`competitor_mentions\` jsonb. For a brand with thousands of results that's a multi-hundred-MB transfer + GC-heavy reducers on every insights page load — and the page fires 4–5 of these actions in parallel on mount.

## What this PR does

### 1. Three new RPCs

In a single new migration \`supabase/migrations/00006_insights_aggregates.sql\`:

| Function | Replaces | Returns |
|---|---|---|
| \`insights_aggregates\` | \`getInsightsSummary\`'s reducer | Totals, sums, last_checked_at, per-model breakdown |
| \`competitor_aggregates\` | \`getCompetitorComparison\`'s reducer | Brand + per-competitor sums, per-provider grids for the table |
| \`share_of_voice_aggregates\` | \`getShareOfVoiceData\`'s reducer | Totals, per (model_used, platform), per-day buckets |

Each returns a single JSONB row of raw **sums + counts**, never pre-divided averages. The final \`/\` + \`Math.round\` still happens in JS exactly as before — guarantees the displayed numbers don't drift by even ±1 from a half-rule mismatch between JS's \`Math.round\` and Postgres \`ROUND\`. The provider mapping (\`resolveProvider\`) also stays in JS so the SQL doesn't ship a duplicate lookup that has to be kept in sync as engines land.

\`SECURITY DEFINER\` to match the existing \`get_latest_prompt_results\` pattern; route layer still verifies brand-belongs-to-org access before calling.

### 2. Composite index

\`CREATE INDEX (brand_id, created_at DESC) ON prompt_results\` — the exact shape every insights filter needs. Existing indexes are single-column on \`brand_id\` and \`created_at\` separately, forcing the planner to pick one and re-sort/filter on the other in the heap. The composite serves both the old query path (still used by listing endpoints like \`getPromptResults\`, \`getVisibilityTrend\`) and the new RPC \`WHERE\`s.

### 3. Refactor of three action functions

\`web/src/lib/actions/tracking.ts\` — the three problem functions now do:
- One RPC call for the displayed window
- Two parallel RPC calls (current 7-day vs previous 7-day) for the delta
- A trivial fold over the small grouped arrays the RPC returns
- \`resolveProvider\` over those grouped rows for provider buckets

\`buildResultsQuery\` and \`applyModelFilter\` stay — they're still used by row-listing endpoints (\`getPromptResults\`, \`getVisibilityTrend\`).

## Parity verification

Before merging anything, ran the RPCs against a real brand with **5054 prompt_results** in prod and diffed every field against the equivalent inline-SQL aggregation that mirrors the JS reducer arithmetic. Every field matched byte-for-byte at decimal precision (e.g. \`sum_visibility = 384907.7615259740259744489904\` from both paths). Verified for:

- \`insights_aggregates\` — unfiltered, plus with a 30-day date filter
- \`competitor_aggregates\` — brand_total_mentions, brand_total_citations, sum-of-competitor-mentions, provider combo counts, competitor × provider combo counts (70 distinct combos checked)
- \`share_of_voice_aggregates\` — totals, distinct day count, distinct (model_used, platform) combos

Local smoke load of \`/dashboard/insights\` then renders the same KPIs, breakdowns, and trend lines with the new path — no console errors, no server-side RPC errors, filters work.

## Why this is the safe rewrite

- **Pure addition** at the schema level: new index, new functions. No table altered, no column changed, no row touched. Drop the functions and the index → table is identical.
- **Read-side only**: tracking worker writes, on-demand Run All / Refresh / Test Single Prompt writes — none of these change. \`prompt_results.shopping_cards\` capture and every other write path stays exactly as-is.
- **No TTL cache introduced**: explicit constraint in the issue (Run All / Refresh must reflect immediately). This PR achieves the speedup *without* hiding fresh data behind any cache window.
- **JS-side rounding preserved**: the only practical drift risk on a SQL refactor like this is rounding/half-rule mismatch. By returning raw sums + counts and doing the final divide + round in JS, that risk class is closed.
- **Reversible**: \`git revert\` on the code commit alone returns behavior to the old \`select('*')\` path; the migration's functions and index sit idle if unused.

## Files

| File | Change |
|---|---|
| \`supabase/migrations/00006_insights_aggregates.sql\` | New migration: composite index + three RPCs |
| \`web/src/lib/actions/tracking.ts\` | Three insights actions refactored to call the RPCs; new \`modelFilterArray\` helper + RPC return-shape interfaces |
| \`web/src/types/supabase.ts\` | Added \`Functions\` entries for the three new RPCs so the \`.rpc()\` call sites type-check |

## Deploy order

The migration has already been applied to the cloud project (additive, reversible). Self-hosters pick it up at the next release via \`supabase db push\` — standard prosedür per CONTRIBUTING.

## Out of scope (deferred, from #93)

- **Precomputed daily summary table** (phase 2) — only worth it if phase 1 doesn't move the needle enough; measure first.
- **Use cache / cacheTag invalidation on insights reads** (phase 3) — complement to this PR, layers on top of these RPCs.