### PR TITLE
fix(ci): add eslint check to web job in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   web:
-    name: web — format & typecheck
+    name: web — format, lint & typecheck
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -22,5 +22,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - name: Prettier format check
         run: yarn format:check
+      - name: ESLint
+        run: yarn lint
       - name: TypeScript typecheck
         run: yarn typecheck


### PR DESCRIPTION
Add ESLint linting step to the existing web job in .github/workflows/ci.yml. This ensures ESLint violations are caught on every PR and push to main, preventing lint errors from landing on the main branch.