### PR TITLE
fix(traffic): point cloud tracking snippet to api.ansvisor.com

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -637,7 +637,7 @@ function CompetitorsTab({ brandId }: { brandId: string }) {
 function TrackingTab({ brand }: { brand: Brand }) {
   const [copied, setCopied] = useState<'code' | 'snippet' | null>(null);
   const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
-  const apiUrl = isCloud ? 'https://api.ansops.ai' : process.env.NEXT_PUBLIC_API_URL;
+  const apiUrl = isCloud ? 'https://api.ansvisor.com' : process.env.NEXT_PUBLIC_API_URL;
   const snippet = apiUrl
     ? `<script src="${apiUrl}/t.js" data-t="${brand.trackingCode || ''}" defer></script>`
     : '';

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -107,7 +107,7 @@ function DeltaBadge({ current, previous }: { current: number; previous: number }
 function SnippetBanner({ trackingCode }: { trackingCode?: string }) {
   const [copied, setCopied] = useState(false);
   const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
-  const apiUrl = isCloud ? 'https://api.ansops.ai' : process.env.NEXT_PUBLIC_API_URL;
+  const apiUrl = isCloud ? 'https://api.ansvisor.com' : process.env.NEXT_PUBLIC_API_URL;
   const snippet = `<script src="${apiUrl}/t.js" data-t="${trackingCode || 'YOUR_TRACKING_CODE'}" defer></script>`;
 
   if (!trackingCode || !apiUrl) return null;


### PR DESCRIPTION
## What

Fixes the AI-traffic install snippet, which hardcoded `https://api.ansops.ai` in cloud mode. That host is **NXDOMAIN**, so the `<script src="…/t.js">` cloud users copy never loaded and no traffic was ever recorded. Switched to the correct managed API host `https://api.ansvisor.com` (same as `NEXT_PUBLIC_API_URL`).

Closes #217.

## Changes

Two snippet builders, one line each:

- `web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx`
- `web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx`

```diff
- const apiUrl = isCloud ? 'https://api.ansops.ai' : process.env.NEXT_PUBLIC_API_URL;
+ const apiUrl = isCloud ? 'https://api.ansvisor.com' : process.env.NEXT_PUBLIC_API_URL;
```

Self-hosted mode (`!isCloud`) still uses `NEXT_PUBLIC_API_URL`, unchanged.

## Verification

- `grep -rni ansops` over `web/src` + `server/src` → no matches remain.
- `https://api.ansvisor.com/t.js` returns HTTP 200; `POST https://api.ansvisor.com/track/<code>` returns 204 and records a row in `ai_traffic_logs`. `api.ansops.ai` is NXDOMAIN.
- Prettier `format:check` passes on both files.
