### PR TITLE
ux(brands): bolden the brand breadcrumb avatar fallback

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/layout.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/layout.tsx
@@ -49,7 +49,7 @@ export default function BrandDetailLayout({
           <div className="flex items-center gap-3">
             <Avatar className="h-9 w-9 rounded-lg bg-zinc-50 dark:bg-zinc-100">
               <AvatarImage src={brand.logoUrl} alt={brand.name} className="object-contain p-1" />
-              <AvatarFallback className="rounded-lg bg-primary/10 text-primary text-sm font-semibold">
+              <AvatarFallback className="rounded-lg bg-primary text-primary-foreground text-sm font-semibold">
                 {initials}
               </AvatarFallback>
             </Avatar>


### PR DESCRIPTION
## Summary

The brand detail breadcrumb (`/dashboard/brands/<id>/...`) renders its avatar with [`bg-primary/10 text-primary`](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/%5Blocale%5D/(dashboard)/dashboard/brands/%5Bid%5D/layout.tsx#L52) — 10% primary background + primary text — so when a brand has no `logoUrl`, the initials read as a faint wash.

The sidebar's [BrandSwitcher avatar](https://github.com/ansvisor/ansvisor/blob/main/web/src/components/layout/brand-switcher.tsx#L69) already uses the solid `bg-primary text-primary-foreground` pairing for the same fallback. Bringing the breadcrumb avatar in line drops the visual inconsistency and surfaces the initials at full contrast.

One-line class swap, no asset or behavior change.

## Test plan

- [ ] Visit `/dashboard/brands/<id>/...` for a brand without a `logoUrl` — initials read in solid primary, matching the sidebar BrandSwitcher.
- [ ] Brands that do have a logo still render the `<AvatarImage>` exactly as before.