### PR TITLE
ux(sidebar): drop the redundant Settings nav entry

### DIFF
--- a/web/src/config/dashboard.ts
+++ b/web/src/config/dashboard.ts
@@ -5,7 +5,6 @@ import {
   Globe,
   LineChart,
   Quote,
-  Settings,
   ShoppingBag,
   Sparkles,
   Tag,
@@ -107,16 +106,6 @@ export const dashboardNav: NavGroup[] = [
         href: '/dashboard/content',
         icon: FileText,
         requiredFeature: 'content_optimization',
-      },
-    ],
-  },
-  {
-    title: 'System',
-    items: [
-      {
-        title: 'Settings',
-        href: '/dashboard/settings',
-        icon: Settings,
       },
     ],
   },


### PR DESCRIPTION
## Summary

The sidebar exposed `/dashboard/settings` through two affordances on the same surface: the **System → Settings** nav item *and* the user-profile row at the bottom (which already links to settings). This removes the duplicate nav row.

Closes #161.

## Changes

- **`web/src/config/dashboard.ts`** — drop the entire `System` group from `dashboardNav` and remove the now-unused `Settings` import from the lucide-react block.

Mobile nav reads the same `dashboardNav` config, so it inherits the change for free. `navKeyMap` in `sidebar.tsx` keeps its harmless unused `Settings` key (keyed off item titles that still exist).

## Acceptance criteria

- [x] Sidebar no longer renders a Settings row in the main nav (desktop + mobile)
- [x] Profile row at the bottom still navigates to `/dashboard/settings`
- [x] The Settings page itself is unaffected
- [x] `tsc --noEmit` + `eslint` clean

## Out of scope

Reworking the profile-row affordance / collapse toggle / other sidebar entries; renaming the Settings route.

Made with [Cursor](https://cursor.com)