### PR TITLE
docs: add product tour badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![🚀 Try the Cloud — ansvisor.com](https://img.shields.io/badge/🚀_Try_the_Cloud-ansvisor.com-6366f1?style=for-the-badge&logoColor=white&logo=vercel)](https://ansvisor.com)
 [![📚 Docs](https://img.shields.io/badge/📚_Docs-docs.ansvisor.com-10b981?style=for-the-badge&logoColor=white&logo=readthedocs)](https://docs.ansvisor.com)
+[![🎬 Product Tour](https://img.shields.io/badge/🎬_Product_Tour-Watch_the_demo-f59e0b?style=for-the-badge&logoColor=white)](https://app.supademo.com/demo/cmq2b1p5k0rk9qm6ugicrn655)
 
 [![Star on GitHub](https://img.shields.io/github/stars/ansvisor/ansvisor?style=for-the-badge&logo=github&color=gold)](https://github.com/ansvisor/ansvisor)
 [![MIT License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
﻿## Summary
- Add a Product Tour badge to the README header CTA row
- Link the badge to the clean public Supademo share URL from the issue
- Match the existing shields.io `for-the-badge` style with a distinct amber color

Closes #193.

## Validation
- `git diff --check`
- Confirmed the README link uses `https://app.supademo.com/demo/cmq2b1p5k0rk9qm6ugicrn655` without `preview=true` or `step=1` query parameters