### PR TITLE
Added Product Tour button

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
@@ -5,7 +5,7 @@ import { getBrands } from '@/lib/actions/brand';
 import { getPlan, isCloud as checkIsCloud } from '@/config/plans';
 import { BrandsClient } from './_brands-client';
 import { Button } from '@/components/ui/button';
-import { Crown, Plus } from 'lucide-react';
+import { Crown, Plus , Compass , ExternalLink } from 'lucide-react';
 
 function BrandsHeader({
   canAddBrand,
@@ -21,6 +21,17 @@ function BrandsHeader({
         <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
         <p className="text-muted-foreground text-sm">{t('description')}</p>
       </div>
+      <div className="flex items-center gap-2">
+      <a
+        href="https://app.supademo.com/demo/cmq2b1p5k0rk9qm6ugicrn655?utm_source=link"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-input bg-background text-foreground bg-clip-padding text-sm font-medium whitespace-nowrap transition-all h-8 px-2.5 gap-2 hover:bg-accent hover:text-accent-foreground"
+      >
+        <Compass className="h-4 w-4 shrink-0" />
+        <span>Product Tour</span>
+        <ExternalLink className="h-4 w-4 shrink-0 opacity-50" />
+      </a>
       {canAddBrand ? (
         <Link href="/dashboard/brands/new">
           <Button className="gap-2">
@@ -36,6 +47,7 @@ function BrandsHeader({
           </Button>
         </Link>
       ) : null}
+      </div>
     </div>
   );
 }

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx
@@ -4,8 +4,8 @@ import { createClient } from '@/lib/supabase/server';
 import { getBrands } from '@/lib/actions/brand';
 import { getPlan, isCloud as checkIsCloud } from '@/config/plans';
 import { BrandsClient } from './_brands-client';
-import { Button } from '@/components/ui/button';
-import { Crown, Plus , Compass , ExternalLink } from 'lucide-react';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Crown, Plus, Compass, ExternalLink } from 'lucide-react';
 
 function BrandsHeader({
   canAddBrand,
@@ -22,31 +22,31 @@ function BrandsHeader({
         <p className="text-muted-foreground text-sm">{t('description')}</p>
       </div>
       <div className="flex items-center gap-2">
-      <a
-        href="https://app.supademo.com/demo/cmq2b1p5k0rk9qm6ugicrn655?utm_source=link"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-input bg-background text-foreground bg-clip-padding text-sm font-medium whitespace-nowrap transition-all h-8 px-2.5 gap-2 hover:bg-accent hover:text-accent-foreground"
-      >
-        <Compass className="h-4 w-4 shrink-0" />
-        <span>Product Tour</span>
-        <ExternalLink className="h-4 w-4 shrink-0 opacity-50" />
-      </a>
-      {canAddBrand ? (
-        <Link href="/dashboard/brands/new">
-          <Button className="gap-2">
-            <Plus className="h-4 w-4" />
-            {t('addBrand')}
-          </Button>
-        </Link>
-      ) : needsUpgrade ? (
-        <Link href="/dashboard/settings?tab=billing">
-          <Button variant="outline" className="gap-2">
-            <Crown className="h-4 w-4" />
-            {t('addBrand')}
-          </Button>
-        </Link>
-      ) : null}
+        <a
+          href="https://app.supademo.com/demo/cmq2b1p5k0rk9qm6ugicrn655?utm_source=link"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonVariants({ variant: 'outline', size: 'sm' })}
+        >
+          <Compass className="h-4 w-4 shrink-0" />
+          <span>Product Tour</span>
+          <ExternalLink className="h-4 w-4 shrink-0 opacity-50" />
+        </a>
+        {canAddBrand ? (
+          <Link href="/dashboard/brands/new">
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              {t('addBrand')}
+            </Button>
+          </Link>
+        ) : needsUpgrade ? (
+          <Link href="/dashboard/settings?tab=billing">
+            <Button variant="outline" className="gap-2">
+              <Crown className="h-4 w-4" />
+              {t('addBrand')}
+            </Button>
+          </Link>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Add Product Tour button to Brands page header

Fix #194

## What changed
Added a **Product Tour** button to the `BrandsHeader` component in `web/src/app/[locale]/(dashboard)/dashboard/brands/page.tsx`.

## Details
- Button is positioned immediately to the left of the **Add Brand** button in the page header
- Opens the interactive product tour in a new tab (`target="_blank"`, `rel="noopener noreferrer"`)
- URL: `https://app.supademo.com/demo/cmq2b1p5k0rk9qm6ugicrn655?utm_source=link`
- Renders as an outline/secondary style so **Add Brand** remains the primary action
- Always visible regardless of `canAddBrand` / `needsUpgrade` state
- Uses `Compass` and `ExternalLink` icons from `lucide-react`
- Label: **Product Tour**

## Screenshots
<img width="293" height="86" alt="Screenshot 2026-06-10 195447" src="https://github.com/user-attachments/assets/d1b5fb8e-4118-42d9-b3a3-1783bbf5c323" />

## Notes
- Button styling follows existing outline conventions; minor theme color variance may be addressed in a follow-up