### PR TITLE
feat(mcp): expose get_visibility_trend tool (visibility time-series) + REST endpoint

### DIFF
--- a/supabase/migrations/00008_visibility_trend_aggregates.sql
+++ b/supabase/migrations/00008_visibility_trend_aggregates.sql
@@ -1,0 +1,98 @@
+-- DB-side aggregation for the visibility-over-time trend (#96).
+--
+-- The existing getVisibilityTrend in actions/tracking.ts fetches every
+-- prompt_results row in the window and folds by day in JS. That works for
+-- one user loading the insights page; it scales badly for an MCP client
+-- (e.g. the planned in-product assistant in #94) firing repeated trend
+-- queries — each call ships back tens of MB of jsonb rows just to be
+-- reduced to a handful of date buckets. This RPC mirrors the structural
+-- decisions of 00006 (the insights / competitor / SoV aggregates): one
+-- jsonb-shaped return, raw sums + counts, ORDER BY inside jsonb_agg for
+-- a stable response, and SECURITY DEFINER for symmetry with the other
+-- aggregate RPCs (org-membership enforcement is tracked in #115).
+--
+-- Granularity is constrained to 'day' or 'week' so the response shape
+-- stays predictable for chart-rendering consumers. date_trunc would
+-- happily accept 'month' / 'year' too, but exposing those introduces
+-- empty-bucket ambiguity at the assistant layer; if a caller wants
+-- monthly aggregation today they can group the daily buckets client
+-- side.
+CREATE OR REPLACE FUNCTION public.visibility_trend_aggregates(
+  p_brand_id     uuid,
+  p_models       text[]       DEFAULT NULL,
+  p_region       text         DEFAULT NULL,
+  p_date_from    timestamptz  DEFAULT NULL,
+  p_date_to      timestamptz  DEFAULT NULL,
+  p_topic_id     uuid         DEFAULT NULL,
+  p_granularity  text         DEFAULT 'day'
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH filtered AS (
+    SELECT pr.visibility_score, pr.mention_count, pr.citation_count,
+           pr.created_at, pr.competitor_mentions
+    FROM public.prompt_results pr
+    WHERE pr.brand_id = p_brand_id
+      AND (p_models    IS NULL OR pr.model_used  = ANY (p_models))
+      AND (p_region    IS NULL OR pr.region      = p_region)
+      AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR pr.created_at <= p_date_to)
+      AND (p_topic_id  IS NULL OR EXISTS (
+             SELECT 1 FROM public.prompts p
+             WHERE p.id = pr.prompt_id AND p.topic_id = p_topic_id))
+  ),
+  buckets AS (
+    SELECT
+      -- Bucket key always stored as YYYY-MM-DD in UTC so callers can sort
+      -- lexicographically and so the JS reducer doesn't have to think about
+      -- the server's timezone. For weeks, this is the Monday-start ISO week
+      -- per Postgres's date_trunc semantics.
+      to_char(
+        date_trunc(p_granularity, created_at AT TIME ZONE 'UTC'),
+        'YYYY-MM-DD'
+      ) AS bucket_date,
+      COUNT(*)                                                                AS row_count,
+      COALESCE(SUM(visibility_score), 0)                                      AS sum_visibility,
+      COALESCE(SUM(mention_count), 0)::bigint                                 AS sum_mentions,
+      COALESCE(SUM(citation_count), 0)::bigint                                AS sum_citations,
+      -- Competitor mentions are unnested per-row, then summed. We sum inside
+      -- a correlated subquery so a row with five competitor entries
+      -- contributes once per entry rather than five times to the brand
+      -- numbers above.
+      COALESCE(SUM((
+        SELECT COALESCE(SUM((cm.value->>'visibility_score')::numeric), 0)
+        FROM jsonb_array_elements(COALESCE(competitor_mentions, '[]'::jsonb)) cm
+      )), 0)                                                                  AS comp_sum_visibility,
+      COALESCE(SUM((
+        SELECT COUNT(*)
+        FROM jsonb_array_elements(COALESCE(competitor_mentions, '[]'::jsonb)) cm
+      )), 0)::bigint                                                          AS comp_count
+    FROM filtered
+    GROUP BY to_char(
+      date_trunc(p_granularity, created_at AT TIME ZONE 'UTC'),
+      'YYYY-MM-DD'
+    )
+  )
+  SELECT COALESCE(
+    (SELECT jsonb_agg(
+              jsonb_build_object(
+                'bucket_date',         b.bucket_date,
+                'row_count',           b.row_count,
+                'sum_visibility',      b.sum_visibility,
+                'sum_mentions',        b.sum_mentions,
+                'sum_citations',       b.sum_citations,
+                'comp_sum_visibility', b.comp_sum_visibility,
+                'comp_count',          b.comp_count
+              )
+              ORDER BY b.bucket_date)
+     FROM buckets b),
+    '[]'::jsonb);
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.visibility_trend_aggregates(uuid, text[], text, timestamptz, timestamptz, uuid, text)
+  TO authenticated, service_role;

--- a/web/src/app/api/mcp/visibility-trend/route.ts
+++ b/web/src/app/api/mcp/visibility-trend/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { authenticateMcpRequest } from '@/lib/mcp-auth';
+import { getVisibilityTrendFor, type VisibilityTrendGranularity } from '@/lib/mcp/data';
+
+/**
+ * GET /api/mcp/visibility-trend
+ *
+ * Parallel REST surface for the `get_visibility_trend` MCP tool — same
+ * data-layer function, same ownership guarantee. Query params mirror the
+ * MCP args: brand_id (required), date_from, date_to, granularity, model,
+ * region, topic_id.
+ */
+export async function GET(req: Request) {
+  const auth = await authenticateMcpRequest(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const url = new URL(req.url);
+  const brandId = url.searchParams.get('brand_id');
+  if (!brandId) {
+    return NextResponse.json({ error: 'brand_id is required' }, { status: 400 });
+  }
+
+  const granularityParam = url.searchParams.get('granularity');
+  let granularity: VisibilityTrendGranularity | undefined;
+  if (granularityParam !== null) {
+    if (granularityParam !== 'day' && granularityParam !== 'week') {
+      return NextResponse.json({ error: 'granularity must be "day" or "week"' }, { status: 400 });
+    }
+    granularity = granularityParam;
+  }
+
+  try {
+    const result = await getVisibilityTrendFor(auth, {
+      brandId,
+      dateFrom: url.searchParams.get('date_from') ?? undefined,
+      dateTo: url.searchParams.get('date_to') ?? undefined,
+      model: url.searchParams.get('model') ?? undefined,
+      region: url.searchParams.get('region') ?? undefined,
+      topicId: url.searchParams.get('topic_id') ?? undefined,
+      granularity,
+    });
+    if (!result) {
+      return NextResponse.json({ error: 'Brand not found' }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/lib/mcp/data.ts
+++ b/web/src/lib/mcp/data.ts
@@ -1084,3 +1084,105 @@ export async function listCitationsFor(
     top_urls: topUrls,
   };
 }
+
+// ── Visibility trend ────────────────────────────────────────────────────────
+
+export type VisibilityTrendGranularity = 'day' | 'week';
+
+export interface VisibilityTrendParams {
+  brandId: string;
+  dateFrom?: string;
+  dateTo?: string;
+  /** Comma-separated model_used slugs (e.g. `gpt-4o,claude-sonnet-4-6`). */
+  model?: string;
+  region?: string;
+  topicId?: string;
+  granularity?: VisibilityTrendGranularity;
+}
+
+export interface VisibilityTrendOutput {
+  granularity: VisibilityTrendGranularity;
+  buckets: Array<{
+    /** UTC bucket key in `YYYY-MM-DD` (week bucket = the ISO Monday). */
+    date: string;
+    result_count: number;
+    avg_visibility_score: number;
+    total_mentions: number;
+    total_citations: number;
+    /** Average competitor visibility unwrapped from `competitor_mentions`. */
+    avg_competitor_score: number | null;
+  }>;
+}
+
+interface VisibilityTrendBucketRpc {
+  bucket_date: string;
+  row_count: number;
+  sum_visibility: number;
+  sum_mentions: number;
+  sum_citations: number;
+  comp_sum_visibility: number;
+  comp_count: number;
+}
+
+/**
+ * Visibility / mentions / citations over time for a brand, with the
+ * competitor average pulled out of `competitor_mentions` per row so a chart
+ * can plot brand vs. competitor lines side by side.
+ *
+ * Aggregates server-side via the `visibility_trend_aggregates` RPC introduced
+ * in 00008 — same pattern as the insights / competitor / SoV surfaces from
+ * #114. The JS layer only divides and rounds; the row scan stays in
+ * Postgres. Designed for the chart-rendering surfaces in the planned
+ * in-product assistant (#94), which can fire a lot of these.
+ *
+ * Ownership-check first; wrong-org or missing brand returns null (→ 404)
+ * before the RPC fires.
+ */
+export async function getVisibilityTrendFor(
+  auth: McpAuthContext,
+  params: VisibilityTrendParams,
+): Promise<VisibilityTrendOutput | null> {
+  if (!auth.organizationId) return null;
+
+  const { data: brand } = await supabaseAdmin
+    .from('brands')
+    .select('id')
+    .eq('id', params.brandId)
+    .eq('organization_id', auth.organizationId)
+    .maybeSingle();
+  if (!brand) return null;
+
+  const p_models = params.model
+    ? params.model
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : null;
+
+  const granularity: VisibilityTrendGranularity = params.granularity ?? 'day';
+
+  const { data, error } = await supabaseAdmin.rpc('visibility_trend_aggregates', {
+    p_brand_id: params.brandId,
+    p_models: p_models && p_models.length > 0 ? p_models : null,
+    p_region: params.region ?? null,
+    p_date_from: params.dateFrom ?? null,
+    p_date_to: params.dateTo ?? null,
+    p_topic_id: params.topicId ?? null,
+    p_granularity: granularity,
+  });
+  if (error) throw new Error(error.message);
+
+  const raw = (data as unknown as VisibilityTrendBucketRpc[]) ?? [];
+  const buckets = raw.map((b) => ({
+    date: b.bucket_date,
+    result_count: Number(b.row_count),
+    avg_visibility_score:
+      b.row_count > 0 ? Math.round(Number(b.sum_visibility) / Number(b.row_count)) : 0,
+    total_mentions: Number(b.sum_mentions),
+    total_citations: Number(b.sum_citations),
+    avg_competitor_score:
+      b.comp_count > 0 ? Math.round(Number(b.comp_sum_visibility) / Number(b.comp_count)) : null,
+  }));
+
+  return { granularity, buckets };
+}

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -8,6 +8,7 @@ import {
   getCompetitorComparisonFor,
   getContentOpportunityFor,
   getVisibilitySummaryFor,
+  getVisibilityTrendFor,
   listBrandsFor,
   listCitationsFor,
   listContentOpportunitiesFor,
@@ -372,6 +373,58 @@ export function createMcpServer(auth: McpAuthContext): McpServer {
         region: args.region,
         topicId: args.topic_id,
         limit: args.limit,
+      });
+      if (!result) {
+        return {
+          content: [{ type: 'text', text: 'Brand not found' }],
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'get_visibility_trend',
+    {
+      description:
+        'Get a brand\'s visibility over time for a date range, bucketed by day or week. Returns one bucket per period with result_count, avg_visibility_score (0-100), total_mentions, total_citations, and avg_competitor_score (mean of competitor visibility scores from the same period, or null if no competitors were mentioned). Use this for "how has my visibility changed?" trend questions and to render brand-vs-competitor line charts. Complements get_visibility_summary, which is a single-window snapshot.',
+      inputSchema: {
+        brand_id: z.string().uuid().describe('Brand UUID, from list_brands.'),
+        date_from: z
+          .string()
+          .optional()
+          .describe('ISO timestamp (inclusive) lower bound, e.g. 2026-05-01T00:00:00Z.'),
+        date_to: z.string().optional().describe('ISO timestamp (inclusive) upper bound.'),
+        granularity: z
+          .enum(['day', 'week'])
+          .optional()
+          .describe('Bucket size — "day" (default) or "week" (ISO Monday-start weeks).'),
+        model: z
+          .string()
+          .optional()
+          .describe(
+            'Optional model slug filter, or comma-separated list of slugs to filter a provider family.',
+          ),
+        region: z.string().optional().describe('Optional region code filter (e.g. "US", "TR").'),
+        topic_id: z
+          .string()
+          .uuid()
+          .optional()
+          .describe('Optional topic UUID (from list_topics) to restrict to one topic.'),
+      },
+    },
+    async (args) => {
+      const result = await getVisibilityTrendFor(auth, {
+        brandId: args.brand_id,
+        dateFrom: args.date_from,
+        dateTo: args.date_to,
+        model: args.model,
+        region: args.region,
+        topicId: args.topic_id,
+        granularity: args.granularity,
       });
       if (!result) {
         return {

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -899,6 +899,18 @@ export type Database = {
         };
         Returns: Json;
       };
+      visibility_trend_aggregates: {
+        Args: {
+          p_brand_id: string;
+          p_models?: string[] | null;
+          p_region?: string | null;
+          p_date_from?: string | null;
+          p_date_to?: string | null;
+          p_topic_id?: string | null;
+          p_granularity?: string | null;
+        };
+        Returns: Json;
+      };
       share_of_voice_aggregates: {
         Args: {
           p_brand_id: string;


### PR DESCRIPTION
Closes #96. **Last of the A-group MCP read tools** — the in-product assistant epic (#94) can start in earnest after this lands.

## What

- New MCP tool: \`get_visibility_trend(brand_id, ..., granularity)\` → buckets of visibility / mentions / citations over time, plus avg competitor score per bucket for brand-vs-competitor charts.
- New REST endpoint: \`GET /api/mcp/visibility-trend\`.
- New migration \`00008_visibility_trend_aggregates.sql\` — DB-side bucketing via \`date_trunc\`, jsonb return shape mirroring 00006.

## Shape of the response

\`\`\`json
{
  "granularity": "day",
  "buckets": [
    {
      "date": "2026-03-30",
      "result_count": 154,
      "avg_visibility_score": 76,
      "total_mentions": 646,
      "total_citations": 693,
      "avg_competitor_score": 63
    }
  ]
}
\`\`\`

\`date\` is \`YYYY-MM-DD\` in UTC (week granularity = the ISO Monday). \`avg_competitor_score\` is the mean of every competitor score unwrapped from \`competitor_mentions\` in that bucket — \`null\` if no competitors were mentioned. Stable lex-sortable bucket keys + small numeric fields = chart-friendly without any client-side date-parse step.

## Why DB-side

The existing \`getVisibilityTrend\` in \`actions/tracking.ts\` fetches every \`prompt_results\` row in the window and folds by day in JS. Fine for one human loading the insights page; bad for MCP / the assistant in #94, which will fire repeated trend queries and would otherwise pay full row transfer + JS reduce per call. The new RPC buckets server-side and returns ~one row per day. Same lever as #93 / #114, applied to the trend surface.

## Granularity

Constrained to \`'day'\` or \`'week'\` — both at the SQL layer (the tool description) and the REST layer (400 if anything else). \`date_trunc\` would happily accept \`'month'\` / \`'year'\` too, but exposing those introduces empty-bucket ambiguity at the assistant layer. If a caller wants monthly aggregation today they can group the daily buckets themselves.

## Parity verification

Against the largest brand in the cloud project (5054 prompt results, 35 distinct UTC day buckets):

- ✅ \`row_count\`, \`sum_visibility\`, \`sum_mentions\`, \`sum_citations\`, \`comp_sum_visibility\`, \`comp_count\` match the inline-SQL aggregation **byte-for-byte at decimal precision** across all 35 buckets
- ✅ Bucket date range matches expected window (\`2026-03-30\` → \`2026-05-06\`)
- ✅ \`yarn typecheck\` + \`yarn format:check\` clean
- ✅ Migration applied to the cloud project; \`SECURITY DEFINER\` + \`GRANT EXECUTE\` for \`authenticated\` + \`service_role\` matches the existing aggregate RPC pattern

## Auth + safety

Ownership check first via \`supabaseAdmin\` — wrong-org or missing \`brand_id\` returns null (→ 404) **before the RPC fires**. Same defensive pattern as the other MCP data fns. Membership enforcement inside the function itself is tracked uniformly in #115 alongside the other aggregate RPCs.

## Files

| File | Change |
|---|---|
| \`supabase/migrations/00008_visibility_trend_aggregates.sql\` | New RPC: jsonb-shaped buckets by day/week, raw sums + counts |
| \`web/src/lib/mcp/data.ts\` | \`getVisibilityTrendFor\` data fn + \`VisibilityTrendParams\` / \`VisibilityTrendOutput\` / \`VisibilityTrendGranularity\` types |
| \`web/src/lib/mcp/server.ts\` | Registers \`get_visibility_trend\` |
| \`web/src/types/supabase.ts\` | Generated-types entry for the new RPC |
| \`web/src/app/api/mcp/visibility-trend/route.ts\` | GET handler with granularity-param validation |

## A-group complete

After this lands, the MCP read-tool surface the assistant epic (#94) needs is **done**:

- ✅ \`list_brands\`, \`get_visibility_summary\` (#20)
- ✅ \`list_topics\`, \`list_prompts\` (#35)
- ✅ \`list_content_opportunities\`, \`get_content_opportunity\` (#74)
- ✅ \`generate_content_brief\` (#109), \`update_opportunity_status\` (#110)
- ✅ \`get_competitor_comparison\` (#116)
- ✅ \`list_citations\` (#117)
- ✅ \`get_visibility_trend\` (this PR)

\#94 epic can now sequence onto Phase 2 (agent + chat UI text-only) without parallel-codepath teknik borç.