### PR TITLE
Remove debug log from Stripe checkout route

### DIFF
--- a/web/src/app/api/stripe/checkout/route.ts
+++ b/web/src/app/api/stripe/checkout/route.ts
@@ -60,10 +60,9 @@ export async function POST(req: NextRequest) {
         .eq('id', organizationId);
     }
 
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
 
-
-    const session = await stripe.checkout.sessions.create({
+const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
       customer: customerId,
       line_items: [{ price: priceId, quantity: 1 }],

--- a/web/src/app/api/stripe/checkout/route.ts
+++ b/web/src/app/api/stripe/checkout/route.ts
@@ -60,9 +60,9 @@ export async function POST(req: NextRequest) {
         .eq('id', organizationId);
     }
 
-      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
 
-      const session = await stripe.checkout.sessions.create({
+    const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
       customer: customerId,
       line_items: [{ price: priceId, quantity: 1 }],

--- a/web/src/app/api/stripe/checkout/route.ts
+++ b/web/src/app/api/stripe/checkout/route.ts
@@ -62,7 +62,6 @@ export async function POST(req: NextRequest) {
 
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
 
-    console.log('appUrl', appUrl);
 
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',

--- a/web/src/app/api/stripe/checkout/route.ts
+++ b/web/src/app/api/stripe/checkout/route.ts
@@ -60,9 +60,9 @@ export async function POST(req: NextRequest) {
         .eq('id', organizationId);
     }
 
-const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
 
-const session = await stripe.checkout.sessions.create({
+      const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
       customer: customerId,
       line_items: [{ price: priceId, quantity: 1 }],


### PR DESCRIPTION
Closes #182

Removed the leftover debug `console.log` from the Stripe checkout route.

The existing error logging remains unchanged and no functionality was modified.