### PR TITLE
fix: add aria-labels to icon-only buttons for accessibility

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/layout.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/layout.tsx
@@ -41,7 +41,7 @@ export default function BrandDetailLayout({
       {/* Brand header + back */}
       <div className="flex items-center gap-4">
         <Link href="/dashboard/brands">
-          <Button variant="ghost" size="icon">
+          <Button variant="ghost" size="icon" aria-label="Back to brands list">
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -409,6 +409,7 @@ function DomainsTab({
                   size="icon"
                   className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
                   onClick={() => removeDomainLocal(d.id)}
+                  aria-label="Remove domain"
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                 </Button>
@@ -441,6 +442,7 @@ function DomainsTab({
               size="icon"
               onClick={addDomain}
               disabled={!newDomain.trim()}
+              aria-label="Add domain"
             >
               <Plus className="h-4 w-4" />
             </Button>
@@ -557,6 +559,7 @@ function CompetitorsTab({ brandId }: { brandId: string }) {
                         size="icon"
                         className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
                         onClick={() => setDeletingId(c.id)}
+                        aria-label="Delete competitor"
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                       </Button>
@@ -693,6 +696,7 @@ function TrackingTab({ brand }: { brand: Brand }) {
                   size="icon"
                   className="shrink-0"
                   onClick={() => copyToClipboard(brand.trackingCode!, 'code')}
+                  aria-label="Copy tracking code"
                 >
                   {copied === 'code' ? (
                     <Check className="h-4 w-4 text-green-500" />
@@ -720,6 +724,7 @@ function TrackingTab({ brand }: { brand: Brand }) {
                     size="icon"
                     className="absolute top-2 right-2 h-7 w-7"
                     onClick={() => copyToClipboard(snippet, 'snippet')}
+                    aria-label="Copy tracking script"
                   >
                     {copied === 'snippet' ? (
                       <Check className="h-3.5 w-3.5 text-green-500" />

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
@@ -159,6 +159,7 @@ export default function BrandTopicsPage({ params }: PageProps) {
                           size="icon"
                           className="h-7 w-7 shrink-0"
                           onClick={() => handleEdit(topic.id)}
+                          aria-label="Save topic changes"
                         >
                           <Check className="h-3.5 w-3.5" />
                         </Button>
@@ -167,6 +168,7 @@ export default function BrandTopicsPage({ params }: PageProps) {
                           size="icon"
                           className="h-7 w-7 shrink-0"
                           onClick={() => setEditingId(null)}
+                          aria-label="Cancel edit"
                         >
                           <X className="h-3.5 w-3.5" />
                         </Button>
@@ -184,6 +186,7 @@ export default function BrandTopicsPage({ params }: PageProps) {
                                 setEditingId(topic.id);
                                 setEditName(topic.name);
                               }}
+                              aria-label="Edit topic"
                             >
                               <Pencil className="h-3.5 w-3.5" />
                             </Button>
@@ -194,6 +197,7 @@ export default function BrandTopicsPage({ params }: PageProps) {
                                     variant="ghost"
                                     size="icon"
                                     className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
+                                    aria-label="Delete topic"
                                   />
                                 }
                               >

--- a/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
@@ -700,6 +700,7 @@ function ModelSubGroup({
               e.stopPropagation();
               onViewRow(group.latest);
             }}
+            aria-label="View latest AI response"
           >
             <Eye className="h-3.5 w-3.5" />
           </Button>
@@ -750,6 +751,7 @@ function ModelSubGroup({
                         e.stopPropagation();
                         onViewRow(row);
                       }}
+                      aria-label="View AI response"
                     >
                       <Eye className="h-3 w-3" />
                     </Button>

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
@@ -183,7 +183,7 @@ export default function ContentDetailPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-4">
         <Link href="/dashboard/content">
-          <Button variant="ghost" size="icon">
+          <Button variant="ghost" size="icon" aria-label="Go back to content list">
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -927,6 +927,7 @@ function PlatformSubGroup({
                               e.stopPropagation();
                               onViewResult(r);
                             }}
+                            aria-label="View previous run details"
                           >
                             <Eye className="h-3 w-3" />
                           </Button>
@@ -1019,6 +1020,7 @@ function PromptSubGroup({
               e.stopPropagation();
               onRefresh(group.promptId);
             }}
+            aria-label="Refresh prompt results"
           >
             {refreshingId === group.promptId ? (
               <Loader2 className="h-3 w-3 animate-spin" />

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -250,6 +250,7 @@ function PlatformResultGroup({
                     event.stopPropagation();
                     onViewResult(result);
                   }}
+                  aria-label="View response details"
                 >
                   <Eye className="h-3.5 w-3.5" />
                 </Button>

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
@@ -182,6 +182,7 @@ export function SuggestionsCard({ brandId }: Props) {
                       onClick={() => handleAccept(s)}
                       disabled={busy}
                       title="Add to tracked prompts"
+                      aria-label="Add to tracked prompts"
                     >
                       {busy ? (
                         <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -195,7 +196,8 @@ export function SuggestionsCard({ brandId }: Props) {
                       className="h-8 w-8 text-muted-foreground"
                       onClick={() => handleDismiss(s)}
                       disabled={busy}
-                      title="Dismiss"
+                      title="Dismiss suggestion"
+                      aria-label="Dismiss suggestion"
                     >
                       <X className="h-3.5 w-3.5" />
                     </Button>

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -134,7 +134,13 @@ function SnippetBanner({ trackingCode }: { trackingCode?: string }) {
             </pre>
           </div>
         </div>
-        <Button variant="ghost" size="icon" className="shrink-0 h-8 w-8" onClick={handleCopy}>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="shrink-0 h-8 w-8"
+          onClick={handleCopy}
+          aria-label="Copy tracking script"
+        >
           {copied ? (
             <Check className="h-3.5 w-3.5 text-green-500" />
           ) : (

--- a/web/src/components/dashboard/prompt-suggestion-card.tsx
+++ b/web/src/components/dashboard/prompt-suggestion-card.tsx
@@ -161,6 +161,7 @@ export const PromptSuggestionCard = memo(function PromptSuggestionCard({
                 className="h-7 w-7 shrink-0"
                 onClick={handleSave}
                 disabled={!editText.trim() || !hasAnySelection}
+                aria-label="Save changes"
               >
                 <Check className="h-3.5 w-3.5" />
               </Button>
@@ -169,6 +170,7 @@ export const PromptSuggestionCard = memo(function PromptSuggestionCard({
                 variant="ghost"
                 className="h-7 w-7 shrink-0"
                 onClick={handleCancel}
+                aria-label="Cancel edit"
               >
                 <X className="h-3.5 w-3.5" />
               </Button>
@@ -327,6 +329,7 @@ export const PromptSuggestionCard = memo(function PromptSuggestionCard({
                 variant="ghost"
                 className="h-7 w-7"
                 onClick={() => setIsEditing(true)}
+                aria-label="Edit prompt"
               >
                 <Pencil className="h-3 w-3" />
               </Button>
@@ -338,6 +341,7 @@ export const PromptSuggestionCard = memo(function PromptSuggestionCard({
                         size="icon"
                         variant="ghost"
                         className="h-7 w-7 text-destructive hover:text-destructive"
+                        aria-label="Delete prompt"
                       />
                     }
                   >


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

- Add accessible names to icon-only buttons across the dashboard to ensure all interactive icon controls are properly labeled for screen readers.
- Improve overall accessibility consistency by ensuring no icon-only button relies solely on visual cues or tooltips.
- Standardize aria-label usage so assistive technologies can reliably identify button actions without ambiguity.

## Related issue
 Closes #221 


## Type of change

<!-- Check all that apply -->

- [ ] feat — New feature
- [x] fix — Bug fix
- [ ] chore — Maintenance / dependencies
- [ ] docs — Documentation only
- [ ] refactor — Code change that neither fixes a bug nor adds a feature
- [ ] test — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
