### PR TITLE
ux(brands): soften the active brand card outline

### DIFF
--- a/web/src/components/dashboard/brand-card.tsx
+++ b/web/src/components/dashboard/brand-card.tsx
@@ -35,7 +35,7 @@ export function BrandCard({ brand }: BrandCardProps) {
       className={cn(
         'overflow-hidden rounded-xl border bg-card transition-all',
         'hover:border-primary/40 hover:shadow-sm',
-        isActive && 'ring-2 ring-primary border-primary/60',
+        isActive && 'ring-1 ring-primary/40 border-primary/40',
       )}
     >
       <div className="flex items-start gap-3 px-4 py-3.5">


### PR DESCRIPTION
## Summary

[`web/src/components/dashboard/brand-card.tsx:38`](https://github.com/ansvisor/ansvisor/blob/main/web/src/components/dashboard/brand-card.tsx#L38) was using `ring-2 ring-primary border-primary/60` on the active card, which stacks a full-saturation 2px ring on top of an opaque primary border — visually ~3px and noticeably heavier than the rest of the grid.

Swap to `ring-1 ring-primary/40 border-primary/40`:

- Ring thickness halved (`ring-2` → `ring-1`).
- Both the ring and the border now share the same 40% primary tint so the highlight reads as a soft outline rather than a hard halo.

The hover affordance (`hover:border-primary/40 hover:shadow-sm`) is unchanged.

## Test plan

- [x] On `/dashboard/brands`, the active card's outline is clearly identifiable but feels in line with the inactive cards' weight.
- [x] Hover state on the inactive cards still works.
- [x] Switching brands via clicking another card moves the highlight as expected.