### PR TITLE
ux(sidebar): tighten nav item density (#159)

### DIFF
--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -122,7 +122,7 @@ export function Sidebar() {
                     <span
                       key={item.href}
                       className={cn(
-                        'flex cursor-not-allowed items-center gap-3 rounded-md px-2 py-2 text-sm font-medium text-muted-foreground/50',
+                        'flex cursor-not-allowed items-center gap-3 rounded-md px-2 py-1.5 text-[13px] font-medium text-muted-foreground/50',
                         isCollapsed && 'justify-center',
                       )}
                       title={
@@ -155,7 +155,7 @@ export function Sidebar() {
                   <Link key={item.href} href={item.href}>
                     <span
                       className={cn(
-                        'flex items-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors',
+                        'flex items-center gap-3 rounded-md px-2 py-1.5 text-[13px] font-medium transition-colors',
                         isActive
                           ? 'bg-primary/10 text-primary'
                           : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',


### PR DESCRIPTION
Closes #159.

## Summary

- Both nav-item class strings in [`web/src/components/layout/sidebar.tsx`](https://github.com/ansvisor/ansvisor/blob/main/web/src/components/layout/sidebar.tsx) drop from `text-sm py-2` to `text-[13px] py-1.5` — the locked (plan-gated) span and the regular `Link` span.
- Group section headers, brand switcher, user-profile row, and collapse toggle untouched.

## Test plan

- [x] Nav rows render at 13px with `py-1.5` in both regular and plan-locked states.
- [x] Active highlight, hover state, and icon alignment look correct.
- [x] Collapsed sidebar (icon-only) layout is unaffected.