### PR TITLE
fix(web): keep ChatGPT avatar visible in light mode

### DIFF
--- a/web/src/components/ai-provider-avatar.tsx
+++ b/web/src/components/ai-provider-avatar.tsx
@@ -160,7 +160,8 @@ export function AIProviderAvatar({
       title={meta.label}
       aria-label={meta.label}
       className={cn(
-        'relative flex h-5 w-5 shrink-0 overflow-hidden rounded-full border bg-background',
+        'relative flex h-5 w-5 shrink-0 overflow-hidden rounded-full border',
+        provider === 'openai' ? 'bg-black dark:bg-background' : 'bg-background',
         className,
       )}
     >


### PR DESCRIPTION
## What changed

Fixes the ChatGPT/OpenAI provider avatar contrast in light mode by giving only the OpenAI icon wrapper a dark light-mode surface. Other provider icons keep the existing `bg-background` wrapper, so their rendering path is unchanged.

The issue comes from `/chatgpt.svg` using a white fill while `bg-background` is also white in light mode. The component now uses `bg-black dark:bg-background` when `provider === 'openai'`, matching the issue's smallest proposed fix without changing the SVG asset or every provider avatar.

## Verification

- `npm run version:check`
- `corepack yarn install --frozen-lockfile`
- `corepack yarn lint` (passes with existing warnings)
- `corepack yarn typecheck`
- `corepack yarn format:check`
- `git diff --check`

Closes #158
