### PR TITLE
fix: sync docker compose image tags with package version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/ansvisor/ansvisor/web:0.1.0
+    image: ghcr.io/ansvisor/ansvisor/web:0.1.2
     build: ./web
     ports:
       - "3000:3000"
@@ -11,7 +11,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: ghcr.io/ansvisor/ansvisor/server:0.1.0
+    image: ghcr.io/ansvisor/ansvisor/server:0.1.2
     build: ./server
     ports:
       - "80:80"

--- a/scripts/version-bump.js
+++ b/scripts/version-bump.js
@@ -12,6 +12,7 @@ const PACKAGE_PATHS = [
   resolve(root, 'web/package.json'),
   resolve(root, 'server/package.json'),
 ];
+const COMPOSE_PATH = resolve(root, 'docker-compose.yml');
 
 function parseVersion(version) {
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
@@ -48,4 +49,20 @@ for (const pkgPath of PACKAGE_PATHS) {
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
 }
 
-console.log(`${oldVersion} → ${newVersion}`);
+const compose = readFileSync(COMPOSE_PATH, 'utf8');
+let updatedImageCount = 0;
+const updatedCompose = compose.replace(
+  /(image:\s*ghcr\.io\/ansvisor\/ansvisor\/(?:web|server):)\d+\.\d+\.\d+/g,
+  (_, prefix) => {
+    updatedImageCount += 1;
+    return `${prefix}${newVersion}`;
+  },
+);
+
+if (updatedImageCount === 0) {
+  throw new Error('No docker-compose image tags found to update');
+}
+
+writeFileSync(COMPOSE_PATH, updatedCompose);
+
+console.log(`${oldVersion} -> ${newVersion}`);

--- a/scripts/version-check.js
+++ b/scripts/version-check.js
@@ -12,19 +12,35 @@ const packages = [
   { name: 'web', path: resolve(root, 'web/package.json') },
   { name: 'server', path: resolve(root, 'server/package.json') },
 ];
+const composePath = resolve(root, 'docker-compose.yml');
 
 const versions = packages.map(({ name, path }) => {
   const { version } = JSON.parse(readFileSync(path, 'utf8'));
   return { name, version };
 });
 
+const compose = readFileSync(composePath, 'utf8');
+const imageVersions = [...compose.matchAll(
+  /image:\s*ghcr\.io\/ansvisor\/ansvisor\/(web|server):(\d+\.\d+\.\d+)/g,
+)].map(([, service, version]) => ({
+  name: `docker-compose ${service} image`,
+  version,
+}));
+
+if (imageVersions.length !== 2) {
+  console.error('Could not find both web and server docker-compose image tags.');
+  process.exit(1);
+}
+
+versions.push(...imageVersions);
+
 const allMatch = versions.every((v) => v.version === versions[0].version);
 
 if (allMatch) {
-  console.log(`✓ All packages at v${versions[0].version}`);
+  console.log(`All package and docker-compose versions at v${versions[0].version}`);
   process.exit(0);
 } else {
-  console.error('✗ Version mismatch:');
+  console.error('Version mismatch:');
   for (const { name, version } of versions) {
     console.error(`  ${name}: ${version}`);
   }


### PR DESCRIPTION
## Summary
- update the docker-compose web/server image tags to match the current package version (0.1.2)
- make `version:bump` update docker-compose image tags alongside package.json files
- extend `version:check` to catch package/docker-compose version mismatches

Fixes #183

## Tests
- `node scripts/version-check.js`
- copied the repo to a temporary directory and verified `node scripts/version-bump.js patch` updates root/web/server package versions and both docker-compose image tags to 0.1.3, followed by `node scripts/version-check.js`