### PR TITLE
fix(invite): accept-link session bug + force password setup on join

### DIFF
--- a/web/src/components/team/accept-invitation-card.tsx
+++ b/web/src/components/team/accept-invitation-card.tsx
@@ -5,6 +5,8 @@ import { useRouter } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { acceptInvitation, type TeamRole } from '@/lib/actions/team';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { Loader2, Users } from 'lucide-react';
 
@@ -39,12 +41,41 @@ export function AcceptInvitationCard({
   emailMatches,
 }: Props) {
   const router = useRouter();
+  const [fullName, setFullName] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [isAccepting, setIsAccepting] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
 
-  async function handleAccept() {
+  async function handleAccept(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    if (password.length < 8) {
+      toast.error('Password must be at least 8 characters');
+      return;
+    }
+    if (password !== confirmPassword) {
+      toast.error('Passwords do not match');
+      return;
+    }
+
     setIsAccepting(true);
     try {
+      const supabase = createClient();
+
+      // Order matters: set the password + name first so the moment the
+      // invitation row flips to "accepted" the credentials are already
+      // good. If updateUser fails we abort before mutating the invite —
+      // otherwise the user lands in the same broken state we just fixed
+      // (joined the org but can't sign back in).
+      const { error: updateErr } = await supabase.auth.updateUser({
+        password,
+        data: fullName.trim() ? { full_name: fullName.trim() } : undefined,
+      });
+      if (updateErr) {
+        throw new Error(updateErr.message);
+      }
+
       await acceptInvitation(token);
       toast.success(`Welcome to ${organizationName}!`);
       router.push('/dashboard');
@@ -109,16 +140,64 @@ export function AcceptInvitationCard({
           </Button>
         </div>
       ) : (
-        <Button onClick={handleAccept} disabled={isAccepting} className="mt-6 w-full">
-          {isAccepting ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Joining...
-            </>
-          ) : (
-            `Accept and join ${organizationName}`
-          )}
-        </Button>
+        <form onSubmit={handleAccept} className="mt-6 space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="invite-fullname">Full name</Label>
+            <Input
+              id="invite-fullname"
+              type="text"
+              placeholder="Your name"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              autoComplete="name"
+              disabled={isAccepting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="invite-password">Set a password</Label>
+            <Input
+              id="invite-password"
+              type="password"
+              placeholder="At least 8 characters"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="new-password"
+              required
+              minLength={8}
+              disabled={isAccepting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="invite-confirm-password">Confirm password</Label>
+            <Input
+              id="invite-confirm-password"
+              type="password"
+              placeholder="Repeat the password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+              required
+              minLength={8}
+              disabled={isAccepting}
+            />
+          </div>
+
+          <Button type="submit" disabled={isAccepting} className="w-full">
+            {isAccepting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Joining...
+              </>
+            ) : (
+              `Accept and join ${organizationName}`
+            )}
+          </Button>
+          <p className="text-xs text-muted-foreground text-center">
+            You&apos;ll use this password the next time you sign in.
+          </p>
+        </form>
       )}
     </div>
   );

--- a/web/src/lib/actions/team.ts
+++ b/web/src/lib/actions/team.ts
@@ -202,7 +202,15 @@ export async function inviteMember(email: string, role: TeamRole) {
 
   const token = randomBytes(32).toString('hex');
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  const inviteLink = `${appUrl}/invite/${token}`;
+  // Route the invite mail through /auth/callback first so Supabase's
+  // ?code= ends up at a route that calls exchangeCodeForSession() before
+  // the user lands on /invite/<token>. Without this hop the invite page
+  // server-renders without a session, falls into its `if (!user)` branch,
+  // and ejects the user to /sign-up — where signUp() trips on the
+  // existing auth.users row, no password is actually set, and the user
+  // gets bounced to /sign-in with credentials that don't work.
+  const inviteAcceptPath = `/invite/${token}`;
+  const inviteLink = `${appUrl}/auth/callback?next=${encodeURIComponent(inviteAcceptPath)}`;
 
   const { data: invitation, error: insertError } = await supabaseAdmin
     .from('invitations')


### PR DESCRIPTION
## What

Clicking an invite mail used to bounce the user to `/sign-up`, then to `/sign-in` with credentials that didn't work. Two stacked bugs.

### Bug A — session never established on `/invite/<token>`

The invite mail's `redirect_to` pointed straight at our `/invite/<token>` page. After Supabase verified the magic-link token, it appended `?code=<session-code>` to that URL and redirected the user there. But our [`/invite/[token]/page.tsx`](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/%5Blocale%5D/invite/%5Btoken%5D/page.tsx) is a server component — `supabase.auth.getUser()` returns null because the `?code=` hadn't been exchanged for a cookie session yet. The `if (!user)` branch fired and ejected the user to `/sign-up?invite=...`.

On `/sign-up`, the form called `supabase.auth.signUp({ email, password })` on an email that **already existed** (created by `inviteUserByEmail`). Supabase returned a soft success without actually changing credentials, and the form pushed the user to `/sign-in?verified=pending`. The password they typed didn't match anything in the DB.

### Bug B — invited users have no password to sign back in with

`inviteUserByEmail` creates an `auth.users` row with no `encrypted_password`. Even if Bug A hadn't existed, the user would land on the accept card with a single 'Join' button, accept, get into the dashboard once via the magic-link session — then never be able to sign back in. They have nothing to type at the sign-in form.

## Why

This is the canonical broken-invite-flow that every customer's first invited teammate would have hit. The team-invite UI itself works (the mail goes out via Resend) so it looks healthy from the inviter's side — the breakage is entirely downstream, on the invitee's first click.

## Scope

- [`team.ts`](https://github.com/ansvisor/ansvisor/blob/main/web/src/lib/actions/team.ts): the invite link in `inviteMember` is now
  ```
  ${appUrl}/auth/callback?next=${encodeURIComponent(`/invite/${token}`)}
  ```
  [`/auth/callback`](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/auth/callback/route.ts) already calls `exchangeCodeForSession` and forwards to `next`. So by the time the user lands on `/invite/<token>` they have a cookie session and the `!user` branch never fires.

- [`AcceptInvitationCard`](https://github.com/ansvisor/ansvisor/blob/main/web/src/components/team/accept-invitation-card.tsx): the single 'Join' button is now a small form — Full name (optional), Password + Confirm Password (required, min 8 chars). On submit it does
  ```
  await supabase.auth.updateUser({ password, data: { full_name } });
  await acceptInvitation(token);
  ```
  Order matters: if `updateUser` fails we never flip the invitation to 'accepted' — the user can retry the link instead of landing in a half-joined state.

## Test plan

1. Delete any prior `auth.users` / `invitations` for the test email
2. From the dashboard team page, invite the test email
3. Open the mail (delivered via Resend), click 'Accept the invite'
4. Land on `/invite/<token>` directly (no detour through `/sign-up`)
5. Set full name + password, click 'Accept and join'
6. Land in `/dashboard` as a member of the inviter's org
7. Sign out → sign back in with the password just set → succeeds

## Out of scope

- The `/sign-up?invite=...` fallback path in `/invite/[token]/page.tsx` (line ~32). With the redirect fix this path shouldn't fire for normal invite clicks; if someone lands on `/invite/<token>` directly without a session it's still the same old broken redirect. Out of scope here, easy follow-up if anyone hits it.
- 'Delete user from team' doesn't clean up `auth.users` — separate concern, separate fix.