### PR TITLE
fix(security): apply cloud tracking quota to /tracking/check

### DIFF
--- a/server/src/lib/tracking-quota.js
+++ b/server/src/lib/tracking-quota.js
@@ -1,0 +1,112 @@
+/**
+ * On-demand tracking cost controls (cloud mode).
+ *
+ * Both user-triggered tracking entry points — POST /api/tracking/check and
+ * POST /api/tracking/analyze-new — enqueue a real tracking job that spends
+ * Cloro + LLM credits. They must enforce the same cloud-mode guards so neither
+ * can be used to bypass billing:
+ *
+ *   1. an active (or trialing) subscription is required,
+ *   2. a per-brand daily on-demand cap, and
+ *   3. a per-brand cooldown between on-demand runs.
+ *
+ * Self-hosted installs (isCloud() === false) are unrestricted.
+ *
+ * Quota accounting keys off jobs whose `data` carries `onDemand: true`, so any
+ * caller that goes through this guard must also tag its job with onDemand:true
+ * (otherwise its runs won't count toward the cap / cooldown).
+ */
+import supabaseAdmin from '../config/supabase.js';
+import { isCloud, getPlan, isSubscriptionActive } from '../config/plans.js';
+
+/**
+ * Carries the HTTP status + JSON body a route should return when a run is
+ * blocked, so the existing response shapes are preserved exactly.
+ */
+export class TrackingQuotaError extends Error {
+  constructor(statusCode, body) {
+    super(body.message || 'Tracking quota exceeded');
+    this.name = 'TrackingQuotaError';
+    this.statusCode = statusCode;
+    this.body = body;
+  }
+}
+
+/**
+ * Enforce the cloud-mode subscription gate + daily on-demand limit + cooldown
+ * for an on-demand tracking run. No-op when self-hosted. Throws
+ * TrackingQuotaError when the run must be blocked.
+ *
+ * @param {string} brandId
+ * @param {string} organizationId  the brand's organization_id
+ */
+export async function enforceOnDemandTrackingQuota(brandId, organizationId) {
+  if (!isCloud()) return;
+
+  const { data: org } = await supabaseAdmin
+    .from('organizations')
+    .select('plan, subscription_status')
+    .eq('id', organizationId)
+    .single();
+
+  // Block tracking outright when the org's Stripe subscription isn't active or
+  // trialing. Previously this fell back to starter limits, which let
+  // unsubscribed signups run jobs silently.
+  if (!isSubscriptionActive(org?.subscription_status)) {
+    throw new TrackingQuotaError(402, {
+      message:
+        'An active subscription or free trial is required to run tracking. Please choose a plan to continue.',
+    });
+  }
+
+  const plan = getPlan(org.plan);
+  const { maxDailyOnDemand, onDemandCooldownMinutes } = plan.limits;
+
+  // Daily on-demand limit
+  if (maxDailyOnDemand !== -1) {
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const { count: todayCount } = await supabaseAdmin
+      .from('jobs')
+      .select('id', { count: 'exact', head: true })
+      .eq('brand_id', brandId)
+      .eq('type', 'tracking')
+      .gte('created_at', todayStart.toISOString())
+      .contains('data', { onDemand: true });
+
+    if ((todayCount || 0) >= maxDailyOnDemand) {
+      throw new TrackingQuotaError(429, {
+        success: false,
+        message: `Daily on-demand analysis limit reached (${maxDailyOnDemand}/day). Next analyses will run with the daily scheduled job.`,
+        limit: maxDailyOnDemand,
+      });
+    }
+  }
+
+  // Cooldown between on-demand runs
+  if (onDemandCooldownMinutes > 0) {
+    const cooldownCutoff = new Date(Date.now() - onDemandCooldownMinutes * 60 * 1000).toISOString();
+
+    const { data: recentJobs } = await supabaseAdmin
+      .from('jobs')
+      .select('created_at')
+      .eq('brand_id', brandId)
+      .eq('type', 'tracking')
+      .contains('data', { onDemand: true })
+      .gte('created_at', cooldownCutoff)
+      .limit(1);
+
+    if (recentJobs && recentJobs.length > 0) {
+      const nextAvailable = new Date(
+        new Date(recentJobs[0].created_at).getTime() + onDemandCooldownMinutes * 60 * 1000,
+      );
+      const minutesLeft = Math.ceil((nextAvailable.getTime() - Date.now()) / 60_000);
+      throw new TrackingQuotaError(429, {
+        success: false,
+        message: `Please wait ${minutesLeft} minute${minutesLeft !== 1 ? 's' : ''} before running another analysis.`,
+        retryAfterMinutes: minutesLeft,
+      });
+    }
+  }
+}

