### PR TITLE
chore(github): add issue forms & PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report something that isn't working as expected
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the sections below so we can reproduce and fix it quickly.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the behavior?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment mode
+      description: Are you on the managed cloud or a self-hosted instance?
+      options:
+        - Cloud (ansvisor.com)
+        - Self-hosted
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser / OS / Node version, as relevant.
+      placeholder: "e.g. Chrome 125 on macOS 14, Node 20"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Console output, server logs, or screenshots. This is automatically formatted as code, so no need for backticks.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://docs.ansvisor.com
+    about: Setup, self-hosting, and usage guides.
+  - name: Questions & Ideas
+    url: https://github.com/ansvisor/ansvisor/discussions
+    about: Ask a question or propose an idea in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! For open-ended ideas you can also start a thread in [Discussions](https://github.com/ansvisor/ansvisor/discussions/categories/ideas).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What's the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] `feat` — New feature
+- [ ] `fix` — Bug fix
+- [ ] `chore` — Maintenance / dependencies
+- [ ] `docs` — Documentation only
+- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
+- [ ] `test` — Adding or updating tests
+
+## Checklist
+
+- [ ] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] `yarn lint` passes (run from `web/`)
+- [ ] `yarn typecheck` passes (run from `web/`)
+- [ ] `yarn format:check` passes (run from `web/`)
+- [ ] Changes are focused — one concern per PR


### PR DESCRIPTION
Closes https://github.com/ansvisor/ansvisor/issues/180

## What

The repo had no `.github/ISSUE_TEMPLATE/` and no PR template. This adds them.

- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — GitHub YAML issue form: description, steps to reproduce, expected vs actual, a **Cloud / Self-hosted** dropdown, environment (browser/OS/Node), and a `render: shell` logs field. Auto-labels `bug`.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — issue form: problem/motivation, proposed solution, alternatives considered. Auto-labels `enhancement`. Points open-ended ideas to Discussions.
- **`.github/ISSUE_TEMPLATE/config.yml`** — `blank_issues_enabled: false` so the chooser is the entry point, plus contact links to the docs (https://docs.ansvisor.com) and Discussions.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — summary, related issue, type-of-change (mapped to the Conventional Commit types in `CONTRIBUTING.md`), and a checklist.

## Checklist alignment

Per `CONTRIBUTING.md`, the **web app uses yarn**, so the PR checklist lists `yarn lint`, `yarn typecheck`, and `yarn format:check` run from `web/` (these are the actual package scripts CI runs — `yarn typecheck` is the project's `tsc --noEmit` alias). Branch-naming and Conventional Commits links point back to `CONTRIBUTING.md`.

## Verification

- All three issue-form YAMLs parse cleanly (`yaml.safe_load`).
- File layout matches GitHub's expected paths, so opening a new issue will show the **Bug report** / **Feature request** chooser and new PRs will pre-fill the template.

Docs-only / community-health change — no application code touched.