### PR TITLE
fix(team): display role labels in selects

### DIFF
--- a/web/src/components/settings/team-section.tsx
+++ b/web/src/components/settings/team-section.tsx
@@ -275,7 +275,13 @@ function MemberRow({
           disabled={pendingRole !== null}
         >
           <SelectTrigger size="sm" className="w-36">
-            {pendingRole ? <Loader2 className="h-3 w-3 animate-spin" /> : <SelectValue />}
+            {pendingRole ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <SelectValue>
+                {(value) => (value ? roleLabel(value as TeamRole) : 'Select role')}
+              </SelectValue>
+            )}
           </SelectTrigger>
           <SelectContent>
             {ROLE_OPTIONS.map((opt) => (
@@ -504,7 +510,9 @@ function InviteDialog({ canInvite, onInvited }: { canInvite: boolean; onInvited:
                 disabled={submitting}
               >
                 <SelectTrigger className="w-full">
-                  <SelectValue />
+                  <SelectValue>
+                    {(value) => (value ? roleLabel(value as TeamRole) : 'Select role')}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {ROLE_OPTIONS.map((opt) => (


### PR DESCRIPTION
## Summary

- render role labels instead of raw enum values in team role selects
- apply the fix to the member role dropdown
- apply the fix to the invite member dialog role dropdown

## Testing

- changed a member role to Agency Partner and verified the trigger displays "Agency Partner"
- selected Agency Partner in the invite dialog and verified the trigger displays "Agency Partner"
- verified the role update loading spinner still appears while updates are in flight

## Screenshot
<img width="512" height="289" alt="Screenshot 2026-06-02 at 18-07-15 Ansvisor" src="https://github.com/user-attachments/assets/b3d85cb6-492e-40e4-b80e-64f4ae4d5249" />



Closes #145