### PR TITLE
fix(invite): mirror /auth/confirm under [locale]/(marketing) — next-intl rewrite was 404ing

### DIFF
--- a/web/src/app/[locale]/(marketing)/auth/confirm/route.ts
+++ b/web/src/app/[locale]/(marketing)/auth/confirm/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import type { EmailOtpType } from '@supabase/supabase-js';
+
+/**
+ * GET /auth/confirm — locale-prefixed mirror of the root route.
+ *
+ * next-intl middleware rewrites every `/auth/*` request to `/[locale]/auth/*`,
+ * so a root-only file at `/auth/confirm/route.ts` is never actually matched.
+ * This file is what serves the URL the user clicks in their invite mail
+ * (we keep the root sibling around to match the existing /auth/callback
+ * convention, even though the locale version is what handles requests).
+ *
+ * Server-side OTP verification using the Supabase recommended SSR pattern:
+ * read `token_hash` + `type` from the URL, call `verifyOtp` to set the
+ * cookie session, then 302 to `redirect_to` or `next` (or `/dashboard`).
+ */
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const tokenHash = searchParams.get('token_hash');
+  const type = searchParams.get('type') as EmailOtpType | null;
+  const rawRedirect = searchParams.get('redirect_to') ?? searchParams.get('next');
+  const redirectTarget = resolveRedirect(rawRedirect, origin);
+
+  if (!tokenHash || !type) {
+    return NextResponse.redirect(`${origin}/sign-in?error=auth_confirm_missing_params`);
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.verifyOtp({ type, token_hash: tokenHash });
+
+  if (error) {
+    return NextResponse.redirect(
+      `${origin}/sign-in?error=auth_confirm_failed&reason=${encodeURIComponent(error.message)}`,
+    );
+  }
+
+  return NextResponse.redirect(redirectTarget);
+}
+
+function resolveRedirect(value: string | null, origin: string): string {
+  if (!value) return `${origin}/dashboard`;
+  if (/^https?:\/\//i.test(value)) return value;
+  if (value.startsWith('/')) return `${origin}${value}`;
+  return `${origin}/dashboard`;
+}

--- a/web/src/app/auth/confirm/route.ts
+++ b/web/src/app/auth/confirm/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import type { EmailOtpType } from '@supabase/supabase-js';
+
+/**
+ * GET /auth/confirm — server-side OTP verification for email-driven auth flows.
+ *
+ * Supabase's default `{{ .ConfirmationURL }}` template variable points at
+ * `https://<project>.supabase.co/auth/v1/verify?token=...&redirect_to=...`,
+ * which returns the session in the URL hash fragment (`#access_token=...`).
+ * Hash fragments aren't visible to server components, so the session never
+ * makes it into our cookies — the user lands on the destination page
+ * still "signed out" from the server's perspective and bounces to /sign-up.
+ *
+ * The fix is the standard Supabase + Next.js SSR pattern: customize the
+ * email templates to point here with `{{ .TokenHash }}` + `{{ .Type }}`,
+ * verify the OTP server-side, set the session via the auth helper's
+ * cookie machinery, then 302 to the original destination.
+ *
+ * Expected template URL:
+ *   {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite&redirect_to={{ .RedirectTo }}
+ *
+ * Works for every email type Supabase ships — invite, signup, recovery,
+ * magiclink, email_change. The type comes from the template, not from us.
+ */
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const tokenHash = searchParams.get('token_hash');
+  const type = searchParams.get('type') as EmailOtpType | null;
+  const rawRedirect = searchParams.get('redirect_to') ?? searchParams.get('next');
+  const redirectTarget = resolveRedirect(rawRedirect, origin);
+
+  if (!tokenHash || !type) {
+    return NextResponse.redirect(`${origin}/sign-in?error=auth_confirm_missing_params`);
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.verifyOtp({ type, token_hash: tokenHash });
+
+  if (error) {
+    return NextResponse.redirect(
+      `${origin}/sign-in?error=auth_confirm_failed&reason=${encodeURIComponent(error.message)}`,
+    );
+  }
+
+  return NextResponse.redirect(redirectTarget);
+}
+
+/**
+ * Accept either a full URL (already absolute, e.g. when Supabase expands
+ * `{{ .RedirectTo }}` we pass during inviteUserByEmail) or a path; default
+ * to /dashboard if neither was provided.
+ */
+function resolveRedirect(value: string | null, origin: string): string {
+  if (!value) return `${origin}/dashboard`;
+  if (/^https?:\/\//i.test(value)) return value;
+  if (value.startsWith('/')) return `${origin}${value}`;
+  return `${origin}/dashboard`;
+}

--- a/web/src/lib/actions/team.ts
+++ b/web/src/lib/actions/team.ts
@@ -202,15 +202,11 @@ export async function inviteMember(email: string, role: TeamRole) {
 
   const token = randomBytes(32).toString('hex');
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  // Route the invite mail through /auth/callback first so Supabase's
-  // ?code= ends up at a route that calls exchangeCodeForSession() before
-  // the user lands on /invite/<token>. Without this hop the invite page
-  // server-renders without a session, falls into its `if (!user)` branch,
-  // and ejects the user to /sign-up — where signUp() trips on the
-  // existing auth.users row, no password is actually set, and the user
-  // gets bounced to /sign-in with credentials that don't work.
-  const inviteAcceptPath = `/invite/${token}`;
-  const inviteLink = `${appUrl}/auth/callback?next=${encodeURIComponent(inviteAcceptPath)}`;
+  // Plain destination URL. The actual auth verification happens inside
+  // /auth/confirm (called from the email link by the customized Invite
+  // User template) — once verifyOtp succeeds and the session cookie is
+  // written, the template's `redirect_to` value drops the user here.
+  const inviteLink = `${appUrl}/invite/${token}`;
 
   const { data: invitation, error: insertError } = await supabaseAdmin
     .from('invitations')

--- a/web/src/lib/actions/team.ts
+++ b/web/src/lib/actions/team.ts
@@ -202,11 +202,14 @@ export async function inviteMember(email: string, role: TeamRole) {
 
   const token = randomBytes(32).toString('hex');
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  // Plain destination URL. The actual auth verification happens inside
-  // /auth/confirm (called from the email link by the customized Invite
-  // User template) — once verifyOtp succeeds and the session cookie is
-  // written, the template's `redirect_to` value drops the user here.
-  const inviteLink = `${appUrl}/invite/${token}`;
+  // What we hand to Supabase as `redirectTo`. It becomes `{{ .RedirectTo }}`
+  // in the Invite User template, which we use as the *base* for the
+  // /auth/confirm URL — token_hash + type get appended in the template.
+  // The benefit: the prefix is whatever appUrl is for *this* environment
+  // (localhost when running `pnpm dev`, app.ansvisor.com in production),
+  // independent of Supabase's project-level Site URL. So a single template
+  // works for both dev and prod.
+  const inviteLink = `${appUrl}/auth/confirm?next=${encodeURIComponent(`/invite/${token}`)}`;
 
   const { data: invitation, error: insertError } = await supabaseAdmin
     .from('invitations')


### PR DESCRIPTION
## What

PR #129 added the new `/auth/confirm` route at the app-root level only:

```
web/src/app/auth/confirm/route.ts
```

After merge + deploy the route still returned 404. Diagnosed via response headers:

| Path | x-matched-path | x-vercel-cache | Status |
|---|---|---|---|
| `/auth/callback` | `/[locale]/auth/callback` | MISS | 307 ✓ |
| `/auth/confirm` | `/404` | HIT | 404 ✗ |
| `/en/auth/confirm` | (redirects to /auth/confirm) | — | 307 → 404 |

next-intl middleware rewrites `/auth/*` to `/[locale]/auth/*` for every request. `/auth/callback` works because there's already a [`[locale]/(marketing)/auth/callback/route.ts`](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/%5Blocale%5D/(marketing)/auth/callback/route.ts) for the rewrite to land on. We didn't have one for confirm.

## Scope

- New [`web/src/app/[locale]/(marketing)/auth/confirm/route.ts`](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/%5Blocale%5D/(marketing)/auth/confirm/route.ts) — same `verifyOtp({ type, token_hash })` logic as the root sibling, just at the path next-intl actually resolves to.
- Kept the root-level `/auth/confirm` file around to stay consistent with how the callback pair is shaped (root + locale, even though only locale is hit in practice).

## Test plan

1. Merge → wait for Vercel deploy
2. `curl -I https://app.ansvisor.com/auth/confirm` should now show `x-matched-path: /[locale]/auth/confirm` and a 302/307 (route runs, falls into the missing-params branch with no token_hash)
3. Update the Supabase Invite User email template to:
   `{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=invite`
4. Fresh invite → click → land on `/invite/<token>` signed in → set password → join → sign back in