### PR TITLE
chore(security): sweep aggregate/row-fetch RPCs to SECURITY INVOKER for org isolation

### DIFF
--- a/supabase/migrations/00014_security_invoker_rpcs.sql
+++ b/supabase/migrations/00014_security_invoker_rpcs.sql
@@ -1,0 +1,98 @@
+-- 00014_security_invoker_rpcs.sql
+--
+-- Security hardening (defense-in-depth): flip every aggregate / row-fetch RPC
+-- from SECURITY DEFINER to SECURITY INVOKER so the database itself enforces
+-- org isolation via Row Level Security, instead of relying solely on the route
+-- layer to verify brand-belongs-to-org before calling.
+--
+-- Why this is safe (verified against the current schema):
+--   * Every table these RPCs read is already covered by an org-scoped SELECT
+--     policy for the `authenticated` role:
+--       - prompt_results : "Users can read own org prompt results" (00001)
+--       - prompts        : "prompts: member select"               (00001)
+--       - topics         : no RLS, GRANT ALL to authenticated      (00001)
+--   * Dashboard callers (web/src/lib/actions/tracking.ts) use the cookie-based
+--     authenticated client, so auth.uid() is always populated and RLS resolves
+--     to the caller's own organization — legitimate numbers are unchanged.
+--   * MCP / worker callers (web/src/lib/mcp/data.ts) use the service_role
+--     client, which bypasses RLS regardless of INVOKER/DEFINER — unaffected.
+--
+-- Effect for a wrong-org call: RLS filters out every row, so aggregates return
+-- zeroed/empty results and row fetches return no rows. No cross-org data leaks.
+--
+-- We use ALTER FUNCTION (not CREATE OR REPLACE) on purpose: it flips only the
+-- security attribute and leaves each function's body, search_path, volatility
+-- and grants byte-for-byte identical — zero risk of body drift.
+
+-- get_latest_prompt_results — two overloads (00001). Currently unused by app
+-- code, but exposed to PostgREST, so harden anyway.
+ALTER FUNCTION public.get_latest_prompt_results(
+  p_brand_id uuid,
+  p_platform text
+) SECURITY INVOKER;
+
+ALTER FUNCTION public.get_latest_prompt_results(
+  p_brand_id uuid,
+  p_platform text,
+  p_model text,
+  p_region text,
+  p_date_from timestamptz,
+  p_date_to timestamptz
+) SECURITY INVOKER;
+
+-- insights_aggregates (current definition: 00012)
+ALTER FUNCTION public.insights_aggregates(
+  p_brand_id uuid,
+  p_platform text,
+  p_models text[],
+  p_region text,
+  p_date_from timestamptz,
+  p_date_to timestamptz,
+  p_prompt_id uuid,
+  p_topic_id uuid
+) SECURITY INVOKER;
+
+-- competitor_aggregates (current definition: 00012)
+ALTER FUNCTION public.competitor_aggregates(
+  p_brand_id uuid,
+  p_platform text,
+  p_models text[],
+  p_region text,
+  p_date_from timestamptz,
+  p_date_to timestamptz,
+  p_prompt_id uuid,
+  p_topic_id uuid
+) SECURITY INVOKER;
+
+-- share_of_voice_aggregates (current definition: 00012)
+ALTER FUNCTION public.share_of_voice_aggregates(
+  p_brand_id uuid,
+  p_platform text,
+  p_models text[],
+  p_region text,
+  p_date_from timestamptz,
+  p_date_to timestamptz,
+  p_prompt_id uuid,
+  p_topic_id uuid
+) SECURITY INVOKER;
+
+-- visibility_trend_aggregates (current definition: 00012)
+ALTER FUNCTION public.visibility_trend_aggregates(
+  p_brand_id uuid,
+  p_models text[],
+  p_region text,
+  p_date_from timestamptz,
+  p_date_to timestamptz,
+  p_topic_id uuid,
+  p_granularity text
+) SECURITY INVOKER;
+
+-- prompt_performance_aggregates (00013)
+ALTER FUNCTION public.prompt_performance_aggregates(
+  p_brand_id uuid,
+  p_models text[],
+  p_region text,
+  p_date_from timestamptz,
+  p_date_to timestamptz,
+  p_topic_id uuid
+) SECURITY INVOKER;


