### PR TITLE
fix(web): group prompt detail results by platform

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.test.ts
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { PromptResultWithText } from '@/lib/actions/tracking';
+import { groupByPlatform } from './grouping';
+
+function result(overrides: Partial<PromptResultWithText>): PromptResultWithText {
+  return {
+    id: 'result-id',
+    promptId: 'prompt-id',
+    brandId: 'brand-id',
+    platform: 'chatgpt-web',
+    response: 'response text',
+    citations: [],
+    mentionCount: 0,
+    citationCount: 0,
+    sentiment: 'neutral',
+    visibilityScore: 0,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    promptText: 'Where should I buy running shoes?',
+    ...overrides,
+  };
+}
+
+describe('groupByPlatform', () => {
+  it('keeps model slug drift in one platform group and uses latest metadata', () => {
+    const groups = groupByPlatform([
+      result({
+        id: 'older-run',
+        modelUsed: 'gpt-5-5',
+        region: 'US',
+        mentionCount: 1,
+        citationCount: 2,
+        visibilityScore: 40,
+        createdAt: '2026-06-01T00:00:00.000Z',
+      }),
+      result({
+        id: 'latest-run',
+        modelUsed: 'gpt-5-3-mini',
+        region: 'CA',
+        mentionCount: 3,
+        citationCount: 4,
+        visibilityScore: 80,
+        createdAt: '2026-06-02T00:00:00.000Z',
+      }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      key: 'chatgpt-web',
+      platform: 'chatgpt-web',
+      modelUsed: 'gpt-5-3-mini',
+      region: 'CA',
+      avgScore: 60,
+      totalMentions: 4,
+      totalCitations: 6,
+    });
+    expect(groups[0].results.map((r) => r.id)).toEqual(['latest-run', 'older-run']);
+  });
+
+  it('keeps genuinely distinct platforms separate even when model slugs match', () => {
+    const groups = groupByPlatform([
+      result({
+        id: 'chatgpt-run',
+        platform: 'chatgpt-web',
+        modelUsed: 'gpt-5-3-mini',
+        visibilityScore: 70,
+      }),
+      result({
+        id: 'grok-run',
+        platform: 'grok-web',
+        modelUsed: 'gpt-5-3-mini',
+        visibilityScore: 65,
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.key).sort()).toEqual(['chatgpt-web', 'grok-web']);
+  });
+});

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.ts
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.ts
@@ -1,0 +1,43 @@
+import type { PromptResultWithText } from '@/lib/actions/tracking';
+
+export interface PlatformGroup {
+  key: string;
+  platform: string;
+  modelUsed?: string;
+  region?: string;
+  results: PromptResultWithText[];
+  avgScore: number;
+  totalMentions: number;
+  totalCitations: number;
+}
+
+export function groupByPlatform(results: PromptResultWithText[]): PlatformGroup[] {
+  const map = new Map<string, PromptResultWithText[]>();
+  for (const result of results) {
+    const key = result.platform;
+    const items = map.get(key) ?? [];
+    items.push(result);
+    map.set(key, items);
+  }
+
+  return Array.from(map.entries())
+    .map(([key, items]) => {
+      const sorted = [...items].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+      const latest = sorted[0];
+      return {
+        key,
+        platform: latest.platform,
+        modelUsed: latest.modelUsed,
+        region: latest.region,
+        results: sorted,
+        avgScore: Math.round(
+          sorted.reduce((sum, row) => sum + row.visibilityScore, 0) / sorted.length,
+        ),
+        totalMentions: sorted.reduce((sum, row) => sum + row.mentionCount, 0),
+        totalCitations: sorted.reduce((sum, row) => sum + row.citationCount, 0),
+      } satisfies PlatformGroup;
+    })
+    .sort((a, b) => b.avgScore - a.avgScore);
+}

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, ChevronDown, Clock, Eye, MessageSquareText, Quote } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { AIProviderAvatar, resolveAIProvider } from '@/components/ai-provider-avatar';
+import { groupByPlatform, type PlatformGroup } from './grouping';
 
 const PLATFORM_LABELS: Record<string, string> = {
   chatgpt: 'ChatGPT',
@@ -120,48 +121,6 @@ function VisibilityBar({ score }: { score: number }) {
       <span className="w-8 text-right text-xs font-semibold tabular-nums">{rounded}</span>
     </div>
   );
-}
-
-interface PlatformGroup {
-  key: string;
-  platform: string;
-  modelUsed?: string;
-  region?: string;
-  results: PromptResultWithText[];
-  avgScore: number;
-  totalMentions: number;
-  totalCitations: number;
-}
-
-function groupByPlatform(results: PromptResultWithText[]): PlatformGroup[] {
-  const map = new Map<string, PromptResultWithText[]>();
-  for (const result of results) {
-    const key = `${result.platform}|${result.modelUsed ?? ''}`;
-    const items = map.get(key) ?? [];
-    items.push(result);
-    map.set(key, items);
-  }
-
-  return Array.from(map.entries())
-    .map(([key, items]) => {
-      const sorted = [...items].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-      );
-      const latest = sorted[0];
-      return {
-        key,
-        platform: latest.platform,
-        modelUsed: latest.modelUsed,
-        region: latest.region,
-        results: sorted,
-        avgScore: Math.round(
-          sorted.reduce((sum, row) => sum + row.visibilityScore, 0) / sorted.length,
-        ),
-        totalMentions: sorted.reduce((sum, row) => sum + row.mentionCount, 0),
-        totalCitations: sorted.reduce((sum, row) => sum + row.citationCount, 0),
-      };
-    })
-    .sort((a, b) => b.avgScore - a.avgScore);
 }
 
 function KpiCard({


### PR DESCRIPTION
## Summary
- Extract the prompt detail page platform grouping helper into a local module, mirroring the accepted insights grouping pattern from #235.
- Group prompt detail results by `platform` only, so provider model slug changes do not split one logical platform into duplicate cards.
- Keep the group model/region metadata sourced from the latest run and add Vitest coverage for slug drift plus distinct-platform separation.

## Related issue

Closes #236

## Why

The prompt detail page had its own `groupByPlatform()` copy that keyed groups by `platform|modelUsed`. When a provider slug drifted over time, the same platform could appear as two cards even though it was the same logical platform history.

## Validation

- `corepack yarn install --frozen-lockfile`
- `corepack yarn test 'src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.test.ts'`
- `corepack yarn prettier --check 'src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx' 'src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.ts' 'src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.test.ts'`
- `corepack yarn eslint 'src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx' 'src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.ts' 'src/app/[locale]/(dashboard)/dashboard/prompts/[id]/grouping.test.ts'`
- `corepack yarn test`
- `corepack yarn typecheck`
- `corepack yarn format:check`
- `corepack yarn lint` (0 errors; existing unrelated warnings remain in other files)
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`

## Scope

Display/grouping layer only. No data fetching, RPC, or stored data changes.