### PR TITLE
fix(insights): move the raw results count out of the page header

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -1108,10 +1108,14 @@ function PromptResultsGrouped({
       <CardHeader className="pb-2">
         <div className="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
           <CardTitle className="text-sm font-medium">Prompt Results by Topic</CardTitle>
-          {truncated && (
+          {truncated ? (
             <p className="text-xs text-muted-foreground font-normal">
               Showing {loadedRowCount} of {totalRowCount} rows (newest first). Narrow the date range
               or filters to focus the list.
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground font-normal">
+              {totalRowCount} result{totalRowCount !== 1 ? 's' : ''}
             </p>
           )}
         </div>
@@ -1580,7 +1584,7 @@ export default function InsightsPage() {
           <h1 className="text-2xl font-bold tracking-tight">Answer Engine Insights</h1>
 
           <p className="text-muted-foreground text-sm">
-            {brand.name} · Last run: {lastCheckedLabel} · {totalResults} results
+            {brand.name} · Last run: {lastCheckedLabel}
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

On **Answer Engine Insights** (`/dashboard/insights`) the page header subtitle showed a raw results count:

```
{brand.name} · Last run: {lastCheckedLabel} · {N} results
```

That `N` is the size of the raw **Prompt Results** list (capped at ~1000 rows, newest-first). Sitting in the page header — above the KPI cards, the visibility trend, and the Brand vs Competitors leaderboard — it read as a **page-wide** figure and implied those top-level metrics were computed from at most ~1000 rows.

They are not: the KPI cards, leaderboard, and Share of Voice all come from server-side aggregate RPCs (`insights_aggregates`, `competitor_aggregates`, `share_of_voice_aggregates`) that aggregate over the **entire** dataset with no row cap. Only the raw results list (and the CSV export) is bounded.

## Change

Pure relocation of the existing count — no change to how the number is computed:

- **Removed** `· {totalResults} results` from the header subtitle, leaving `{brand.name} · Last run: {lastCheckedLabel}`.
- **Added** the count to the **"Prompt Results by Topic"** card header, where it correctly describes the list it refers to:
  - When the list is truncated, the existing `Showing X of Y rows (newest first)…` note already carries the total.
  - Otherwise, show a plain `{N} results` (singular/plural handled).

`totalResults` is still passed into the card as `totalRowCount`, so no dead state.

## Related issue

Closes #190

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] `yarn lint` passes (run from `web/`) — 0 errors
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
