### PR TITLE
docs: use www ansvisor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-[![Ansvisor Banner](https://cdn.prod.website-files.com/69e606308fb6f96fb911b251/69f0a8f250aa69dd7f6d9a30_s12.svg)](https://ansvisor.com)
+[![Ansvisor Banner](https://cdn.prod.website-files.com/69e606308fb6f96fb911b251/69f0a8f250aa69dd7f6d9a30_s12.svg)](https://www.ansvisor.com)
 
-[![🚀 Try the Cloud — ansvisor.com](https://img.shields.io/badge/🚀_Try_the_Cloud-ansvisor.com-6366f1?style=for-the-badge&logoColor=white&logo=vercel)](https://ansvisor.com)
+[![🚀 Try the Cloud — ansvisor.com](https://img.shields.io/badge/🚀_Try_the_Cloud-ansvisor.com-6366f1?style=for-the-badge&logoColor=white&logo=vercel)](https://www.ansvisor.com)
 [![📚 Docs](https://img.shields.io/badge/📚_Docs-docs.ansvisor.com-10b981?style=for-the-badge&logoColor=white&logo=readthedocs)](https://docs.ansvisor.com)
 [![🎬 Product Tour](https://img.shields.io/badge/🎬_Product_Tour-Watch_the_demo-f59e0b?style=for-the-badge&logoColor=white)](https://app.supademo.com/demo/cmq2b1p5k0rk9qm6ugicrn655)
 
@@ -38,7 +38,7 @@ _Star us to follow along as we ship 👇_
 
 ### Why Ansvisor?
 
-> AI search is replacing the traditional click. When ChatGPT recommends a product, no Google ranking saves you. Ansvisor measures what classical SEO can't see — how often AI engines name your brand, which competitors get cited instead, and which prompts move the needle. Self-host it for free, or use the managed cloud at [ansvisor.com](https://ansvisor.com).
+> AI search is replacing the traditional click. When ChatGPT recommends a product, no Google ranking saves you. Ansvisor measures what classical SEO can't see — how often AI engines name your brand, which competitors get cited instead, and which prompts move the needle. Self-host it for free, or use the managed cloud at [ansvisor.com](https://www.ansvisor.com).
 
 ## Features
 
@@ -50,7 +50,7 @@ _Star us to follow along as we ship 👇_
 - **Competitors** — Compare your AI presence against named competitors and surface visibility gaps to close
 - **Content Optimization** — AI-generated content briefs (title, outline, target keywords, competitor insights) with one-click webhook delivery to your CMS or workflow
 - **Multi-language Support** — 13 languages, 18 regions
-- **Self-hosted or Cloud** — Run it on your own infrastructure with every feature unlocked, or use the managed cloud at [ansvisor.com](https://ansvisor.com)
+- **Self-hosted or Cloud** — Run it on your own infrastructure with every feature unlocked, or use the managed cloud at [ansvisor.com](https://www.ansvisor.com)
 
 ## Quick Start
 

--- a/skills/ansvisor-aeo-coach-standalone/SKILL.md
+++ b/skills/ansvisor-aeo-coach-standalone/SKILL.md
@@ -39,7 +39,7 @@ You need two things from the user, in this order:
 1. **API key** — a token starting with `ans_`. Tell them to grab one
    from their Ansvisor dashboard: **Settings → API Keys → New key**. The
    token is shown once at creation. If they don't have an Ansvisor
-   account yet, point them at <https://ansvisor.com>.
+   account yet, point them at <https://www.ansvisor.com>.
 2. **Base URL** — defaults to `https://app.ansvisor.com`. Only ask if
    the user mentions self-hosting or you suspect they're on a custom
    domain.


### PR DESCRIPTION
## Summary
- update the five bare `https://ansvisor.com` Markdown link targets from issue #206 to `https://www.ansvisor.com`
- leave subdomain links, CDN URLs, badge label text, and the historical changelog entry unchanged

Fixes #206

## Verification
- `rg -n "https://ansvisor\.com|https://www\.ansvisor\.com|docs\.ansvisor\.com|app\.ansvisor\.com|ansvisor\.com/pricing" README.md skills/ansvisor-aeo-coach-standalone/SKILL.md CHANGELOG.md CONTRIBUTING.md`
- Count check confirmed `README.md` has 4 `https://www.ansvisor.com` targets and 0 bare `https://ansvisor.com` targets; `SKILL.md` has 1 `https://www.ansvisor.com` target and 0 bare targets
- `git diff --check`
- `curl -I -L --max-time 20 https://www.ansvisor.com` returned HTTP 200