### PR TITLE
ux(sidebar): move the collapse toggle above the profile row + restyle

### DIFF
--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -17,7 +17,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import { BrandSwitcher } from '@/components/layout/brand-switcher';
 import { UserProfileNavItem } from '@/components/layout/user-profile-nav-item';
-import { Crown, Lock, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { ChevronsLeft, ChevronsRight, Crown, Lock } from 'lucide-react';
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -174,18 +174,25 @@ export function Sidebar() {
         ))}
       </ScrollArea>
 
-      <div className="border-t p-2">
-        <UserProfileNavItem collapsed={isCollapsed} />
+      <div className="p-2">
+        <Button
+          variant="ghost"
+          onClick={toggleCollapse}
+          className={cn(
+            'flex h-9 w-full items-center gap-2 px-2',
+            isCollapsed ? 'justify-center' : 'justify-start',
+          )}
+        >
+          {isCollapsed ? (
+            <ChevronsRight className="h-4 w-4" />
+          ) : (
+            <ChevronsLeft className="h-4 w-4" />
+          )}
+        </Button>
       </div>
 
       <div className="border-t p-2">
-        <Button variant="ghost" size="icon" className="mt-1 w-full" onClick={toggleCollapse}>
-          {isCollapsed ? (
-            <PanelLeftOpen className="h-4 w-4" />
-          ) : (
-            <PanelLeftClose className="h-4 w-4" />
-          )}
-        </Button>
+        <UserProfileNavItem collapsed={isCollapsed} />
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary

The sidebar collapse toggle was the bottom-most element (below the user-profile row) and styled as a bordered, full-width, centered icon button — reading as a third nav surface rather than a small utility. This moves it above the profile row and restyles it to blend into the nav stack.

Closes #163.

## Changes

In `web/src/components/layout/sidebar.tsx`:

- **Order** — collapse-toggle container now sits *above* the user-profile container (the profile row is the natural footer).
- **Border** — dropped `border-t` on the toggle container (`border-t p-2` → `p-2`); the profile row keeps its `border-t`, giving the footer a single seam in the right place.
- **Style** — regular `ghost` button, `h-9 w-full` with `justify-start` expanded / `justify-center` collapsed, matching the nav rows' height + horizontal rhythm.
- **Icons** — `PanelLeftClose` / `PanelLeftOpen` → `ChevronsLeft` / `ChevronsRight`; import block updated.

The store action (`toggleCollapse`) is unchanged.

## Acceptance criteria

- [x] Collapse toggle renders above the user-profile row (expanded + collapsed)
- [x] No top border on the toggle container; profile row keeps its `border-t`
- [x] Expanded: chevron left-aligned; collapsed: centered
- [x] Clicking toggles collapse exactly as before (store action unchanged)
- [x] `tsc --noEmit` + `eslint` clean

## Out of scope

Hiding the toggle on mobile / reworking mobile nav; persisting collapse state anywhere new; reworking the user-profile row.

Made with [Cursor](https://cursor.com)