### PR TITLE
fix(web): group insights results by platform

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/grouping.test.ts
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/grouping.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { PromptResultWithText } from '@/lib/actions/tracking';
+import { groupResultsByPlatform } from './grouping';
+
+function result(overrides: Partial<PromptResultWithText>): PromptResultWithText {
+  return {
+    id: 'result-id',
+    promptId: 'prompt-id',
+    brandId: 'brand-id',
+    platform: 'chatgpt-web',
+    response: 'response text',
+    citations: [],
+    mentionCount: 0,
+    citationCount: 0,
+    sentiment: 'neutral',
+    visibilityScore: 0,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    promptText: 'Where should I buy running shoes?',
+    ...overrides,
+  };
+}
+
+describe('groupResultsByPlatform', () => {
+  it('keeps model slug drift in one platform group and uses latest metadata', () => {
+    const groups = groupResultsByPlatform([
+      result({
+        id: 'older-run',
+        modelUsed: 'gpt-5-5',
+        region: 'US',
+        mentionCount: 1,
+        citationCount: 2,
+        visibilityScore: 40,
+        createdAt: '2026-06-01T00:00:00.000Z',
+      }),
+      result({
+        id: 'latest-run',
+        modelUsed: 'gpt-5-3-mini',
+        region: 'CA',
+        mentionCount: 3,
+        citationCount: 4,
+        visibilityScore: 80,
+        createdAt: '2026-06-02T00:00:00.000Z',
+      }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      key: 'chatgpt-web',
+      platform: 'chatgpt-web',
+      modelUsed: 'gpt-5-3-mini',
+      region: 'CA',
+      latestScore: 80,
+      avgScore: 60,
+      totalMentions: 4,
+      totalCitations: 6,
+    });
+    expect(groups[0].results.map((r) => r.id)).toEqual(['latest-run', 'older-run']);
+  });
+
+  it('keeps genuinely distinct platforms separate even when model slugs match', () => {
+    const groups = groupResultsByPlatform([
+      result({
+        id: 'chatgpt-run',
+        platform: 'chatgpt-web',
+        modelUsed: 'gpt-5-3-mini',
+        visibilityScore: 70,
+      }),
+      result({
+        id: 'grok-run',
+        platform: 'grok-web',
+        modelUsed: 'gpt-5-3-mini',
+        visibilityScore: 65,
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.key).sort()).toEqual(['chatgpt-web', 'grok-web']);
+  });
+});

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/grouping.ts
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/grouping.ts
@@ -1,0 +1,116 @@
+import type { PromptResultWithText } from '@/lib/actions/tracking';
+
+export interface PlatformGroup {
+  key: string;
+  platform: string;
+  modelUsed?: string;
+  region?: string;
+  results: PromptResultWithText[];
+  latest: PromptResultWithText;
+  latestScore: number;
+  avgScore: number;
+  totalMentions: number;
+  totalCitations: number;
+}
+
+export interface PromptGroup {
+  promptId: string;
+  promptText: string;
+  promptCategory?: string;
+  results: PromptResultWithText[];
+  platformGroups: PlatformGroup[];
+  avgScore: number;
+  totalMentions: number;
+  totalCitations: number;
+}
+
+export interface TopicGroup {
+  topicId: string;
+  topicName: string;
+  prompts: PromptGroup[];
+  avgScore: number;
+  totalMentions: number;
+  totalCitations: number;
+  totalResults: number;
+}
+
+export function groupResultsByPlatform(items: PromptResultWithText[]): PlatformGroup[] {
+  const map = new Map<string, PromptResultWithText[]>();
+  for (const r of items) {
+    const key = r.platform;
+    const arr = map.get(key) || [];
+    arr.push(r);
+    map.set(key, arr);
+  }
+
+  return Array.from(map.entries())
+    .map(([key, arr]) => {
+      const sorted = [...arr].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+      const latest = sorted[0];
+      return {
+        key,
+        platform: latest.platform,
+        modelUsed: latest.modelUsed,
+        region: latest.region,
+        results: sorted,
+        latest,
+        latestScore: latest.visibilityScore,
+        avgScore:
+          Math.round((sorted.reduce((s, r) => s + r.visibilityScore, 0) / sorted.length) * 10) / 10,
+        totalMentions: sorted.reduce((s, r) => s + r.mentionCount, 0),
+        totalCitations: sorted.reduce((s, r) => s + r.citationCount, 0),
+      } satisfies PlatformGroup;
+    })
+    .sort((a, b) => b.latestScore - a.latestScore);
+}
+
+function computePromptGroup(promptId: string, items: PromptResultWithText[]): PromptGroup {
+  const sorted = [...items].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+  return {
+    promptId,
+    promptText: sorted[0].promptText,
+    promptCategory: sorted[0].promptCategory,
+    results: sorted,
+    platformGroups: groupResultsByPlatform(sorted),
+    avgScore: Math.round(sorted.reduce((s, r) => s + r.visibilityScore, 0) / sorted.length),
+    totalMentions: sorted.reduce((s, r) => s + r.mentionCount, 0),
+    totalCitations: sorted.reduce((s, r) => s + r.citationCount, 0),
+  };
+}
+
+export function groupResultsByTopic(results: PromptResultWithText[]): TopicGroup[] {
+  const topicMap = new Map<string, PromptResultWithText[]>();
+  for (const r of results) {
+    const key = r.topicName ?? '__uncategorized__';
+    const arr = topicMap.get(key) || [];
+    arr.push(r);
+    topicMap.set(key, arr);
+  }
+
+  return Array.from(topicMap.entries())
+    .map(([topicName, items]) => {
+      const promptMap = new Map<string, PromptResultWithText[]>();
+      for (const r of items) {
+        const arr = promptMap.get(r.promptId) || [];
+        arr.push(r);
+        promptMap.set(r.promptId, arr);
+      }
+      const prompts = Array.from(promptMap.entries()).map(([pid, pItems]) =>
+        computePromptGroup(pid, pItems),
+      );
+      return {
+        topicId: items[0].topicId ?? `__cat_${topicName}`,
+        topicName: topicName === '__uncategorized__' ? 'Uncategorized' : topicName,
+        prompts,
+        avgScore: Math.round(items.reduce((s, r) => s + r.visibilityScore, 0) / items.length),
+        totalMentions: items.reduce((s, r) => s + r.mentionCount, 0),
+        totalCitations: items.reduce((s, r) => s + r.citationCount, 0),
+        totalResults: items.length,
+      } satisfies TopicGroup;
+    })
+    .sort((a, b) => b.avgScore - a.avgScore);
+}

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -11,6 +11,7 @@ import {
   ShareOfVoiceTrendChart,
 } from './_charts';
 import { MetricBreakdownSheet } from './_metric-breakdown-sheet';
+import { groupResultsByTopic, type PlatformGroup, type PromptGroup } from './grouping';
 import { useBrandStore } from '@/stores/use-brand-store';
 import {
   getPromptResults,
@@ -271,131 +272,6 @@ function ModelBadge({ model, platform }: { model: string; platform?: string }) {
       <span className="text-xs">{getModelDisplayName(model, platform)}</span>
     </span>
   );
-}
-
-interface PlatformGroup {
-  key: string;
-  platform: string;
-  modelUsed?: string;
-  region?: string;
-  results: PromptResultWithText[];
-  latest: PromptResultWithText;
-  latestScore: number;
-  avgScore: number;
-  totalMentions: number;
-  totalCitations: number;
-}
-
-interface PromptGroup {
-  promptId: string;
-  promptText: string;
-  promptCategory?: string;
-  results: PromptResultWithText[];
-  platformGroups: PlatformGroup[];
-  avgScore: number;
-  totalMentions: number;
-  totalCitations: number;
-}
-
-function groupResultsByPlatform(items: PromptResultWithText[]): PlatformGroup[] {
-  const map = new Map<string, PromptResultWithText[]>();
-  for (const r of items) {
-    const key = `${r.platform}|${r.modelUsed ?? ''}`;
-    const arr = map.get(key) || [];
-    arr.push(r);
-    map.set(key, arr);
-  }
-
-  return Array.from(map.entries())
-    .map(([key, arr]) => {
-      const sorted = [...arr].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-      );
-      const latest = sorted[0];
-      return {
-        key,
-        platform: latest.platform,
-        modelUsed: latest.modelUsed,
-        region: latest.region,
-        results: sorted,
-        latest,
-        latestScore: latest.visibilityScore,
-        avgScore:
-          Math.round((sorted.reduce((s, r) => s + r.visibilityScore, 0) / sorted.length) * 10) / 10,
-        totalMentions: sorted.reduce((s, r) => s + r.mentionCount, 0),
-        totalCitations: sorted.reduce((s, r) => s + r.citationCount, 0),
-      } satisfies PlatformGroup;
-    })
-    .sort((a, b) => b.latestScore - a.latestScore);
-}
-
-function computePromptGroup(promptId: string, items: PromptResultWithText[]): PromptGroup {
-  const sorted = [...items].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-  );
-  return {
-    promptId,
-    promptText: sorted[0].promptText,
-    promptCategory: sorted[0].promptCategory,
-    results: sorted,
-    platformGroups: groupResultsByPlatform(sorted),
-    avgScore: Math.round(sorted.reduce((s, r) => s + r.visibilityScore, 0) / sorted.length),
-    totalMentions: sorted.reduce((s, r) => s + r.mentionCount, 0),
-    totalCitations: sorted.reduce((s, r) => s + r.citationCount, 0),
-  };
-}
-
-function groupResultsByPrompt(results: PromptResultWithText[]): PromptGroup[] {
-  const map = new Map<string, PromptResultWithText[]>();
-  for (const r of results) {
-    const arr = map.get(r.promptId) || [];
-    arr.push(r);
-    map.set(r.promptId, arr);
-  }
-  return Array.from(map.entries()).map(([promptId, items]) => computePromptGroup(promptId, items));
-}
-
-interface TopicGroup {
-  topicId: string;
-  topicName: string;
-  prompts: PromptGroup[];
-  avgScore: number;
-  totalMentions: number;
-  totalCitations: number;
-  totalResults: number;
-}
-
-function groupResultsByTopic(results: PromptResultWithText[]): TopicGroup[] {
-  const topicMap = new Map<string, PromptResultWithText[]>();
-  for (const r of results) {
-    const key = r.topicName ?? '__uncategorized__';
-    const arr = topicMap.get(key) || [];
-    arr.push(r);
-    topicMap.set(key, arr);
-  }
-
-  return Array.from(topicMap.entries())
-    .map(([topicName, items]) => {
-      const promptMap = new Map<string, PromptResultWithText[]>();
-      for (const r of items) {
-        const arr = promptMap.get(r.promptId) || [];
-        arr.push(r);
-        promptMap.set(r.promptId, arr);
-      }
-      const prompts = Array.from(promptMap.entries()).map(([pid, pItems]) =>
-        computePromptGroup(pid, pItems),
-      );
-      return {
-        topicId: items[0].topicId ?? `__cat_${topicName}`,
-        topicName: topicName === '__uncategorized__' ? 'Uncategorized' : topicName,
-        prompts,
-        avgScore: Math.round(items.reduce((s, r) => s + r.visibilityScore, 0) / items.length),
-        totalMentions: items.reduce((s, r) => s + r.mentionCount, 0),
-        totalCitations: items.reduce((s, r) => s + r.citationCount, 0),
-        totalResults: items.length,
-      };
-    })
-    .sort((a, b) => b.avgScore - a.avgScore);
 }
 
 // ─── Delta Badge ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

- Group the insights dashboard prompt-result buckets by platform only, so provider model slug changes do not split one logical platform into duplicate rows.
- Keep the platform group's model metadata sourced from the latest run, so the badge still reflects the current model.
- Move the pure grouping helpers into a small local module and add Vitest coverage for slug drift plus distinct-platform separation.

## Related issue

Closes #231

## Type of change

- [ ] `feat` - New feature
- [x] `fix` - Bug fix
- [ ] `chore` - Maintenance / dependencies
- [ ] `docs` - Documentation only
- [ ] `refactor` - Code change that neither fixes a bug nor adds a feature
- [x] `test` - Adding or updating tests

## Validation

- `corepack yarn test 'src/app/[locale]/(dashboard)/dashboard/insights/grouping.test.ts'`
- `corepack yarn prettier --check 'src/app/[locale]/(dashboard)/dashboard/insights/page.tsx' 'src/app/[locale]/(dashboard)/dashboard/insights/grouping.ts' 'src/app/[locale]/(dashboard)/dashboard/insights/grouping.test.ts'`
- `corepack yarn eslint 'src/app/[locale]/(dashboard)/dashboard/insights/page.tsx' 'src/app/[locale]/(dashboard)/dashboard/insights/grouping.ts' 'src/app/[locale]/(dashboard)/dashboard/insights/grouping.test.ts'`
- `corepack yarn format:check`
- `corepack yarn test`
- `corepack yarn typecheck`
- `corepack yarn lint` (0 errors; existing unrelated warnings remain in other files)
- `git diff --cached --check`

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) - see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused - one concern per PR
