### PR TITLE
fix(shopping): parse Copilot shoppingProducts wrapper into per-product cards

### DIFF
--- a/server/src/lib/shopping-cards.js
+++ b/server/src/lib/shopping-cards.js
@@ -70,12 +70,17 @@ function parsePrice(value) {
         : typeof value.value === 'number'
           ? value.value
           : Number.parseFloat(value.amount ?? value.value ?? '');
-    const currency =
+    let currency =
       typeof value.currency === 'string'
         ? value.currency.toUpperCase()
         : typeof value.currencyCode === 'string'
           ? value.currencyCode.toUpperCase()
           : null;
+    // Providers (e.g. Copilot) often leave `currency` null but ship a
+    // `currencySymbol` like "₺" / "$". Map the symbol to an ISO code.
+    if (!currency && typeof value.currencySymbol === 'string') {
+      currency = CURRENCY_SYMBOLS[value.currencySymbol.trim()] ?? null;
+    }
     return {
       amount: Number.isFinite(amount) ? amount : null,
       currency: currency && CURRENCY_CODES.has(currency) ? currency : currency || null,
@@ -221,26 +226,49 @@ export function parseAiModeCard(card, position) {
 }
 
 /**
- * Microsoft Copilot card normalizer. CamelCase, slightly different field
- * names from AI Mode (`productName`, `productBrand`, `merchantName`).
+ * Microsoft Copilot product normalizer. Per the Cloro docs, Copilot ships
+ * shopping data as wrapper objects `{ type, layout, products: [ … ] }`;
+ * `normalizeShoppingCards` flattens those, so this receives an individual
+ * product:
+ *
+ *   { product, position, offerId, url, name, description, images,
+ *     specifications, tags, price, discountPrice, seller, sellerLogoUrl,
+ *     brandName, rating: { value, count }, canTrackPrice }
+ *
+ * Older fallbacks (`productName`, `imageUrl`, numeric `rating`) are kept so a
+ * shape change doesn't silently null the columns.
  *
  * @param {object} card
  * @param {number} position
  */
 export function parseCopilotCard(card, position) {
-  const price = parsePrice(card.price);
+  const price = parsePrice(card.price ?? card.discountPrice);
   const merchantUrl = toStringOrNull(card.url ?? card.link ?? card.productUrl);
+  // Images ship as `[{ title, url }]`; older shapes used a flat `imageUrl`.
+  const imageUrl =
+    toStringOrNull(card.imageUrl ?? card.image) ??
+    (Array.isArray(card.images) ? toStringOrNull(card.images[0]?.url) : null);
+  // Rating is an object `{ value, count }` in the documented shape, but
+  // tolerate a bare number from older/other shapes.
+  const ratingObj = card.rating && typeof card.rating === 'object' ? card.rating : null;
   return {
-    position,
-    product_title: toStringOrNull(card.productName ?? card.title ?? card.name),
-    product_brand: toStringOrNull(card.productBrand ?? card.brand ?? card.merchantName),
+    // The provider's own `position` is a flat 1-indexed rank across every
+    // card in the response — unique per result, so prefer it over the array
+    // index (which resets once we flatten the `products[]` wrappers).
+    position: toInteger(card.position) ?? position,
+    product_title: toStringOrNull(card.name ?? card.productName ?? card.title),
+    product_brand: toStringOrNull(
+      card.brandName ?? card.productBrand ?? card.brand ?? card.seller ?? card.merchantName,
+    ),
     price_amount: price.amount,
     price_currency: price.currency,
-    image_url: toStringOrNull(card.imageUrl ?? card.image),
+    image_url: imageUrl,
     merchant_url: merchantUrl,
     merchant_domain: extractHostname(merchantUrl),
-    rating: toNumber(card.rating),
-    review_count: toInteger(card.reviewCount ?? card.reviewsCount ?? card.reviews),
+    rating: ratingObj ? toNumber(ratingObj.value) : toNumber(card.rating),
+    review_count: ratingObj
+      ? toInteger(ratingObj.count)
+      : toInteger(card.reviewCount ?? card.reviewsCount ?? card.reviews ?? card.review),
     raw: card,
   };
 }
@@ -260,6 +288,31 @@ function pickParser(platform) {
 }
 
 /**
+ * Some providers (Microsoft Copilot) return shopping data as wrapper
+ * objects — `{ type: 'shoppingProducts', layout, products: [ … ] }` — rather
+ * than a flat array of product cards. Flatten any such wrapper into its
+ * `products` so each product becomes its own normalized card. Elements that
+ * are already flat product objects pass through untouched.
+ *
+ * @param {unknown[]} cards
+ * @returns {object[]}
+ */
+function flattenProductWrappers(cards) {
+  const out = [];
+  for (const card of cards) {
+    if (!card || typeof card !== 'object') continue;
+    if (Array.isArray(card.products)) {
+      for (const product of card.products) {
+        if (product && typeof product === 'object') out.push(product);
+      }
+    } else {
+      out.push(card);
+    }
+  }
+  return out;
+}
+
+/**
  * Normalize the raw `shopping_cards` array off a prompt_results row into
  * an array of analytical-column-shaped objects ready for insert.
  *
@@ -273,9 +326,8 @@ export function normalizeShoppingCards(platform, cards) {
   if (!Array.isArray(cards) || cards.length === 0) return [];
   const parser = pickParser(platform);
   if (!parser) return [];
-  return cards
+  return flattenProductWrappers(cards)
     .map((card, i) => {
-      if (!card || typeof card !== 'object') return null;
       try {
         return parser(card, i);
       } catch (err) {

--- a/server/src/lib/shopping-cards.test.js
+++ b/server/src/lib/shopping-cards.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeShoppingCards, parseCopilotCard } from './shopping-cards.js';
+
+// The documented Copilot response shape: a `shoppingProducts` wrapper whose
+// `products[]` holds the real cards. See Cloro docs — "Shopping cards".
+const copilotWrapper = {
+  type: 'shoppingProducts',
+  layout: 'Carousel',
+  products: [
+    {
+      product: { id: 'prod_12345', groupId: 'group_12345' },
+      position: 1,
+      offerId: 'offer_12345',
+      url: 'https://www.microsoft.com/en-us/d/surface-laptop-studio-2/8rqr54krf1dz',
+      name: 'Microsoft Surface Laptop Studio 2',
+      images: [{ title: 'Front view', url: 'https://example.com/surface.jpg' }],
+      price: { amount: 1999.99, currency: 'USD', currencySymbol: '$' },
+      seller: 'Microsoft Store',
+      brandName: 'Microsoft',
+      rating: { value: 4.7, count: 542 },
+      canTrackPrice: true,
+    },
+    {
+      // Real-world TR shape: no `currency`, only `currencySymbol`; brand only
+      // present in the name; rating absent.
+      position: 2,
+      url: 'https://www.occasion.com.tr/nike-air-max-1-kadin-beyaz-sneaker/?utm_source=copilot.com',
+      name: 'Nike W Air Max 1 Kadın Beyaz Sneaker',
+      images: [{ url: 'https://th.bing.com/th?id=OPEC.x', title: null }],
+      price: { amount: 4720, currency: null, currencySymbol: '₺' },
+      brandName: null,
+      rating: null,
+    },
+  ],
+};
+
+describe('normalizeShoppingCards — Copilot wrapper', () => {
+  const cards = normalizeShoppingCards('copilot-web', [copilotWrapper]);
+
+  it('flattens the products[] wrapper into one card per product', () => {
+    expect(cards).toHaveLength(2);
+  });
+
+  it('extracts the product title from `name` (not "Unknown Product")', () => {
+    expect(cards[0].product_title).toBe('Microsoft Surface Laptop Studio 2');
+    expect(cards[1].product_title).toBe('Nike W Air Max 1 Kadın Beyaz Sneaker');
+  });
+
+  it('uses the product-level flat `position`', () => {
+    expect(cards.map((c) => c.position)).toEqual([1, 2]);
+  });
+
+  it('parses price amount + currency, including symbol-only currency', () => {
+    expect(cards[0].price_amount).toBe(1999.99);
+    expect(cards[0].price_currency).toBe('USD');
+    expect(cards[1].price_amount).toBe(4720);
+    expect(cards[1].price_currency).toBe('TRY'); // derived from "₺"
+  });
+
+  it('reads the first image url + merchant domain', () => {
+    expect(cards[0].image_url).toBe('https://example.com/surface.jpg');
+    expect(cards[0].merchant_domain).toBe('microsoft.com');
+    expect(cards[1].merchant_domain).toBe('occasion.com.tr');
+  });
+
+  it('reads rating + review count from the rating object', () => {
+    expect(cards[0].rating).toBe(4.7);
+    expect(cards[0].review_count).toBe(542);
+    expect(cards[1].rating).toBeNull();
+    expect(cards[1].review_count).toBeNull();
+  });
+
+  it('prefers brandName, falling back to seller', () => {
+    expect(cards[0].product_brand).toBe('Microsoft');
+  });
+});
+
+describe('parseCopilotCard — bare product (already flat)', () => {
+  it('still parses a non-wrapped product', () => {
+    const card = parseCopilotCard({ name: 'Foo', price: { amount: 10, currencySymbol: '$' } }, 0);
+    expect(card.product_title).toBe('Foo');
+    expect(card.price_currency).toBe('USD');
+    expect(card.position).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Microsoft Copilot returns shopping data as a **wrapper object** `{ type, layout, products: [...] }`, not a flat array of product cards (confirmed against the [Cloro docs](https://docs.cloro.dev)). The normalizer treated each wrapper as a single card and looked for the product name at the wrapper level — which only has `type` / `layout` / `products` — so:

- every Copilot result collapsed to **one empty row** → the drawer showed **"Cards returned (1)" / "Unknown Product"**
- the real products inside `products[]` (name, price, image, rating) were silently dropped

100% of stored Copilot cards (28/28) were affected; Perplexity / Google AI Mode are unaffected (different, already-flat shapes).

## Fix

- **`normalizeShoppingCards`** — flatten `products[]` wrappers into one normalized card per product (platform-agnostic; flat cards pass through untouched)
- **`parseCopilotCard`** — map the documented product schema: `name`, `brandName` / `seller`, `images[].url`, `rating.{value,count}` (object), and the product's flat 1-indexed `position` (kept unique per result). Older fallbacks (`productName`, `imageUrl`, numeric `rating`) retained.
- **`parsePrice`** — derive the ISO currency from `currencySymbol` (e.g. `₺` → `TRY`, `$` → `USD`) when `currency` is null, which it is for non-US Copilot results

## Tests

Adds `server/src/lib/shopping-cards.test.js` (8 tests) covering the wrapper flatten, `name` extraction, symbol-only currency, `images[].url`, the rating object, and brand fallback. `vitest` + `prettier` + `eslint` clean.

## Validation

Ran the new normalizer against real stored data: a wrapper that previously produced 1 "Unknown Product" now expands to its 6 real products with title, price, currency, merchant domain, image, and rating all populated.

## Data backfill

The 28 stale empty rows have already been removed and re-derived from `prompt_results.shopping_cards` via `backfill-shopping-cards.js` (162 correct product cards, 0 null titles). **No further data step is needed** — this PR only needs a server redeploy so new Copilot results parse correctly going forward.