### PR TITLE
chore(lint): clear the 8 existing ESLint errors so #128 can land

### DIFF
--- a/web/src/app/[locale]/invite/[token]/page.tsx
+++ b/web/src/app/[locale]/invite/[token]/page.tsx
@@ -21,6 +21,7 @@ export default async function InviteAcceptPage({
     return <InvalidInvitation reason={invitation.status} />;
   }
 
+  // eslint-disable-next-line react-hooks/purity -- server component renders fresh per request; Date.now() is the correct expiration check, the purity rule targets client-side memoization which doesn't apply on the server.
   if (new Date(invitation.expiresAt).getTime() < Date.now()) {
     return <InvalidInvitation reason="expired" />;
   }

--- a/web/src/components/layout/mobile-nav.tsx
+++ b/web/src/components/layout/mobile-nav.tsx
@@ -25,7 +25,13 @@ export function MobileNav() {
   const { activeBrandId } = useBrandStore();
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  // Hydration guard — see sidebar.tsx for the rationale; the two
+  // components mirror each other and can't share a hook without breaking
+  // their independent layout contexts.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
 
   const logoSrc = mounted && resolvedTheme === 'dark' ? '/logo_dark.svg' : '/logo_light.svg';
 

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -26,7 +26,14 @@ export function Sidebar() {
   const { canUse, requiredPlanFor, isCloud } = useFeatureGate();
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  // Hydration guard: SSR can't know the resolved theme, so we render the
+  // light logo first and swap after mount. This is the canonical Next.js
+  // pattern for "render client-only content after hydration" — there's no
+  // useEffect-free version that avoids the hydration mismatch.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
 
   const logoSrc = mounted && resolvedTheme === 'dark' ? '/logo_dark.svg' : '/logo_light.svg';
 

--- a/web/src/lib/mcp/data.ts
+++ b/web/src/lib/mcp/data.ts
@@ -398,7 +398,7 @@ export async function listContentOpportunitiesFor(
       prompt_id: string | null;
       created_at: string | null;
       updated_at: string | null;
-      brief: any | null;
+      brief: Record<string, unknown> | null;
       prompts: Array<{ text: string }> | { text: string } | null;
     }> | null) ?? [];
 
@@ -431,8 +431,8 @@ export interface ContentOpportunityDetail {
   status: string;
   prompt_id: string | null;
   prompt_text: string | null;
-  source_data: Record<string, any> | null;
-  brief: Record<string, any> | null;
+  source_data: Record<string, unknown> | null;
+  brief: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;
 }
@@ -540,8 +540,8 @@ export async function getContentOpportunityFor(
     prompt_id: string | null;
     created_at: string | null;
     updated_at: string | null;
-    source_data: any | null;
-    brief: any | null;
+    source_data: Record<string, unknown> | null;
+    brief: Record<string, unknown> | null;
     prompts: Array<{ text: string }> | { text: string } | null;
   };
 


### PR DESCRIPTION
## What

#128 (external contributor, thanks @ayobamiseun) adds `yarn lint` to the web CI job. As-is it would break every PR, because the codebase has 8 existing ESLint errors that the new step would catch. This PR clears them so #128 can merge without taking main red.

Verified locally: `yarn lint` exits 0 (11 warnings remain — unused imports etc. — out of scope, don't fail the build).

## Errors fixed

| File | Error | Fix |
|---|---|---|
| [`web/src/lib/mcp/data.ts`](https://github.com/ansvisor/ansvisor/blob/main/web/src/lib/mcp/data.ts) | 5× `@typescript-eslint/no-explicit-any` on JSON-shaped Supabase rows | Replace `any` with `Record<string, unknown>`. Mirrors the existing `GeneratedBrief.brief` typing right next to them. |
| [`web/src/components/layout/sidebar.tsx`](https://github.com/ansvisor/ansvisor/blob/main/web/src/components/layout/sidebar.tsx) | `react-hooks/set-state-in-effect` on hydration mount flag | Disable on the `setMounted(true)` line with a comment. Canonical Next.js theme-swap pattern — SSR can't know `resolvedTheme`, so we render the light logo first and swap after hydration. No useEffect-free version avoids the hydration mismatch. |
| [`web/src/components/layout/mobile-nav.tsx`](https://github.com/ansvisor/ansvisor/blob/main/web/src/components/layout/mobile-nav.tsx) | Same as sidebar | Same fix; the two components mirror each other. |
| [`web/src/app/[locale]/invite/[token]/page.tsx`](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/%5Blocale%5D/invite/%5Btoken%5D/page.tsx) | `react-hooks/purity` on `Date.now()` expiration check | Disable on that line with a comment. Server component renders fresh per request, the purity rule targets client-side memoization concerns that don't apply on the server. |

## Out of scope

- The 11 unused-import warnings. They don't fail the build; cleaning them is mechanical and doesn't belong in this PR.
- The (`@next/next/no-img-element`) warning on `ai-provider-avatar.tsx` — separate `next/image` migration, also doesn't fail the build.

## Merge sequence

1. This PR
2. #128 (CI lint step) — should now go green
3. Re-cut the 0.1.2 release (closed #132 lives at `release/0.1.2` branch, ready to reopen)