### PR TITLE
fix(ui): merge caller className in PasswordInput via cn

### DIFF
--- a/web/src/components/ui/password-input.tsx
+++ b/web/src/components/ui/password-input.tsx
@@ -3,15 +3,16 @@
 import { useState } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
 import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
 
 type PasswordInputProps = Omit<React.ComponentProps<typeof Input>, 'type'>;
 
-export function PasswordInput(props: PasswordInputProps) {
+export function PasswordInput({ className, ...props }: PasswordInputProps) {
   const [visible, setVisible] = useState(false);
 
   return (
     <div className="relative">
-      <Input type={visible ? 'text' : 'password'} {...props} className="pr-10" />
+      <Input type={visible ? 'text' : 'password'} className={cn('pr-10', className)} {...props} />
       <button
         type="button"
         onClick={() => setVisible((v) => !v)}


### PR DESCRIPTION
## Summary

Fixes a bug in the `PasswordInput` component where a `className` passed by a caller was silently dropped instead of being merged.

Fixes #211
Follow-up to #210

## Root cause

`className="pr-10"` was placed after `{...props}` on the `Input` element, so any `className` in props was overridden. No current caller passes a `className` so there is no visible bug today, but as a reusable `ui/` component the first caller that needs an error style or `aria-invalid` class would silently lose it.

## Change

- Destructure `className` out of props in the function signature
- Merge with `cn('pr-10', className)` so `pr-10` is always applied as the base and the caller's class is appended
- Place `className` before `{...props}` so the spread cannot override it

## Acceptance criteria

- [x] A `className` passed to `PasswordInput` is merged with `pr-10` (both applied), not dropped
- [x] The four existing auth forms render unchanged (none pass a `className`)
- [x] TypeScript: zero errors
- [x] Lint: zero new errors