### PR TITLE
docs(readme): fold tagline into a single left-aligned H1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 [![MIT License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Built%20with-Claude%20Code-green?style=for-the-badge&logo=anthropic)](https://claude.com/claude-code)
 
-# Ansvisor - Open-source AI Visibility Platform for AI Search
-
 </div>
+
+# Ansvisor - Open-source AI Visibility Platform for AI Search
 
 The search landscape is transforming fast. Buyers are moving from traditional search engines to AI platforms like ChatGPT, Claude, Gemini, Google AI Mode, etc.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 [![MIT License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Built%20with-Claude%20Code-green?style=for-the-badge&logo=anthropic)](https://claude.com/claude-code)
 
-# Ansvisor
-
-**Open-source AI Visibility & AI Search Optimization Platform**
+# Ansvisor - Open-source AI Visibility Platform for AI Search
 
 </div>
 


### PR DESCRIPTION
## Summary

Moves the project name and tagline into a single left-aligned H1.

## Changes

- Updated H1 to "Ansvisor - Open-source AI Visibility Platform for AI Search"
- Removed the old subtitle line
- Kept banner and badges centered

## Testing

- Documentation-only change

Fixes #204