--- a/server/src/routes/tracking.js
+++ b/server/src/routes/tracking.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { createJob, getJob, cancelJob } from '../lib/job-manager.js';
 import { runTrackingJob } from '../lib/job-runner.js';
 import supabaseAdmin from '../config/supabase.js';
-import { isCloud, getPlan, isSubscriptionActive } from '../config/plans.js';
+import { enforceOnDemandTrackingQuota, TrackingQuotaError } from '../lib/tracking-quota.js';
 import { assertBrandAccess } from '../lib/access.js';
 
 const router = Router();
@@ -41,10 +41,14 @@ router.post('/check', async (req, res) => {
       return res.status(403).json({ success: false, message: 'Unauthorized' });
     }
 
+    // Same cloud-mode cost controls as /analyze-new — this endpoint also
+    // enqueues a real (full-brand when no promptId) tracking run.
+    await enforceOnDemandTrackingQuota(brandId, brand.organization_id);
+
     const job = await createJob({
       type: 'tracking',
       brandId,
-      data: { brandId, promptId: promptId || null, immediate: true },
+      data: { brandId, promptId: promptId || null, immediate: true, onDemand: true },
       maxAttempts: 3,
     });
 
@@ -57,6 +61,9 @@ router.post('/check', async (req, res) => {
       message: 'Tracking job enqueued',
     });
   } catch (error) {
+    if (error instanceof TrackingQuotaError) {
+      return res.status(error.statusCode).json(error.body);
+    }
     console.error('[tracking] Check error:', error.message);
     return res.status(500).json({ success: false, message: error.message });
   }