### PR DESCRIPTION
## What

Flips every aggregate / row-fetch RPC in `supabase/migrations/` from `SECURITY DEFINER` to `SECURITY INVOKER`, so the database itself enforces org isolation through the existing Row Level Security policies instead of relying solely on the route layer to verify brand-belongs-to-org before calling.

Closes #115.

Affected functions (7):
- `get_latest_prompt_results(uuid, text)` and `get_latest_prompt_results(uuid, text, text, text, timestamptz, timestamptz)` — [`00001_initial_schema.sql`](https://github.com/ansvisor/ansvisor/blob/main/supabase/migrations/00001_initial_schema.sql)
- `insights_aggregates(...)`, `competitor_aggregates(...)`, `share_of_voice_aggregates(...)`, `visibility_trend_aggregates(...)` — current definitions in [`00012_shopping_mode.sql`](https://github.com/ansvisor/ansvisor/blob/main/supabase/migrations/00012_shopping_mode.sql)
- `prompt_performance_aggregates(...)` — [`00013_prompt_performance_aggregates.sql`](https://github.com/ansvisor/ansvisor/blob/main/supabase/migrations/00013_prompt_performance_aggregates.sql)

> Scope note vs the original issue: `visibility_trend_aggregates` and `prompt_performance_aggregates` were added after #115 was filed and are included here too.

## Approach

Uses `ALTER FUNCTION ... SECURITY INVOKER` rather than `CREATE OR REPLACE`. This flips only the security attribute and leaves each function's body, `search_path`, volatility and grants byte-for-byte identical — no risk of body drift. It is a metadata-only change: instant to apply, no table lock or rewrite, and trivially reversible.

The `SECURITY INVOKER` direction (vs. keeping `DEFINER` + adding manual membership checks) was chosen because every table these RPCs read is already covered by an org-scoped SELECT policy for the `authenticated` role, so no new policy is needed:
- `prompt_results` → "Users can read own org prompt results"
- `prompts` → "prompts: member select"
- `topics` → no RLS, `GRANT ALL` to `authenticated`

Caller analysis:
- Dashboard callers (`web/src/lib/actions/tracking.ts`) use the cookie-based authenticated client, so `auth.uid()` is always populated and RLS resolves to the caller's own organization.
- MCP / worker callers (`web/src/lib/mcp/data.ts`) use the `service_role` client, which bypasses RLS regardless of `INVOKER`/`DEFINER` — unaffected.
- No session-less anon path calls these RPCs.

## Verification

Applied all migrations (00001 → 00014) to a throwaway Postgres on the official Supabase image, seeded two organizations (A and B), each with a brand and prompt results, then exercised every RPC in three contexts. The working dev database was never touched.

| RPC | `service_role` / Brand A (baseline) | authenticated User A / Brand A | authenticated User A / Brand B (cross-org) |
|---|---|---|---|
| `insights_aggregates` | `total_results=3, mentions=6, vis=180` | **identical** | `total_results=0`, empty |
| `competitor_aggregates` | `brand_row_count=3, vis=180` | **identical** | `brand_row_count=0`, empty |
| `share_of_voice_aggregates` | `total_brand_mentions=6` | **identical** | `0`, `by_day:[]` |
| `visibility_trend_aggregates` | full series | **identical** | `[]` |
| `prompt_performance_aggregates` | `result_count=3, vis=180` | **identical** | `[]` |
| `get_latest_prompt_results` | 2 rows | **2 rows (identical)** | 0 rows |

Contrast check on `insights_aggregates`: with the function temporarily reverted to `SECURITY DEFINER`, the cross-org call leaked Brand B's 2 results; restored to `SECURITY INVOKER`, the same call returns 0. This confirms the leak was real and that the change closes it.

Net result:
- Legitimate dashboard numbers are unchanged (authenticated own-org output is byte-identical to the `service_role` baseline for all 7 functions).
- Cross-org calls now return empty / zeroed results — no cross-org data leaks.
- The MCP / worker `service_role` path is unaffected.

## Out of scope

- Pure DB-layer hardening; no UI changes, no new endpoints.
- The route-layer brand verification stays as-is (this is defense-in-depth, not a replacement).
