### PR TITLE
fix(agent): inject today's date into the system prompt

### DIFF
--- a/web/src/app/api/agent/chat/route.ts
+++ b/web/src/app/api/agent/chat/route.ts
@@ -3,7 +3,7 @@ import { convertToModelMessages, stepCountIs, streamText, type UIMessage } from 
 import { supabaseAdmin } from '@/lib/supabase/admin';
 import { resolveAgentAuth } from '@/lib/agent/auth';
 import { buildAgentTools } from '@/lib/agent/tools';
-import { AGENT_SYSTEM_PROMPT } from '@/lib/agent/system-prompt';
+import { buildAgentSystemPrompt } from '@/lib/agent/system-prompt';
 import { buildAgentModel } from '@/lib/agent/model';
 import { resolveAnthropicKey } from '@/lib/agent/key';
 import { recordAgentTokenUsage } from '@/lib/agent/token-quota';
@@ -95,7 +95,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: buildAgentModel(anthropicKey),
-    system: AGENT_SYSTEM_PROMPT,
+    system: buildAgentSystemPrompt(new Date()),
     messages: await convertToModelMessages(messages),
     tools: buildAgentTools(auth),
     // streamText is single-step by default in v6 — without an explicit

--- a/web/src/lib/agent/system-prompt.ts
+++ b/web/src/lib/agent/system-prompt.ts
@@ -11,10 +11,22 @@
  *     marketing standup
  *   - if the user doesn't name a brand, ask (single-line clarification)
  *   - acknowledge tool gaps explicitly rather than faking the answer
+ *
+ * The system prompt is built per-request so today's date can be
+ * interpolated. Without it the model falls back to its training-time
+ * notion of "now" — which is anywhere in 2024–2025 depending on the
+ * model snapshot — and passes the wrong date_from to the time-aware
+ * tools whenever the user says "today" / "this week" / "last 30 days".
  */
-export const AGENT_SYSTEM_PROMPT = `You are an Answer Engine Optimization (AEO) analyst working on the user's brand visibility inside AI search products (ChatGPT, Gemini, Perplexity, Claude, Copilot, Google AI Overview, Google AI Mode). You are running inside the Ansvisor dashboard as the in-product assistant.
+export function buildAgentSystemPrompt(now: Date): string {
+  const today = now.toISOString().slice(0, 10);
+  return `You are an Answer Engine Optimization (AEO) analyst working on the user's brand visibility inside AI search products (ChatGPT, Gemini, Perplexity, Claude, Copilot, Google AI Overview, Google AI Mode). You are running inside the Ansvisor dashboard as the in-product assistant.
 
 Your job is to turn raw visibility numbers into something the user can act on. A marketer asking "how are we doing?" does not want a JSON dump — they want a 30-second standup: where they stand, what changed, what to fix next.
+
+## Current context
+
+Today's date is **${today}** (UTC). When the user says "today" / "yesterday" / "this week" / "last 30 days" / "last month", compute the date range from this anchor and pass it as \`date_from\` (and \`date_to\` when relevant) to the time-aware tools. Never invent a different "now".
 
 ## Tools available
 
@@ -37,7 +49,7 @@ You have these tools, all scoped to the authenticated user's organization:
 4. **Lead with the headline.** Open with the single most important thing (visibility up/down, biggest competitor move, biggest content gap). Details follow.
 5. **Be concrete about what to do next.** End with one or two specific actions the user could take, not generic advice.
 6. **Acknowledge tool gaps.** If you'd want to answer a question but lack a tool for it (e.g., the user asks about something only an upcoming tool would expose), say what's missing rather than guessing.
-7. **Respect the user's window.** If they ask about "this week," pass an explicit date_from to the time-aware tools; don't fall back to all-time.
+7. **Respect the user's window.** If they ask about "this week," compute it from today's date (above) and pass an explicit \`date_from\` to the time-aware tools; don't fall back to all-time.
 
 ## Scoring reference
 
@@ -46,3 +58,4 @@ You have these tools, all scoped to the authenticated user's organization:
 - **Citations** are URLs AI engines explicitly link to. Owned citations (brand domains) are the strongest signal; news / review citations are next-best; social / forum are softer.
 
 Start by greeting briefly only on the first message in a conversation; on follow-ups, get straight to the answer.`;
+}


### PR DESCRIPTION
Closes #136.

## What

`AGENT_SYSTEM_PROMPT` is now a builder — `buildAgentSystemPrompt(now: Date)` — and the chat route calls it per turn with `new Date()`. The interpolated date lands in a new **Current context** section right after the persona block:

> Today's date is **YYYY-MM-DD** (UTC). When the user says 'today' / 'yesterday' / 'this week' / 'last 30 days' / 'last month', compute the date range from this anchor and pass it as `date_from` (and `date_to` when relevant) to the time-aware tools. Never invent a different 'now'.

## Why

The previous static prompt left the model to guess 'now' from its training data. `claude-sonnet-4-6` typically picked something in 2024–2025, so any window-based question (e.g. "what's today's best prompt?", "how did the trend look last week?") ended up running against a wrong `date_from`. Rule 7 in the prompt explicitly asked the model to respect the user's window, but without a real anchor it couldn't.

## Test plan

1. Start a new conversation, ask "what was the brand's trend over the last 7 days?"
2. Watch the `get_visibility_trend` tool call (expandable via the tool disclosure UI) — `date_from` should be ~7 days before today's actual date, not a 2024 / 2025 value
3. Repeat with "today" — should anchor on today

## Out of scope

- Timezone awareness. UTC is enough for v1 because the time-aware tools also bucket in UTC.
- MCP-server side (Claude Desktop / Cursor users) — separate system message there, separate fix if it ever needs the same treatment.
