### PR TITLE
fix(web): show platform insight totals

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -988,11 +988,11 @@ function PlatformSubGroup({
         <div className="flex items-center gap-4 shrink-0">
           <div className="hidden sm:block text-right">
             <p className="text-[10px] text-muted-foreground">Mentions</p>
-            <p className="text-xs font-semibold tabular-nums">{latest.mentionCount}</p>
+            <p className="text-xs font-semibold tabular-nums">{group.totalMentions}</p>
           </div>
           <div className="hidden sm:block text-right">
             <p className="text-[10px] text-muted-foreground">Citations</p>
-            <p className="text-xs font-semibold tabular-nums">{latest.citationCount}</p>
+            <p className="text-xs font-semibold tabular-nums">{group.totalCitations}</p>
           </div>
           <SentimentBadge sentiment={latest.sentiment} />
           <div className="w-[100px] sm:w-[140px]">


### PR DESCRIPTION
Fixes #169.

This updates the platform rows under `/dashboard/insights` so Mentions and Citations use the existing platform totals instead of the latest run counts. That keeps the platform row consistent with the topic and prompt rows above it when an older run has mentions/citations but the latest rerun is zero.

The expanded "Previous runs" table still renders each run's own counts, and the visibility bar still uses the latest run snapshot.

Verification:
- `corepack yarn install --frozen-lockfile`
- `corepack yarn --cwd web lint` (0 errors, 11 existing warnings)
- `corepack yarn --cwd web typecheck`
- `corepack yarn --cwd web format:check`
- `git diff --check`
