### PR TITLE
fix(web): show role label instead of raw enum in Team settings selects

### DIFF
--- a/web/src/components/settings/team-section.tsx
+++ b/web/src/components/settings/team-section.tsx
@@ -270,6 +270,7 @@ function MemberRow({
 
       {canEdit ? (
         <Select
+          items={ROLE_OPTIONS}
           value={member.role}
           onValueChange={(v) => handleRoleChange(v as TeamRole)}
           disabled={pendingRole !== null}
@@ -499,6 +500,7 @@ function InviteDialog({ canInvite, onInvited }: { canInvite: boolean; onInvited:
             <div className="space-y-2">
               <Label htmlFor="invite-role">Role</Label>
               <Select
+                items={ROLE_OPTIONS}
                 value={role}
                 onValueChange={(v) => setRole(v as TeamRole)}
                 disabled={submitting}


### PR DESCRIPTION
## What & why

In **Settings -> Team**, the role `<Select>` displayed the raw enum value (e.g. `agency_partner`) instead of the human label (`Agency Partner`) after a selection — in both the existing-member role dropdown and the invite dialog.

Base UI's `<Select.Value />` renders the raw value unless the `items` map is provided on `<Select.Root>`. This passes the existing `ROLE_OPTIONS` array as `items` to both selects, so the human-readable label is shown.

Closes #145.

## How to test

1. Go to **Settings -> Team**.
2. Change an existing member's role via the dropdown — the control now shows e.g. **Agency Partner** instead of `agency_partner`.
3. Open the **Invite** dialog and pick a role — same: the label is shown.

## Notes

- Minimal change: reuses the existing `ROLE_OPTIONS` (single source of truth), adds no new strings, and leaves `SelectValue` untouched.
- Verified locally: `prettier --check`, `eslint`, and `tsc --noEmit` all pass.
