### PR TITLE
fix(sidebar): gate Shopping entry by active brand, not org-wide (#170)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/layout.tsx
+++ b/web/src/app/[locale]/(dashboard)/layout.tsx
@@ -51,16 +51,12 @@ export default async function DashboardLayout({ children }: { children: React.Re
   }
 
   const planId = (org?.plan ?? 'starter') as PlanId;
-  // Sidebar reveals the Shopping entry when at least one brand has Shopping
-  // mode on (#155). Org-wide signal, derived from the brand list we already
-  // fetch here.
-  const shoppingModeEnabled = brands.some((b) => b.shoppingModeEnabled);
 
   return (
     <>
       <AuthProvider user={user} />
       <BrandLoader brands={brands} />
-      <PlanProvider planId={planId} shoppingModeEnabled={shoppingModeEnabled}>
+      <PlanProvider planId={planId}>
         <RoleProvider role={role}>
           <div className="flex h-screen overflow-hidden">
             {/* Desktop sidebar */}

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -7,8 +7,8 @@ import { useTranslations } from 'next-intl';
 import { usePathname, Link } from '@/i18n/navigation';
 import { dashboardNav } from '@/config/dashboard';
 import { useSidebarStore } from '@/stores/use-sidebar-store';
+import { useBrandStore } from '@/stores/use-brand-store';
 import { useFeatureGate } from '@/hooks/use-feature-gate';
-import { usePlanContext } from '@/components/providers/plan-provider';
 import { siteConfig } from '@/config/site';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -25,11 +25,14 @@ export function Sidebar() {
   const t = useTranslations('nav');
   const tBrands = useTranslations('brands');
   const { canUse, requiredPlanFor, isCloud } = useFeatureGate();
-  const { shoppingModeEnabled } = usePlanContext();
-  // Map from a NavItem.requiresOrgPref key to its current value. Sidebar
-  // hides the item entirely when this returns false — see #155 for why
-  // Shopping uses this on top of the existing plan-feature gate.
-  const orgPrefs = { shoppingModeEnabled };
+  // Brand-scoped gates follow the active brand, not the org. Selecting the
+  // derived brand keeps this reactive: switching brands via BrandSwitcher or
+  // toggling the flag in Brand Settings flips the gate without a route change.
+  const activeBrand = useBrandStore((s) => s.brands.find((b) => b.id === s.activeBrandId) ?? null);
+  // Map from a NavItem.requiresBrandPref key to the active brand's value.
+  // Sidebar hides the item entirely when this returns false — see #155/#170
+  // for why Shopping uses this on top of the existing plan-feature gate.
+  const brandPrefs = { shoppingModeEnabled: !!activeBrand?.shoppingModeEnabled };
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   // Hydration guard: SSR can't know the resolved theme, so we render the
@@ -100,10 +103,10 @@ export function Sidebar() {
             {group.title && isCollapsed && i > 0 && <Separator className="my-2" />}
             <nav className="space-y-0.5">
               {group.items.map((item) => {
-                // Hide entirely if a required org preference is off — the
-                // user shouldn't see "Shopping (upgrade)" when they're
-                // simply not in e-commerce.
-                if (item.requiresOrgPref && !orgPrefs[item.requiresOrgPref]) {
+                // Hide entirely if a required brand preference is off — the
+                // user shouldn't see "Shopping (upgrade)" when the active
+                // brand simply isn't in e-commerce.
+                if (item.requiresBrandPref && !brandPrefs[item.requiresBrandPref]) {
                   return null;
                 }
 

--- a/web/src/components/providers/plan-provider.tsx
+++ b/web/src/components/providers/plan-provider.tsx
@@ -6,29 +6,25 @@ import type { PlanId } from '@/config/plans';
 interface PlanContextValue {
   planId: PlanId;
   isCloud: boolean;
-  shoppingModeEnabled: boolean;
 }
 
 const PlanContext = createContext<PlanContextValue>({
   planId: 'self_hosted',
   isCloud: false,
-  shoppingModeEnabled: false,
 });
 
 export function PlanProvider({
   planId,
-  shoppingModeEnabled,
   children,
 }: {
   planId: PlanId;
-  shoppingModeEnabled: boolean;
   children: React.ReactNode;
 }) {
   const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
   const effectivePlan: PlanId = isCloud ? planId : 'self_hosted';
 
   return (
-    <PlanContext.Provider value={{ planId: effectivePlan, isCloud, shoppingModeEnabled }}>
+    <PlanContext.Provider value={{ planId: effectivePlan, isCloud }}>
       {children}
     </PlanContext.Provider>
   );

--- a/web/src/components/providers/plan-provider.tsx
+++ b/web/src/components/providers/plan-provider.tsx
@@ -13,13 +13,7 @@ const PlanContext = createContext<PlanContextValue>({
   isCloud: false,
 });
 
-export function PlanProvider({
-  planId,
-  children,
-}: {
-  planId: PlanId;
-  children: React.ReactNode;
-}) {
+export function PlanProvider({ planId, children }: { planId: PlanId; children: React.ReactNode }) {
   const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
   const effectivePlan: PlanId = isCloud ? planId : 'self_hosted';
 

--- a/web/src/config/dashboard.ts
+++ b/web/src/config/dashboard.ts
@@ -13,14 +13,14 @@ import {
 import type { Feature } from '@/config/plans';
 
 /**
- * An org-level preference that, when present on a NavItem, must be `true`
- * for the item to render at all. Distinct from plan-level `requiredFeature`
- * which downgrades the item to a locked/disabled state when the plan
- * doesn't include it — `requiresOrgPref` hides the item entirely so it
- * doesn't appear as a "you could have this if you paid more" hint when the
- * relevant org isn't supposed to see Shopping in the first place.
+ * A brand-level preference that, when present on a NavItem, must be `true`
+ * on the active brand for the item to render at all. Distinct from plan-level
+ * `requiredFeature` which downgrades the item to a locked/disabled state when
+ * the plan doesn't include it — `requiresBrandPref` hides the item entirely so
+ * it doesn't appear as a "you could have this if you paid more" hint when the
+ * active brand isn't supposed to see Shopping in the first place.
  */
-export type OrgPrefKey = 'shoppingModeEnabled';
+export type BrandPrefKey = 'shoppingModeEnabled';
 
 export interface NavItem {
   title: string;
@@ -29,7 +29,7 @@ export interface NavItem {
   badge?: string;
   disabled?: boolean;
   requiredFeature?: Feature;
-  requiresOrgPref?: OrgPrefKey;
+  requiresBrandPref?: BrandPrefKey;
 }
 
 export interface NavGroup {
@@ -82,7 +82,7 @@ export const dashboardNav: NavGroup[] = [
         href: '/dashboard/shopping',
         icon: ShoppingBag,
         requiredFeature: 'shopping_analytics',
-        requiresOrgPref: 'shoppingModeEnabled',
+        requiresBrandPref: 'shoppingModeEnabled',
       },
       {
         title: 'AI Traffic Analytics',


### PR DESCRIPTION
## Summary

Fixes #170. The sidebar's Shopping entry was gated by `brands.some((b) => b.shoppingModeEnabled)` — i.e. "does **any** brand in the org have shopping mode on?" — so an org with one e-commerce brand showed Shopping on every brand, including the ones where the checkbox was explicitly left off. The gate now follows the **active** brand.

- Drop the org-level `shoppingModeEnabled` derivation from the dashboard layout and remove the field from `PlanProvider` — it's brand-scoped, not plan-scoped, so it doesn't belong on the plan provider.
- Read the active brand reactively from `useBrandStore` in `sidebar.tsx` and gate `requiresBrandPref: 'shoppingModeEnabled'` off `activeBrand?.shoppingModeEnabled`. Switching brands via `BrandSwitcher` or toggling the flag in Brand Settings flips the entry instantly without a route change.
- Rename `OrgPrefKey`/`requiresOrgPref` to `BrandPrefKey`/`requiresBrandPref` in `config/dashboard.ts` so the type tells the truth.

## Test plan

- [ ] Active brand `shopping_mode_enabled = false` → Shopping entry hidden, even when a sibling brand has it on.
- [ ] Switching brands via BrandSwitcher reveals/hides the Shopping entry instantly.
- [ ] Toggling Shopping mode in Brand Settings updates the sidebar without a refresh.
- [x] `yarn tsc --noEmit` + `yarn lint` clean.

## Out of scope

- Mobile nav already didn't apply this gate (separate pre-existing behavior); per the issue, only the sidebar gate was wrong.

Made with [Cursor](https://cursor.com)