### PR TITLE
ux(brands): align typography with the Insights page

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
@@ -19,7 +19,7 @@ function BrandsHeader({
     <div className="flex items-center justify-between">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
-        <p className="text-muted-foreground">{t('description')}</p>
+        <p className="text-muted-foreground text-sm">{t('description')}</p>
       </div>
       {canAddBrand ? (
         <Link href="/dashboard/brands/new">

--- a/web/src/components/dashboard/brand-card.tsx
+++ b/web/src/components/dashboard/brand-card.tsx
@@ -47,7 +47,7 @@ export function BrandCard({ brand }: BrandCardProps) {
         </Avatar>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <h3 className="truncate font-semibold leading-tight">{brand.name}</h3>
+            <h3 className="truncate text-sm font-semibold leading-tight">{brand.name}</h3>
             {isActive && (
               <Badge
                 variant="secondary"
@@ -59,7 +59,7 @@ export function BrandCard({ brand }: BrandCardProps) {
             )}
           </div>
           {primaryDomain && (
-            <p className="mt-0.5 flex items-center gap-1 truncate text-xs text-muted-foreground">
+            <p className="mt-0.5 flex items-center gap-1 truncate text-sm text-muted-foreground">
               <Globe className="h-3 w-3 shrink-0" />
               {primaryDomain.domain}
             </p>


### PR DESCRIPTION
## Summary

Two small typography tweaks so `/dashboard/brands` feels consistent with `/dashboard/insights` and with itself across the page and card surfaces.

### Page header

[`web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx:22`](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/%5Blocale%5D/(dashboard)/dashboard/brands/page.tsx#L22) — description drops from default body size to `text-sm`, matching the `text-muted-foreground text-sm` description that the [Insights header](https://github.com/ansvisor/ansvisor/blob/main/web/src/app/%5Blocale%5D/(dashboard)/dashboard/insights/page.tsx#L1724) already uses.

### Brand card

[`web/src/components/dashboard/brand-card.tsx`](https://github.com/ansvisor/ansvisor/blob/main/web/src/components/dashboard/brand-card.tsx) — brand name and the primary-domain row now share the same `text-sm` scale. They stay distinguishable via `font-semibold` on the name and the muted-foreground tone on the domain — the size match removes the heavy `text-base` / `text-xs` contrast that read as inconsistent next to the rest of the dashboard.

## Test plan

- [ ] `/dashboard/brands` page header description visually matches the Insights header description.
- [ ] Brand card brand name and domain rows read as a coherent pair — name still stands out via weight, domain still recedes via tone.
- [ ] Active-card ring + brand-row layout unchanged.