### PR TITLE
fix(insights): CSV export writes platform display names, not slugs

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useState, useEffect } from 'react';
+import { PLATFORM_LABELS } from '@/config/platform-labels';
 import {
   AreaChart,
   Area,
@@ -101,25 +102,6 @@ const PLATFORM_COLORS: Record<string, string> = {
   'claude-opus-4-6': '#ea580c',
   'gemini-2.5-pro': '#22c55e',
   'gemini-2.5-flash': '#4ade80',
-};
-
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
-  'google-ai-mode': 'Google AI Mode',
-  'google-aimode': 'Google AI Mode',
-  'gpt-5-chat-latest': 'GPT-5',
-  'gpt-5-mini': 'GPT-5 Mini',
-  'claude-sonnet-4-6': 'Claude Sonnet 4.6',
-  'claude-opus-4-6': 'Claude Opus 4.6',
-  'gemini-2.5-pro': 'Gemini 2.5 Pro',
-  'gemini-2.5-flash': 'Gemini 2.5 Flash',
 };
 
 // ─── Custom Tooltips ──────────────────────────────────────────────────────────

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -29,6 +29,7 @@ import {
   type BreakdownMetric,
 } from '@/lib/actions/tracking';
 import { getTopics } from '@/lib/actions/topic';
+import { PLATFORM_LABELS } from '@/config/platform-labels';
 import type { Topic } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -209,25 +210,6 @@ function VisibilityBar({ score, max = 100 }: { score: number; max?: number }) {
     </div>
   );
 }
-
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
-  'google-ai-mode': 'Google AI Mode',
-  'chatgpt-web': 'ChatGPT',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'perplexity-web': 'Perplexity',
-  'gemini-web': 'Google Gemini',
-};
 
 const MODEL_DISPLAY_NAME: Record<string, string> = {
   'gpt-4o': 'GPT-4o',
@@ -1646,7 +1628,7 @@ export default function InsightsPage() {
       created_at: r.createdAt,
       prompt: r.promptText,
       topic: r.topicName ?? '',
-      platform: r.platform,
+      platform: PLATFORM_LABELS[r.platform] ?? r.platform,
       model: r.modelUsed ?? '',
       region: r.region ?? '',
       mention_count: r.mentionCount,

--- a/web/src/config/platform-labels.ts
+++ b/web/src/config/platform-labels.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical platform display-name map.
+ *
+ * Centralized here so the insights charts, the page-level labels, and the CSV
+ * export all render the same human-readable names instead of raw slugs. Always
+ * look up with a fallback (`PLATFORM_LABELS[slug] ?? slug`) so unknown
+ * platforms stay visible rather than disappearing.
+ *
+ * It also carries a few model-slug labels, because a couple of chart/progress
+ * spots reuse this map to label models when no platform is available.
+ */
+export const PLATFORM_LABELS: Record<string, string> = {
+  // Generic platform slugs.
+  chatgpt: 'ChatGPT',
+  gemini: 'Gemini',
+  perplexity: 'Perplexity',
+  claude: 'Claude',
+  grok: 'Grok',
+  copilot: 'Copilot',
+  'meta-ai': 'Meta AI',
+  'google-ai-overviews': 'Google AI',
+  'google-ai-mode': 'Google AI Mode',
+
+  // Tracked scraper platform slugs, as stored in `prompt_results.platform`.
+  'chatgpt-web': 'ChatGPT',
+  'google-aio': 'Google AI Overview',
+  'google-aimode': 'Google AI Mode',
+  'copilot-web': 'Microsoft Copilot',
+  'grok-web': 'Grok',
+  'perplexity-web': 'Perplexity',
+  'gemini-web': 'Google Gemini',
+
+  // Model slugs reused as a fallback label in a few chart/progress spots.
+  'gpt-5-chat-latest': 'GPT-5',
+  'gpt-5-mini': 'GPT-5 Mini',
+  'claude-sonnet-4-6': 'Claude Sonnet 4.6',
+  'claude-opus-4-6': 'Claude Opus 4.6',
+  'gemini-2.5-pro': 'Gemini 2.5 Pro',
+  'gemini-2.5-flash': 'Gemini 2.5 Flash',
+};


### PR DESCRIPTION
Closes https://github.com/ansvisor/ansvisor/issues/187

## Problem

On `/dashboard/insights`, **Export CSV** wrote the raw platform slug (e.g. `chatgpt-web`, `google-aio`) in the `platform` column, while the charts and tables everywhere else show display names (`ChatGPT`, `Google AI Overview`). `handleExportCsv` mapped `platform: r.platform` directly.

The label map existed but lived locally — and was in fact **duplicated** in both `_charts.tsx` and `page.tsx` — so the export couldn't reach it.

## Fix

- New shared module `web/src/config/platform-labels.ts` exporting `PLATFORM_LABELS` — the **union of the two local copies**, every existing label preserved (generic slugs, the tracked `*-web`/`google-aio`/`google-aimode` slugs, plus the handful of model-slug fallback labels the charts already carried).
- `_charts.tsx` and `insights/page.tsx` now import from it; both local definitions removed.
- CSV export maps `platform: PLATFORM_LABELS[r.platform] ?? r.platform` — falls back to the raw slug for unknown platforms so nothing disappears.

## Verification

- `yarn typecheck` — clean
- `yarn lint` — clean (the one `groupResultsByPrompt` warning is pre-existing on `main`, unrelated)
- `yarn format:check` — clean
- `yarn build` — compiles; `/[locale]/dashboard/insights` and `/insights/[id]` render

## Follow-up (out of scope, noted)

There are **three more** copies of essentially the same map, with minor label drift between them, in `insights/[id]/page.tsx`, `prompts/[id]/page.tsx`, and `citations/page.tsx` (e.g. `gemini-web` is `Gemini` in some, `Google Gemini` in others; `google-ai-overviews` is `Google AI` vs `Google AI Overview`). I kept this PR scoped to the export bug rather than silently changing labels on those unrelated pages — happy to follow up with a second PR that migrates all three onto the shared module if wanted.