### PR TITLE
feat(auth): add password visibility toggle to auth forms

### DIFF
--- a/web/src/components/auth/reset-password-form.tsx
+++ b/web/src/components/auth/reset-password-form.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
@@ -51,9 +51,8 @@ export function ResetPasswordForm() {
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
         <Label htmlFor="password">{t('newPassword')}</Label>
-        <Input
+        <PasswordInput
           id="password"
-          type="password"
           placeholder={t('passwordPlaceholder')}
           value={password}
           onChange={(e) => setPassword(e.target.value)}
@@ -65,9 +64,8 @@ export function ResetPasswordForm() {
 
       <div className="space-y-2">
         <Label htmlFor="confirmPassword">{t('confirmPassword')}</Label>
-        <Input
+        <PasswordInput
           id="confirmPassword"
-          type="password"
           placeholder={t('passwordPlaceholder')}
           value={confirm}
           onChange={(e) => setConfirm(e.target.value)}

--- a/web/src/components/auth/sign-in-form.tsx
+++ b/web/src/components/auth/sign-in-form.tsx
@@ -7,6 +7,7 @@ import { useRouter, Link } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
@@ -93,9 +94,8 @@ export function SignInForm() {
               {t('forgotPassword')}
             </Link>
           </div>
-          <Input
+          <PasswordInput
             id="password"
-            type="password"
             placeholder={t('passwordPlaceholder')}
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/web/src/components/auth/sign-up-form.tsx
+++ b/web/src/components/auth/sign-up-form.tsx
@@ -7,6 +7,7 @@ import { useRouter, Link } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
@@ -104,9 +105,8 @@ export function SignUpForm() {
 
         <div className="space-y-2">
           <Label htmlFor="password">{t('password')}</Label>
-          <Input
+          <PasswordInput
             id="password"
-            type="password"
             placeholder={t('passwordPlaceholder')}
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/web/src/components/team/accept-invitation-card.tsx
+++ b/web/src/components/team/accept-invitation-card.tsx
@@ -6,6 +6,7 @@ import { createClient } from '@/lib/supabase/client';
 import { acceptInvitation, type TeamRole } from '@/lib/actions/team';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { Loader2, Users } from 'lucide-react';
@@ -156,9 +157,8 @@ export function AcceptInvitationCard({
 
           <div className="space-y-2">
             <Label htmlFor="invite-password">Set a password</Label>
-            <Input
+            <PasswordInput
               id="invite-password"
-              type="password"
               placeholder="At least 8 characters"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -171,9 +171,8 @@ export function AcceptInvitationCard({
 
           <div className="space-y-2">
             <Label htmlFor="invite-confirm-password">Confirm password</Label>
-            <Input
+            <PasswordInput
               id="invite-confirm-password"
-              type="password"
               placeholder="Repeat the password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}

--- a/web/src/components/ui/password-input.tsx
+++ b/web/src/components/ui/password-input.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+
+type PasswordInputProps = Omit<React.ComponentProps<typeof Input>, 'type'>;
+
+export function PasswordInput(props: PasswordInputProps) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className="relative">
+      <Input type={visible ? 'text' : 'password'} {...props} className="pr-10" />
+      <button
+        type="button"
+        onClick={() => setVisible((v) => !v)}
+        aria-label={visible ? 'Hide password' : 'Show password'}
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+        tabIndex={-1}
+      >
+        {visible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a reusable `PasswordInput` component and wires it into all four auth forms so users can reveal or mask their password by clicking the eye icon.

Closes #209

## Changes

- **new** `web/src/components/ui/password-input.tsx` — reusable component that wraps the existing `Input` with an `Eye`/`EyeOff` toggle from `lucide-react` (already a dependency, no new packages added)
- `web/src/components/auth/sign-in-form.tsx` — password field swapped to `PasswordInput`
- `web/src/components/auth/sign-up-form.tsx` — password field swapped to `PasswordInput`
- `web/src/components/auth/reset-password-form.tsx` — both password fields swapped to `PasswordInput`, `Input` import removed (no longer needed)
- `web/src/components/team/accept-invitation-card.tsx` — both password fields swapped to `PasswordInput`

## Acceptance criteria

- [x] Password fields have a working eye toggle (masked by default)
- [x] Toggle button is `type="button"` — does not submit the form
- [x] `aria-label` set for accessibility (`Show password` / `Hide password`)
- [x] No existing form logic, validation, or state changed
- [x] TypeScript: zero errors
- [x] Lint: zero new warnings