@@ -155,78 +162,8 @@ router.post('/analyze-new', async (req, res) => {
       return res.json({ success: true, newCount: 0, message: 'All prompts already analyzed' });
     }
 
-    // --- Cloud-mode subscription gate + rate limiting ---
-    if (isCloud()) {
-      const { data: org } = await supabaseAdmin
-        .from('organizations')
-        .select('plan, subscription_status')
-        .eq('id', brand.organization_id)
-        .single();
-
-      // Block tracking outright when the org's Stripe subscription isn't
-      // active or trialing. Previously this fell back to starter limits,
-      // which let unsubscribed signups run jobs silently.
-      if (!isSubscriptionActive(org?.subscription_status)) {
-        return res.status(402).json({
-          message:
-            'An active subscription or free trial is required to run tracking. Please choose a plan to continue.',
-        });
-      }
-
-      const plan = getPlan(org.plan);
-
-      const { maxDailyOnDemand, onDemandCooldownMinutes } = plan.limits;
-
-      // Check daily on-demand limit
-      if (maxDailyOnDemand !== -1) {
-        const todayStart = new Date();
-        todayStart.setHours(0, 0, 0, 0);
-
-        const { count: todayCount } = await supabaseAdmin
-          .from('jobs')
-          .select('id', { count: 'exact', head: true })
-          .eq('brand_id', brandId)
-          .eq('type', 'tracking')
-          .gte('created_at', todayStart.toISOString())
-          .contains('data', { onDemand: true });
-
-        if ((todayCount || 0) >= maxDailyOnDemand) {
-          return res.status(429).json({
-            success: false,
-            message: `Daily on-demand analysis limit reached (${maxDailyOnDemand}/day). Next analyses will run with the daily scheduled job.`,
-            limit: maxDailyOnDemand,
-          });
-        }
-      }
-
-      // Check cooldown
-      if (onDemandCooldownMinutes > 0) {
-        const cooldownCutoff = new Date(
-          Date.now() - onDemandCooldownMinutes * 60 * 1000,
-        ).toISOString();
-
-        const { data: recentJobs } = await supabaseAdmin
-          .from('jobs')
-          .select('created_at')
-          .eq('brand_id', brandId)
-          .eq('type', 'tracking')
-          .contains('data', { onDemand: true })
-          .gte('created_at', cooldownCutoff)
-          .limit(1);
-
-        if (recentJobs && recentJobs.length > 0) {
-          const nextAvailable = new Date(
-            new Date(recentJobs[0].created_at).getTime() + onDemandCooldownMinutes * 60 * 1000,
-          );
-          const minutesLeft = Math.ceil((nextAvailable.getTime() - Date.now()) / 60_000);
-          return res.status(429).json({
-            success: false,
-            message: `Please wait ${minutesLeft} minute${minutesLeft !== 1 ? 's' : ''} before running another analysis.`,
-            retryAfterMinutes: minutesLeft,
-          });
-        }
-      }
-    }
+    // --- Cloud-mode subscription gate + rate limiting (shared with /check) ---
+    await enforceOnDemandTrackingQuota(brandId, brand.organization_id);
 
     const job = await createJob({
       type: 'tracking',
@@ -245,6 +182,9 @@ router.post('/analyze-new', async (req, res) => {
       message: `Analyzing ${newPromptIds.length} new prompt${newPromptIds.length !== 1 ? 's' : ''}`,
     });
   } catch (error) {
+    if (error instanceof TrackingQuotaError) {
+      return res.status(error.statusCode).json(error.body);
+    }
     console.error('[tracking] analyze-new error:', error.message);
     return res.status(500).json({ success: false, message: error.message });
   }


### PR DESCRIPTION
## Summary

`POST /api/tracking/check` enqueued a real tracking run (full-brand when no `promptId` is passed) after **only an ownership check**, while `POST /api/tracking/analyze-new` gated the same kind of run behind three cloud-mode controls: an active/trialing subscription (`402`), a per-brand daily on-demand cap (`429`), and a per-brand cooldown (`429`).

So any authenticated user could call `/check` to **bypass billing** and trigger **unbounded Cloro + LLM spend** — repeatedly, and even with no active subscription.

## Change

- Extract the shared guard into **`server/src/lib/tracking-quota.js`** — `enforceOnDemandTrackingQuota(brandId, organizationId)` + `TrackingQuotaError`, preserving the exact `402`/`429` status codes and response bodies.
- Call it from **both** `/check` and `/analyze-new` (the inline block in `analyze-new` is replaced by the helper — single source of truth, no drift).
- `/check`'s job is now tagged `onDemand: true` so its runs **count toward** the daily cap and cooldown (previously untracked).

## Why it's safe — no impact on legitimate flows

- **Self-hosted** (`isCloud() === false`): the guard is a no-op — unrestricted, unchanged.
- **Active/trialing (paying) orgs**: pass the guard exactly as they pass `/analyze-new` today — unaffected.
- **Onboarding is not broken**:
  - Cloud onboarding triggers the first tracking run via the internal `/api/internal/trigger-tracking` endpoint (CRON_SECRET) **after payment**, which this guard does not touch; the org is `trialing`/`active` by then anyway.
  - The only `/check` call in the onboarding flow runs **in self-hosted mode only** (cloud returns to the subscription step before it), where the guard is a no-op.
- Non-active orgs that could previously abuse `/check` are now blocked consistently — they were already blocked on `/analyze-new`, so this is the existing policy applied uniformly, not a new restriction.

## Verification

- `node --check`, `eslint`, `prettier` clean on both files.
- Read-only confirmed against the codebase + DB: onboarding path, the `active`/`trialing` pass-through, and that the guard logic is a faithful extraction (identical status codes/bodies).

## Type of change

- [x] `fix` — security / billing-bypass
