### PR TITLE
feat: add "Own domain only" filter for citations isolation

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -827,10 +827,10 @@ export default function CitationsPage() {
     if (!activeBrandId) return;
     getTopics(activeBrandId)
       .then(setTopics)
-      .catch(() => { });
+      .catch(() => {});
     getBrandPrompts(activeBrandId)
       .then((rows) => setPrompts(rows.map((r) => ({ id: r.id, text: r.text }))))
-      .catch(() => { });
+      .catch(() => {});
   }, [activeBrandId]);
 
   const loadData = useCallback(async () => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -156,6 +156,7 @@ interface UIFilters {
   prompt: string;
   excludeOwnDomain: boolean;
   competitorOnly: boolean;
+  ownOnly: boolean;
 }
 
 interface PromptOption {
@@ -185,6 +186,7 @@ const DEFAULT_FILTERS: UIFilters = {
   prompt: '',
   excludeOwnDomain: false,
   competitorOnly: false,
+  ownOnly: false,
 };
 
 function buildPlatformOptions(rows: CitationsOverview['rows']): PlatformOption[] {
@@ -589,7 +591,12 @@ function FilterBar({
           variant={filters.excludeOwnDomain ? 'default' : 'outline'}
           size="sm"
           className="h-8 text-xs"
-          onClick={() => onChange({ excludeOwnDomain: !filters.excludeOwnDomain })}
+          onClick={() =>
+            onChange({
+              excludeOwnDomain: !filters.excludeOwnDomain,
+              ownOnly: false,
+            })
+          }
         >
           Exclude own domain
         </Button>
@@ -602,10 +609,26 @@ function FilterBar({
             onChange({
               competitorOnly: !filters.competitorOnly,
               excludeOwnDomain: !filters.competitorOnly ? true : filters.excludeOwnDomain,
+              ownOnly: false,
             })
           }
         >
           Competitors only
+        </Button>
+        <Button
+          type="button"
+          variant={filters.ownOnly ? 'default' : 'outline'}
+          size="sm"
+          className="h-8 text-xs"
+          onClick={() =>
+            onChange({
+              ownOnly: !filters.ownOnly,
+              excludeOwnDomain: false,
+              competitorOnly: false,
+            })
+          }
+        >
+          Own domain only
         </Button>
       </div>
     </div>
@@ -804,10 +827,10 @@ export default function CitationsPage() {
     if (!activeBrandId) return;
     getTopics(activeBrandId)
       .then(setTopics)
-      .catch(() => {});
+      .catch(() => { });
     getBrandPrompts(activeBrandId)
       .then((rows) => setPrompts(rows.map((r) => ({ id: r.id, text: r.text }))))
-      .catch(() => {});
+      .catch(() => { });
   }, [activeBrandId]);
 
   const loadData = useCallback(async () => {
@@ -831,6 +854,7 @@ export default function CitationsPage() {
         promptIds: filters.prompt ? [filters.prompt] : undefined,
         excludeOwnDomain: filters.excludeOwnDomain,
         competitorOnly: filters.competitorOnly,
+        ownOnly: filters.ownOnly,
       };
       const overview = await getCitationsOverview(activeBrandId, apiFilters);
       setData(overview);
@@ -866,6 +890,7 @@ export default function CitationsPage() {
     filters.prompt,
     filters.excludeOwnDomain,
     filters.competitorOnly,
+    filters.ownOnly,
   ]);
 
   useEffect(() => {

--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -26,6 +26,7 @@ export interface CitationsFilters {
   regions?: string[];
   excludeOwnDomain?: boolean;
   competitorOnly?: boolean;
+  ownOnly?: boolean;
 }
 
 export interface CitationArticleTypeCount {
@@ -240,6 +241,7 @@ export async function getCitationsOverview(
       const category = classifyDomain(host, classifyCtx);
       if (filters.excludeOwnDomain && category === 'you') continue;
       if (filters.competitorOnly && category !== 'competitor') continue;
+      if (filters.ownOnly && category !== 'you') continue;
 
       totalCitations += 1;
 


### PR DESCRIPTION
Introduces a new **"Own domain only"** filter on the Citations page to let users isolate search citation results belonging specifically to their own tracked domain. Activating the toggle filters both the lists and charts to show only `category = 'you'` citations, and disables the other domain-related toggles to maintain mutual exclusivity.

Closes #149 
