### PR TITLE
ux(brands): slim brand list card to nav-menu shape (#154)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -431,7 +431,9 @@
       "citations": "Citations",
       "domainsTracked": "Domains Tracked",
       "manage": "Manage",
-      "viewInsights": "View Insights"
+      "viewInsights": "View Insights",
+      "addTopic": "Add Topics",
+      "addPrompt": "Add Prompts"
     }
   },
   "plans": {

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -502,7 +502,7 @@ export default function PromptsPage() {
       {canManage && (
         <div className="grid gap-4 md:grid-cols-2">
           {/* Manual Add */}
-          <Card>
+          <Card id="add-prompt" className="scroll-mt-24">
             <CardHeader className="pb-3">
               <CardTitle className="flex items-center gap-2 text-base">
                 <Plus className="h-4 w-4" />

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
@@ -247,7 +247,7 @@ export default function BrandTopicsPage({ params }: PageProps) {
               <>
                 <Separator />
 
-                <div className="space-y-2">
+                <div id="add-topic" className="space-y-2 scroll-mt-24">
                   <Label className="text-sm font-medium">Add Topic</Label>
                   <div className="flex gap-2">
                     <Input

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/_brands-client.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/_brands-client.tsx
@@ -7,15 +7,13 @@ import { useBrandStore } from '@/stores/use-brand-store';
 import { BrandCard } from '@/components/dashboard/brand-card';
 import { Button } from '@/components/ui/button';
 import type { Brand } from '@/types';
-import type { BrandCardSummary } from '@/lib/actions/brand';
 import { Building2, Plus } from 'lucide-react';
 
 interface BrandsClientProps {
   brands: Brand[];
-  summaries: Record<string, BrandCardSummary>;
 }
 
-export function BrandsClient({ brands, summaries }: BrandsClientProps) {
+export function BrandsClient({ brands }: BrandsClientProps) {
   const { setBrands } = useBrandStore();
 
   useEffect(() => {
@@ -29,7 +27,7 @@ export function BrandsClient({ brands, summaries }: BrandsClientProps) {
   return (
     <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
       {brands.map((brand) => (
-        <BrandCard key={brand.id} brand={brand} summary={summaries[brand.id]} />
+        <BrandCard key={brand.id} brand={brand} />
       ))}
     </div>
   );

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/server';
-import { getBrands, getBrandsCardSummary } from '@/lib/actions/brand';
+import { getBrands } from '@/lib/actions/brand';
 import { getPlan, isCloud as checkIsCloud } from '@/config/plans';
 import { BrandsClient } from './_brands-client';
 import { Button } from '@/components/ui/button';
@@ -64,12 +64,10 @@ export default async function BrandsPage() {
   const canAddBrand = maxBrands === -1 || brands.length < maxBrands;
   const needsUpgrade = !canAddBrand && checkIsCloud();
 
-  const summaries = await getBrandsCardSummary(brands.map((b) => b.id));
-
   return (
     <div className="space-y-6">
       <BrandsHeader canAddBrand={canAddBrand} needsUpgrade={needsUpgrade} />
-      <BrandsClient brands={brands} summaries={summaries} />
+      <BrandsClient brands={brands} />
     </div>
   );
 }

--- a/web/src/components/dashboard/brand-card.tsx
+++ b/web/src/components/dashboard/brand-card.tsx
@@ -1,135 +1,21 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { Link, useRouter } from '@/i18n/navigation';
+import { Link } from '@/i18n/navigation';
 import { useBrandStore } from '@/stores/use-brand-store';
 import type { Brand } from '@/types';
-import type { BrandCardSummary } from '@/lib/actions/brand';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import {
-  ArrowUpRight,
-  BarChart3,
-  CheckCircle2,
-  Globe,
-  MessageSquareText,
-  MoreHorizontal,
-  Settings,
-  Sparkles,
-  Tag,
-  TrendingDown,
-  TrendingUp,
-} from 'lucide-react';
+import { ChevronRight, Globe, MessageSquareText, Plus, Settings, Tag } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface BrandCardProps {
   brand: Brand;
-  summary?: BrandCardSummary;
 }
 
-const GRADIENTS = [
-  'from-indigo-500/30 via-purple-500/20 to-fuchsia-500/10',
-  'from-sky-500/30 via-cyan-500/20 to-emerald-500/10',
-  'from-rose-500/30 via-pink-500/20 to-amber-500/10',
-  'from-violet-500/30 via-indigo-500/20 to-blue-500/10',
-  'from-emerald-500/30 via-teal-500/20 to-cyan-500/10',
-  'from-amber-500/30 via-orange-500/20 to-rose-500/10',
-  'from-fuchsia-500/30 via-purple-500/20 to-indigo-500/10',
-  'from-blue-500/30 via-sky-500/20 to-teal-500/10',
-];
-
-function pickGradient(seed: string): string {
-  let hash = 0;
-  for (let i = 0; i < seed.length; i++) {
-    hash = (hash * 31 + seed.charCodeAt(i)) | 0;
-  }
-  return GRADIENTS[Math.abs(hash) % GRADIENTS.length];
-}
-
-function Sparkline({ data, positive }: { data: number[]; positive: boolean }) {
-  if (!data.length || data.every((v) => v === 0)) {
-    return (
-      <svg viewBox="0 0 100 28" className="h-7 w-full opacity-30">
-        <line
-          x1="0"
-          y1="14"
-          x2="100"
-          y2="14"
-          stroke="currentColor"
-          strokeWidth="1"
-          strokeDasharray="2 3"
-        />
-      </svg>
-    );
-  }
-  const max = Math.max(...data, 1);
-  const min = Math.min(...data, 0);
-  const range = Math.max(max - min, 1);
-  const points = data
-    .map((v, i) => {
-      const x = (i / (data.length - 1)) * 100;
-      const y = 26 - ((v - min) / range) * 22;
-      return `${x.toFixed(2)},${y.toFixed(2)}`;
-    })
-    .join(' ');
-  const stroke = positive ? '#10b981' : '#ef4444';
-  return (
-    <svg viewBox="0 0 100 28" className="h-7 w-full" preserveAspectRatio="none">
-      <polyline
-        fill="none"
-        stroke={stroke}
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        points={points}
-      />
-    </svg>
-  );
-}
-
-function StatusPill({ status }: { status: BrandCardSummary['status'] }) {
-  const config = {
-    healthy: {
-      label: 'Tracking',
-      color: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
-      icon: CheckCircle2,
-    },
-    declining: {
-      label: 'Needs attention',
-      color: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400',
-      icon: TrendingDown,
-    },
-    'no-prompts': {
-      label: 'No prompts yet',
-      color: 'border-zinc-500/30 bg-zinc-500/10 text-zinc-600 dark:text-zinc-400',
-      icon: MessageSquareText,
-    },
-    'no-data': {
-      label: 'Awaiting data',
-      color: 'border-blue-500/30 bg-blue-500/10 text-blue-600 dark:text-blue-400',
-      icon: Sparkles,
-    },
-  } as const;
-  const c = config[status];
-  return (
-    <Badge variant="outline" className={cn('gap-1 text-[10px]', c.color)}>
-      <c.icon className="h-2.5 w-2.5" />
-      {c.label}
-    </Badge>
-  );
-}
-
-export function BrandCard({ brand, summary }: BrandCardProps) {
-  const t = useTranslations('brands');
-  const router = useRouter();
+export function BrandCard({ brand }: BrandCardProps) {
+  const tNav = useTranslations('nav');
+  const tCard = useTranslations('brands.card');
   const { activeBrandId, setActiveBrand } = useBrandStore();
   const isActive = brand.id === activeBrandId;
 
@@ -141,166 +27,105 @@ export function BrandCard({ brand, summary }: BrandCardProps) {
     .slice(0, 2);
 
   const primaryDomain = brand.domains.find((d) => d.isPrimary);
-  const gradient = pickGradient(brand.id);
 
-  const visibility = summary?.visibility7d ?? 0;
-  const delta = summary?.visibilityDelta ?? 0;
-  const mentions = summary?.mentions7d ?? 0;
-  const prompts = summary?.promptCount ?? 0;
-  const trafficVisits = summary?.trafficVisits7d ?? 0;
-  const trend = summary?.trend ?? [];
-  const status = summary?.status ?? 'no-prompts';
-  const trendPositive = delta >= 0;
-
-  const handleSelectAndGo = (path: string) => {
-    setActiveBrand(brand.id);
-    router.push(path);
-  };
+  const select = () => setActiveBrand(brand.id);
 
   return (
     <div
       className={cn(
-        'group relative overflow-hidden rounded-xl border bg-card transition-all',
-        'hover:border-primary/40 hover:shadow-lg hover:-translate-y-0.5',
+        'overflow-hidden rounded-xl border bg-card transition-all',
+        'hover:border-primary/40 hover:shadow-sm',
         isActive && 'ring-2 ring-primary border-primary/60',
       )}
     >
-      {/* Hero gradient backdrop */}
-      <div className={cn('relative h-28 bg-gradient-to-br px-5 pt-5', gradient)}>
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(255,255,255,0.15),_transparent_60%)]" />
-        <div className="relative flex items-start justify-between gap-3">
-          <Avatar className="h-14 w-14 rounded-xl ring-4 ring-background shadow-md bg-zinc-50 dark:bg-zinc-100">
-            <AvatarImage src={brand.logoUrl} alt={brand.name} className="object-contain p-1.5" />
-            <AvatarFallback className="rounded-xl bg-background text-foreground text-base font-bold">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
-          <div className="flex items-center gap-1.5">
+      <div className="flex items-start gap-3 px-4 py-3.5">
+        <Avatar className="h-10 w-10 rounded-lg bg-zinc-50 dark:bg-zinc-100">
+          <AvatarImage src={brand.logoUrl} alt={brand.name} className="object-contain p-1" />
+          <AvatarFallback className="rounded-lg bg-background text-foreground text-sm font-bold">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate font-semibold leading-tight">{brand.name}</h3>
             {isActive && (
               <Badge
                 variant="secondary"
-                className="gap-1 border-primary/30 bg-primary/15 text-primary text-[10px]"
+                className="gap-1 border-primary/30 bg-primary/15 text-[10px] text-primary"
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-primary" />
                 Active
               </Badge>
             )}
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 bg-background/40 backdrop-blur hover:bg-background/70"
-                  >
-                    <MoreHorizontal className="h-3.5 w-3.5" />
-                  </Button>
-                }
-              />
-              <DropdownMenuContent align="end" className="w-44">
-                <DropdownMenuItem render={<Link href={`/dashboard/brands/${brand.id}/prompts`} />}>
-                  <MessageSquareText className="h-3.5 w-3.5 mr-2" />
-                  Prompts
-                </DropdownMenuItem>
-                <DropdownMenuItem render={<Link href={`/dashboard/brands/${brand.id}/topics`} />}>
-                  <Tag className="h-3.5 w-3.5 mr-2" />
-                  Topics
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem render={<Link href={`/dashboard/brands/${brand.id}/settings`} />}>
-                  <Settings className="h-3.5 w-3.5 mr-2" />
-                  Settings
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
           </div>
+          {primaryDomain && (
+            <p className="mt-0.5 flex items-center gap-1 truncate text-xs text-muted-foreground">
+              <Globe className="h-3 w-3 shrink-0" />
+              {primaryDomain.domain}
+            </p>
+          )}
         </div>
       </div>
 
-      {/* Body */}
-      <div className="px-5 pt-3 pb-4 space-y-4">
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0 flex-1">
-            <h3 className="font-semibold text-base leading-tight truncate">{brand.name}</h3>
-            {primaryDomain && (
-              <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground truncate">
-                <Globe className="h-3 w-3 shrink-0" />
-                {primaryDomain.domain}
-              </p>
-            )}
-          </div>
-          <StatusPill status={status} />
-        </div>
+      <div className="border-t">
+        <NavRow
+          icon={Tag}
+          label={tCard('addTopic')}
+          href={`/dashboard/brands/${brand.id}/topics`}
+          addHref={`/dashboard/brands/${brand.id}/topics#add-topic`}
+          addLabel={tCard('addTopic')}
+          onSelect={select}
+        />
+        <NavRow
+          icon={MessageSquareText}
+          label={tCard('addPrompt')}
+          href={`/dashboard/brands/${brand.id}/prompts`}
+          addHref={`/dashboard/brands/${brand.id}/prompts#add-prompt`}
+          addLabel={tCard('addPrompt')}
+          onSelect={select}
+        />
+        <NavRow
+          icon={Settings}
+          label={tNav('settings')}
+          href={`/dashboard/brands/${brand.id}/settings`}
+          onSelect={select}
+        />
+      </div>
+    </div>
+  );
+}
 
-        {/* Visibility hero metric */}
-        <div className="rounded-lg border bg-muted/30 p-3">
-          <div className="flex items-end justify-between gap-3">
-            <div>
-              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                Visibility · 7d
-              </p>
-              <div className="flex items-baseline gap-2 mt-0.5">
-                <span className="text-2xl font-bold tabular-nums">
-                  {visibility}
-                  <span className="text-base font-medium text-muted-foreground">%</span>
-                </span>
-                {summary && summary.visibilityDelta !== 0 && (
-                  <span
-                    className={cn(
-                      'flex items-center gap-0.5 text-xs font-medium tabular-nums',
-                      trendPositive ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500',
-                    )}
-                  >
-                    {trendPositive ? (
-                      <TrendingUp className="h-3 w-3" />
-                    ) : (
-                      <TrendingDown className="h-3 w-3" />
-                    )}
-                    {trendPositive ? '+' : ''}
-                    {delta}%
-                  </span>
-                )}
-              </div>
-            </div>
-            <div className="flex-1 max-w-[100px] text-emerald-500">
-              <Sparkline data={trend} positive={trendPositive} />
-            </div>
-          </div>
-        </div>
+interface NavRowProps {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  href: string;
+  addHref?: string;
+  addLabel?: string;
+  onSelect: () => void;
+}
 
-        {/* Compact stat strip */}
-        <div className="grid grid-cols-3 gap-2 text-center">
-          <div className="rounded-md border bg-card px-2 py-1.5">
-            <p className="text-base font-semibold tabular-nums leading-none">{prompts}</p>
-            <p className="mt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-              Prompts
-            </p>
-          </div>
-          <div className="rounded-md border bg-card px-2 py-1.5">
-            <p className="text-base font-semibold tabular-nums leading-none">{mentions}</p>
-            <p className="mt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-              Mentions
-            </p>
-          </div>
-          <div className="rounded-md border bg-card px-2 py-1.5">
-            <p className="text-base font-semibold tabular-nums leading-none">
-              {trafficVisits >= 1000 ? `${(trafficVisits / 1000).toFixed(1)}k` : trafficVisits}
-            </p>
-            <p className="mt-1 text-[10px] uppercase tracking-wide text-muted-foreground">Visits</p>
-          </div>
-        </div>
-
-        {/* CTA */}
-        <Button
-          size="sm"
-          className="w-full gap-1.5"
-          onClick={() => handleSelectAndGo('/dashboard/insights')}
+function NavRow({ icon: Icon, label, href, addHref, addLabel, onSelect }: NavRowProps) {
+  return (
+    <div className="flex items-center border-t text-sm first:border-t-0 hover:bg-muted/50">
+      <Link href={href} onClick={onSelect} className="flex flex-1 items-center gap-3 px-4 py-2.5">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+        <span className="font-medium">{label}</span>
+      </Link>
+      {addHref && addLabel ? (
+        <Link
+          href={addHref}
+          onClick={onSelect}
+          aria-label={addLabel}
+          title={addLabel}
+          className="flex items-center px-4 py-2.5 text-muted-foreground hover:text-foreground"
         >
-          <BarChart3 className="h-3.5 w-3.5" />
-          {t('card.viewInsights')}
-          <ArrowUpRight className="h-3.5 w-3.5 ml-auto" />
-        </Button>
-      </div>
+          <Plus className="h-4 w-4" />
+        </Link>
+      ) : (
+        <div className="px-4 py-2.5 text-muted-foreground">
+          <ChevronRight className="h-4 w-4" />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #154.

## Summary

- Strips the `/dashboard/brands` card down to **avatar + name + primary domain** plus three full-width nav rows: **Add Topics**, **Add Prompts**, **Settings**.
- Each row uses a real `<Link>` (so middle-click → new tab works) and calls `setActiveBrand` on click.
- Topics and Prompts rows expose a trailing `+` button that jumps to the destination page's add form via the new `#add-topic` / `#add-prompt` anchors. Settings keeps the chevron — it has no quick-add equivalent.
- Drops the gradient cover, visibility hero, sparkline, 3-stat strip, View Insights CTA, StatusPill, and the more-menu dropdown. The Insights page is one click away in the sidebar and is the right home for that detail.
- `getBrandsCardSummary` call removed from the brands list page since `BrandCard` no longer consumes it. The action itself stays in `brand.ts` per the issue's "leave the action in place" note.
- Card height drops ~50% per the issue, grid layout unchanged.

## Acceptance criteria

- [x] Cards render only avatar, name, domain, three nav rows
- [x] Each nav row navigates AND sets the brand as active in the store
- [x] Active brand still shows the `ring-2 ring-primary` outline
- [x] No more colored cover / sparkline / 3-stat strip / View Insights button
- [x] `yarn tsc --noEmit` + `yarn lint` clean
- [x] `summary` prop dropped from `BrandCardProps`, `getBrandsCardSummary` call removed from the list page

## Test plan

- [ ] `/dashboard/brands` shows the slim cards with hover + active-ring states intact
- [ ] Click "Add Topics" row → lands on `/dashboard/brands/<id>/topics` with that brand active in the store
- [ ] Click the `+` next to "Add Topics" → lands on the same page scrolled to the Add Topic input
- [ ] Same for Add Prompts / `+`
- [ ] Click Settings row → lands on `/dashboard/brands/<id>/settings`