### PR TITLE
fix csv export platform names

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/lib/actions/tracking';
 import { getTopics } from '@/lib/actions/topic';
 import type { Topic } from '@/types';
+import { getPlatformDisplayName } from '@/config/platform-labels';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -1646,7 +1647,7 @@ export default function InsightsPage() {
       created_at: r.createdAt,
       prompt: r.promptText,
       topic: r.topicName ?? '',
-      platform: r.platform,
+      platform: getPlatformDisplayName(r.platform),
       model: r.modelUsed ?? '',
       region: r.region ?? '',
       mention_count: r.mentionCount,

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -48,6 +48,7 @@ import { aggregatePromptVolumeClusters } from '@/lib/prompt-volume-clusters';
 import type { PromptVolume, Prompt } from '@/types';
 import { toast } from 'sonner';
 import { toCsv } from '@/lib/csv';
+import { getPlatformDisplayName } from '@/config/platform-labels';
 
 // ─── Info Tooltip ─────────────────────────────────────────────────────────────
 
@@ -426,7 +427,7 @@ export default function PromptsPage() {
       text: p.text,
       topic_id: p.topicId ?? '',
       category: p.category ?? '',
-      platforms: p.platforms.join(', '),
+      platforms: p.platforms.map(getPlatformDisplayName).join(', '),
       models: p.models.join(', '),
       regions: p.regions.join(', '),
       is_active: p.isActive,

--- a/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
@@ -82,6 +82,7 @@ import {
   getAIProviderDisplayName,
 } from '@/components/ai-provider-avatar';
 import { toCsv } from '@/lib/csv';
+import { getPlatformDisplayName } from '@/config/platform-labels';
 
 const DATE_PRESETS: ShoppingDatePreset[] = ['7d', '30d', '90d', 'all'];
 
@@ -312,7 +313,7 @@ export default function ShoppingPage() {
                           product_title: p.product_title,
                           product_brand: p.product_brand || '',
                           impressions: p.impressions,
-                          platforms: p.platforms.join('; '),
+                          platforms: p.platforms.map(getPlatformDisplayName).join('; '),
                           regions: p.regions.join('; '),
                           last_price: p.last_price !== null ? p.last_price : '',
                           price_currency: p.price_currency || '',
@@ -378,7 +379,7 @@ export default function ShoppingPage() {
                           product_title: p.product_title,
                           product_brand: p.product_brand || '',
                           impressions: p.impressions,
-                          platforms: p.platforms.join('; '),
+                          platforms: p.platforms.map(getPlatformDisplayName).join('; '),
                           regions: p.regions.join('; '),
                           last_price: p.last_price !== null ? p.last_price : '',
                           price_currency: p.price_currency || '',
@@ -460,7 +461,7 @@ function PromptsTabContent({
     const exportRows = promptsData.prompts.map((p) => ({
       prompt: p.promptText,
       topic: p.topic,
-      platforms: p.platforms.join('; '),
+      platforms: p.platforms.map(getPlatformDisplayName).join('; '),
       total_cards: p.totalCards,
       own_cards: p.ownCardsCount,
       competitor_cards: p.competitorCardsCount,

--- a/web/src/config/platform-labels.ts
+++ b/web/src/config/platform-labels.ts
@@ -1,0 +1,19 @@
+export const PLATFORM_LABELS: Record<string, string> = {
+  chatgpt: 'ChatGPT',
+  'chatgpt-web': 'ChatGPT',
+  'chatgpt-shopping': 'ChatGPT Shopping',
+  'gpt-4o': 'ChatGPT',
+  'gpt-5-mini': 'ChatGPT',
+  'gpt-5-chat-latest': 'ChatGPT',
+  perplexity: 'Perplexity',
+  gemini: 'Gemini',
+  claude: 'Claude',
+  copilot: 'Copilot',
+  'google-ai': 'Google AI Overview',
+};
+
+export function getPlatformDisplayName(slug: string | null | undefined): string {
+  if (!slug) return '';
+  if (slug.startsWith('gpt-')) return 'ChatGPT';
+  return PLATFORM_LABELS[slug] || slug;
+}


### PR DESCRIPTION
Hey! the csv export was exporting raw slugs instead of the proper display names for platforms. I extracted the platform mappings into a central config file and updated the export logic across the dashboard pages to use it. Tests and lint should pass now. let me know if you need anything else!