### PR TITLE
fix(insights): centralize platform labels for csv export

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useEffect, useRef, useState } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useEffect, useState, useCallback, useMemo } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { use, useState, useEffect, useCallback } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { use, useCallback, useEffect, useState } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useState, useEffect, useRef } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/server';

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -86,24 +87,6 @@ const CATEGORY_BADGE_CLASSES: Record<SourceCategory, string> = {
 };
 
 // AI platform / model friendly names — kept in sync with the insights page.
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
-  'google-ai-mode': 'Google AI Mode',
-  'chatgpt-web': 'ChatGPT',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'perplexity-web': 'Perplexity',
-  'gemini-web': 'Google Gemini',
-};
 
 const MODEL_DISPLAY_NAME: Record<string, string> = {
   'gpt-4o': 'GPT-4o',

--- a/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useEffect, useState } from 'react';
@@ -12,24 +13,6 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, ExternalLink, MessageSquareText, Quote, Eye, Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI Overview',
-  'google-ai-mode': 'Google AI Mode',
-  'chatgpt-web': 'ChatGPT',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'perplexity-web': 'Perplexity',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
-};
 
 function SentimentBadge({ sentiment }: { sentiment: 'positive' | 'neutral' | 'negative' }) {
   return (

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useRef, useState, useEffect } from 'react';
@@ -103,24 +104,6 @@ const PLATFORM_COLORS: Record<string, string> = {
   'gemini-2.5-flash': '#4ade80',
 };
 
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
-  'google-ai-mode': 'Google AI Mode',
-  'google-aimode': 'Google AI Mode',
-  'gpt-5-chat-latest': 'GPT-5',
-  'gpt-5-mini': 'GPT-5 Mini',
-  'claude-sonnet-4-6': 'Claude Sonnet 4.6',
-  'claude-opus-4-6': 'Claude Opus 4.6',
-  'gemini-2.5-pro': 'Gemini 2.5 Pro',
-  'gemini-2.5-flash': 'Gemini 2.5 Flash',
-};
 
 // ─── Custom Tooltips ──────────────────────────────────────────────────────────
 

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
@@ -210,24 +211,6 @@ function VisibilityBar({ score, max = 100 }: { score: number; max?: number }) {
   );
 }
 
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
-  'google-ai-mode': 'Google AI Mode',
-  'chatgpt-web': 'ChatGPT',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'perplexity-web': 'Perplexity',
-  'gemini-web': 'Google Gemini',
-};
 
 const MODEL_DISPLAY_NAME: Record<string, string> = {
   'gpt-4o': 'GPT-4o',

--- a/web/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 import { redirect } from 'next/navigation';
 
 export default function DashboardPage() {

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useEffect, useMemo, useState, type ComponentType } from 'react';
@@ -16,24 +17,6 @@ import { ArrowLeft, ChevronDown, Clock, Eye, MessageSquareText, Quote } from 'lu
 import { cn } from '@/lib/utils';
 import { AIProviderAvatar, resolveAIProvider } from '@/components/ai-provider-avatar';
 
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
-  'google-ai-mode': 'Google AI Mode',
-  'chatgpt-web': 'ChatGPT',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'perplexity-web': 'Perplexity',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
-};
 
 const MODEL_DISPLAY_NAME: Record<string, string> = {
   'gpt-4o': 'GPT-4o',

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_charts.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useRef, useState, useEffect } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/similar-topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/similar-topics/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/reports/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/reports/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 import { useTranslations } from 'next-intl';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';

--- a/web/src/app/[locale]/(dashboard)/dashboard/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/settings/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useEffect, useState } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useCallback, useEffect, useRef, useState, use } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/_charts.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useRef, useState, useEffect } from 'react';

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';

--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -1,3 +1,4 @@
+import { PLATFORM_LABELS } from "@/config/platform-labels";
 'use client';
 
 import { useState, useEffect, useRef } from 'react';


### PR DESCRIPTION
Hey, saw issue #187. I extracted PLATFORM_LABELS into a shared config file so the CSV exporter and the charts can both use it, ensuring we get the display names instead of raw slugs in the exports. I also cleaned up the duplicate definitions across the dashboard.