### PR TITLE
fix(rbac/ui): gate Settings → Agent Save / Remove controls behind canAdmin

### DIFF
--- a/web/src/components/settings/agent-section.tsx
+++ b/web/src/components/settings/agent-section.tsx
@@ -8,7 +8,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Loader2, Sparkles, Trash2, CheckCircle2 } from 'lucide-react';
+import { Loader2, Lock, Sparkles, Trash2, CheckCircle2 } from 'lucide-react';
+import { useUserRole } from '@/hooks/use-user-role';
 
 interface KeyState {
   configured: boolean;
@@ -43,6 +44,7 @@ export function AgentSection() {
   const [input, setInput] = useState('');
   const [saving, setSaving] = useState(false);
   const [clearing, setClearing] = useState(false);
+  const { canAdmin } = useUserRole();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -152,55 +154,76 @@ export function AgentSection() {
           </p>
         )}
 
-        <div className="space-y-2">
-          <Label htmlFor="anthropic-key">{configured ? 'Replace key' : 'Anthropic API key'}</Label>
-          <div className="flex gap-2">
-            <Input
-              id="anthropic-key"
-              type="password"
-              autoComplete="off"
-              spellCheck={false}
-              placeholder="sk-ant-…"
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              disabled={saving}
-              className="font-mono"
-            />
-            <Button onClick={handleSave} disabled={saving || !input.trim()}>
-              {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {isReplacing ? 'Replace' : 'Save'}
-            </Button>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Get a key from{' '}
-            <a
-              href="https://console.anthropic.com/settings/keys"
-              target="_blank"
-              rel="noreferrer"
-              className="underline"
-            >
-              console.anthropic.com
-            </a>
-            . The key is encrypted at rest; Ansvisor support cannot read it.
-          </p>
-        </div>
+        {canAdmin ? (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="anthropic-key">
+                {configured ? 'Replace key' : 'Anthropic API key'}
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  id="anthropic-key"
+                  type="password"
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="sk-ant-…"
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  disabled={saving}
+                  className="font-mono"
+                />
+                <Button onClick={handleSave} disabled={saving || !input.trim()}>
+                  {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {isReplacing ? 'Replace' : 'Save'}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Get a key from{' '}
+                <a
+                  href="https://console.anthropic.com/settings/keys"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  console.anthropic.com
+                </a>
+                . The key is encrypted at rest; Ansvisor support cannot read it.
+              </p>
+            </div>
 
-        {configured && (
-          <div className="pt-2 border-t">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleClear}
-              disabled={clearing}
-              className="text-destructive hover:text-destructive"
-            >
-              {clearing ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Trash2 className="mr-2 h-4 w-4" />
-              )}
-              Remove key
-            </Button>
+            {configured && (
+              <div className="pt-2 border-t">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClear}
+                  disabled={clearing}
+                  className="text-destructive hover:text-destructive"
+                >
+                  {clearing ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="mr-2 h-4 w-4" />
+                  )}
+                  Remove key
+                </Button>
+              </div>
+            )}
+          </>
+        ) : (
+          // Server-side, `/api/settings/anthropic-key` PUT/DELETE already
+          // refuses non-admin role with a 403. The form here used to render
+          // anyway and any click ended in an unhelpful toast — replace it
+          // with an explicit read-only message so non-admins know why.
+          <div className="flex items-start gap-3 rounded-md border bg-muted/40 p-3 text-sm">
+            <Lock className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="font-medium">Admin-only setting</p>
+              <p className="mt-1 text-muted-foreground">
+                Only org admins can add, replace, or remove the Anthropic API key. Ask an admin if
+                you need it changed.
+              </p>
+            </div>
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
Closes #131.

## What

Same pattern as #141, smaller scope. The [`/api/settings/anthropic-key`](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/api/settings/anthropic-key/route.ts) PUT and DELETE handlers already enforce `role === 'admin'` (returning 403 for anyone else), but [`AgentSection`](https://github.com/ansvisor/ansvisor/blob/main/web/src/components/settings/agent-section.tsx) rendered the new-key Input, Save button, and Remove key button to every org member. Clicking any of them just produced an unhelpful toast from the catch.

This PR wraps that whole control surface in a single `canAdmin` branch using the [`useUserRole`](https://github.com/ansvisor/ansvisor/blob/main/web/src/hooks/use-user-role.ts) hook landed in #141. The GET endpoint stays member-readable (it only returns metadata — `configured`, `last4`, `set_at`, `set_by_email` — never the plaintext), so non-admins still see the same configured / unconfigured status block.

Non-admins now see:

> 🔒 **Admin-only setting** — Only org admins can add, replace, or remove the Anthropic API key. Ask an admin if you need it changed.

## Test plan

1. Sign in as admin → AgentSection behaves exactly as before: new-key input + Save + Remove button.
2. Sign in as manager / analyst / agency_partner → status block visible (read), no input, no buttons, just the 🔒 banner.

## Out of scope

Other write surfaces still using the same admin-or-manager RLS posture (`brand_domains`, `brand_platforms`, `content_opportunities`). Each becomes a small follow-up that reuses `useUserRole`.