### PR TITLE
fix(web): prevent spurious 'Failed to fetch' toast when switching brand tabs

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -127,13 +127,14 @@ export default function PromptsPage() {
     } catch {}
   }, [brandId]);
 
-  const loadData = useCallback(async () => {
+  const loadData = useCallback(async (isCancelled?: () => boolean) => {
     try {
       const [brandData, sets, topicsData] = await Promise.all([
         getBrandById(brandId),
         getPromptSets(brandId),
         getTopics(brandId),
       ]);
+      if (isCancelled?.()) return;
       setBrand(brandData);
       setTopics(topicsData);
       if (topicsData.length > 0 && !manualCategory) {
@@ -142,15 +143,18 @@ export default function PromptsPage() {
       setGenerateTopics((prev) => (prev === null ? topicsData.map((t) => t.name) : prev));
       setPromptSets(sets);
     } catch {
+      if (isCancelled?.()) return;
       toast.error('Failed to load data');
     } finally {
-      setIsLoading(false);
+      if (!isCancelled?.()) setIsLoading(false);
     }
     fetchUnanalyzed();
   }, [brandId, manualCategory, fetchUnanalyzed]);
 
   useEffect(() => {
-    loadData();
+    let cancelled = false;
+    loadData(() => cancelled);
+    return () => { cancelled = true; };
   }, [loadData]);
 
   const handleGenerate = async () => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -127,34 +127,39 @@ export default function PromptsPage() {
     } catch {}
   }, [brandId]);
 
-  const loadData = useCallback(async (isCancelled?: () => boolean) => {
-    try {
-      const [brandData, sets, topicsData] = await Promise.all([
-        getBrandById(brandId),
-        getPromptSets(brandId),
-        getTopics(brandId),
-      ]);
-      if (isCancelled?.()) return;
-      setBrand(brandData);
-      setTopics(topicsData);
-      if (topicsData.length > 0 && !manualCategory) {
-        setManualCategory(topicsData[0].name);
+  const loadData = useCallback(
+    async (isCancelled?: () => boolean) => {
+      try {
+        const [brandData, sets, topicsData] = await Promise.all([
+          getBrandById(brandId),
+          getPromptSets(brandId),
+          getTopics(brandId),
+        ]);
+        if (isCancelled?.()) return;
+        setBrand(brandData);
+        setTopics(topicsData);
+        if (topicsData.length > 0 && !manualCategory) {
+          setManualCategory(topicsData[0].name);
+        }
+        setGenerateTopics((prev) => (prev === null ? topicsData.map((t) => t.name) : prev));
+        setPromptSets(sets);
+      } catch {
+        if (isCancelled?.()) return;
+        toast.error('Failed to load data');
+      } finally {
+        if (!isCancelled?.()) setIsLoading(false);
       }
-      setGenerateTopics((prev) => (prev === null ? topicsData.map((t) => t.name) : prev));
-      setPromptSets(sets);
-    } catch {
-      if (isCancelled?.()) return;
-      toast.error('Failed to load data');
-    } finally {
-      if (!isCancelled?.()) setIsLoading(false);
-    }
-    fetchUnanalyzed();
-  }, [brandId, manualCategory, fetchUnanalyzed]);
+      fetchUnanalyzed();
+    },
+    [brandId, manualCategory, fetchUnanalyzed],
+  );
 
   useEffect(() => {
     let cancelled = false;
     loadData(() => cancelled);
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [loadData]);
 
   const handleGenerate = async () => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -468,24 +468,29 @@ function CompetitorsTab({ brandId }: { brandId: string }) {
   const [newName, setNewName] = useState('');
   const [newDomain, setNewDomain] = useState('');
 
-  const load = useCallback(async (isCancelled?: () => boolean) => {
-    setIsLoading(true);
-    try {
-      const data = await getCompetitors(brandId);
-      if (isCancelled?.()) return;
-      setCompetitors(data);
-    } catch {
-      if (isCancelled?.()) return;
-      toast.error('Failed to load competitors');
-    } finally {
-      if (!isCancelled?.()) setIsLoading(false);
-    }
-  }, [brandId]);
+  const load = useCallback(
+    async (isCancelled?: () => boolean) => {
+      setIsLoading(true);
+      try {
+        const data = await getCompetitors(brandId);
+        if (isCancelled?.()) return;
+        setCompetitors(data);
+      } catch {
+        if (isCancelled?.()) return;
+        toast.error('Failed to load competitors');
+      } finally {
+        if (!isCancelled?.()) setIsLoading(false);
+      }
+    },
+    [brandId],
+  );
 
   useEffect(() => {
     let cancelled = false;
     load(() => cancelled);
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [load]);
 
   const handleAdd = async () => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -468,20 +468,24 @@ function CompetitorsTab({ brandId }: { brandId: string }) {
   const [newName, setNewName] = useState('');
   const [newDomain, setNewDomain] = useState('');
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (isCancelled?: () => boolean) => {
     setIsLoading(true);
     try {
       const data = await getCompetitors(brandId);
+      if (isCancelled?.()) return;
       setCompetitors(data);
     } catch {
+      if (isCancelled?.()) return;
       toast.error('Failed to load competitors');
     } finally {
-      setIsLoading(false);
+      if (!isCancelled?.()) setIsLoading(false);
     }
   }, [brandId]);
 
   useEffect(() => {
-    load();
+    let cancelled = false;
+    load(() => cancelled);
+    return () => { cancelled = true; };
   }, [load]);
 
   const handleAdd = async () => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
@@ -44,10 +44,11 @@ export default function BrandTopicsPage({ params }: PageProps) {
   const [editName, setEditName] = useState('');
   const { canManage } = useUserRole();
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (isCancelled?: () => boolean) => {
     setIsLoading(true);
     try {
       const data = await getTopics(brandId);
+      if (isCancelled?.()) return;
       setTopics(data);
       const counts: Record<string, number> = {};
       await Promise.all(
@@ -55,16 +56,20 @@ export default function BrandTopicsPage({ params }: PageProps) {
           counts[t.id] = await getPromptCountByTopic(brandId, t.name);
         }),
       );
+      if (isCancelled?.()) return;
       setPromptCounts(counts);
     } catch {
+      if (isCancelled?.()) return;
       toast.error('Failed to load topics');
     } finally {
-      setIsLoading(false);
+      if (!isCancelled?.()) setIsLoading(false);
     }
   }, [brandId]);
 
   useEffect(() => {
-    load();
+    let cancelled = false;
+    load(() => cancelled);
+    return () => { cancelled = true; };
   }, [load]);
 
   const handleAdd = async () => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
@@ -44,32 +44,37 @@ export default function BrandTopicsPage({ params }: PageProps) {
   const [editName, setEditName] = useState('');
   const { canManage } = useUserRole();
 
-  const load = useCallback(async (isCancelled?: () => boolean) => {
-    setIsLoading(true);
-    try {
-      const data = await getTopics(brandId);
-      if (isCancelled?.()) return;
-      setTopics(data);
-      const counts: Record<string, number> = {};
-      await Promise.all(
-        data.map(async (t) => {
-          counts[t.id] = await getPromptCountByTopic(brandId, t.name);
-        }),
-      );
-      if (isCancelled?.()) return;
-      setPromptCounts(counts);
-    } catch {
-      if (isCancelled?.()) return;
-      toast.error('Failed to load topics');
-    } finally {
-      if (!isCancelled?.()) setIsLoading(false);
-    }
-  }, [brandId]);
+  const load = useCallback(
+    async (isCancelled?: () => boolean) => {
+      setIsLoading(true);
+      try {
+        const data = await getTopics(brandId);
+        if (isCancelled?.()) return;
+        setTopics(data);
+        const counts: Record<string, number> = {};
+        await Promise.all(
+          data.map(async (t) => {
+            counts[t.id] = await getPromptCountByTopic(brandId, t.name);
+          }),
+        );
+        if (isCancelled?.()) return;
+        setPromptCounts(counts);
+      } catch {
+        if (isCancelled?.()) return;
+        toast.error('Failed to load topics');
+      } finally {
+        if (!isCancelled?.()) setIsLoading(false);
+      }
+    },
+    [brandId],
+  );
 
   useEffect(() => {
     let cancelled = false;
     load(() => cancelled);
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [load]);
 
   const handleAdd = async () => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -22,6 +22,7 @@ import {
   getJobStatus,
   cancelTrackingJob,
   getBrandPrompts,
+  exportPromptResults,
   type PromptResultWithText,
   type InsightsSummary,
   type CompetitorComparisonData,
@@ -1227,6 +1228,7 @@ export default function InsightsPage() {
   const [competitorData, setCompetitorData] = useState<CompetitorComparisonData | null>(null);
   const [sovData, setSovData] = useState<ShareOfVoiceData | null>(null);
   const [breakdownMetric, setBreakdownMetric] = useState<BreakdownMetric | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
 
@@ -1505,36 +1507,77 @@ export default function InsightsPage() {
     }
   };
 
-  const handleExportCsv = useCallback(() => {
-    const rows = results.map((r) => ({
-      created_at: r.createdAt,
-      prompt: r.promptText,
-      topic: r.topicName ?? '',
-      platform: PLATFORM_LABELS[r.platform] ?? r.platform,
-      model: r.modelUsed ?? '',
-      region: r.region ?? '',
-      mention_count: r.mentionCount,
-      citation_count: r.citationCount,
-      visibility_score: r.visibilityScore,
-      sentiment: r.sentiment,
-      citation_urls: r.citations.map((c) => c.url).join(', '),
-      competitor_mentions:
-        r.competitorMentions?.map((c) => `${c.name}:${c.mention_count}`).join(', ') ?? '',
-    }));
+  const handleExportCsv = useCallback(async () => {
+    if (!brand) return;
+    setIsExporting(true);
+    try {
+      const f = filtersRef.current;
+      const { dateFrom, dateTo } = getDateRange(f.datePreset, {
+        from: f.dateFrom,
+        to: f.dateTo,
+      });
+      const filterOpts = {
+        model: f.model || undefined,
+        region: f.region || undefined,
+        topicId: f.topic || undefined,
+        dateFrom,
+        dateTo,
+      };
 
-    const csv = toCsv(rows, INSIGHT_EXPORT_HEADERS);
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    const date = new Date().toISOString().slice(0, 10);
-    const slug = brand?.slug ?? 'brand';
+      const { results: allResults, isCapped } = await exportPromptResults(brand.id, filterOpts);
 
-    link.href = url;
-    link.download = `ansvisor_${slug}_insights_${date}.csv`;
-    link.click();
+      const rows: Record<string, string | number>[] = allResults.map((r) => ({
+        created_at: r.createdAt,
+        prompt: r.promptText,
+        topic: r.topicName ?? '',
+        platform: PLATFORM_LABELS[r.platform] ?? r.platform,
+        model: r.modelUsed ?? '',
+        region: r.region ?? '',
+        mention_count: r.mentionCount,
+        citation_count: r.citationCount,
+        visibility_score: r.visibilityScore,
+        sentiment: r.sentiment,
+        citation_urls: r.citations.map((c) => c.url).join(', '),
+        competitor_mentions:
+          r.competitorMentions?.map((c) => `${c.name}:${c.mention_count}`).join(', ') ?? '',
+      }));
 
-    URL.revokeObjectURL(url);
-  }, [brand?.slug, results]);
+      if (isCapped) {
+        rows.push({
+          created_at: 'WARNING',
+          prompt: 'Export capped at 50,000 rows',
+          topic: '',
+          platform: '',
+          model: '',
+          region: '',
+          mention_count: 0,
+          citation_count: 0,
+          visibility_score: 0,
+          sentiment: '',
+          citation_urls: '',
+          competitor_mentions: '',
+        });
+        toast.warning('Export capped at 50,000 rows to prevent memory issues');
+      }
+
+      const csv = toCsv(rows, INSIGHT_EXPORT_HEADERS);
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      const date = new Date().toISOString().slice(0, 10);
+      const slug = brand.slug ?? 'brand';
+
+      link.href = url;
+      link.download = `ansvisor_${slug}_insights_${date}.csv`;
+      link.click();
+
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to export CSV');
+    } finally {
+      setIsExporting(false);
+    }
+  }, [brand]);
 
   if (!brand || (isLoading && !summary)) return <InsightsSkeleton />;
 
@@ -1592,9 +1635,18 @@ export default function InsightsPage() {
 
         <div className="flex items-center gap-2 shrink-0">
           {/* Always visible */}
-          <Button variant="outline" className="gap-2" onClick={handleExportCsv}>
-            <Download className="h-4 w-4" />
-            Export CSV
+          <Button
+            variant="outline"
+            className="gap-2"
+            onClick={handleExportCsv}
+            disabled={isExporting}
+          >
+            {isExporting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="h-4 w-4" />
+            )}
+            {isExporting ? 'Exporting...' : 'Export CSV'}
           </Button>
 
           {/* Self-host only */}

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -291,6 +291,112 @@ export async function getPromptResults(
 }
 
 /**
+ * Fetch all prompt results for export, bypassing the default 1000 limit by paginating.
+ * Applies a hard ceiling to prevent OOM errors on massive datasets.
+ */
+export async function exportPromptResults(
+  brandId: string,
+  opts?: {
+    platform?: string;
+    model?: string;
+    region?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    promptId?: string;
+    topicId?: string;
+  },
+): Promise<{ results: PromptResultWithText[]; isCapped: boolean }> {
+  const allRows: Record<string, unknown>[] = [];
+  const pageSize = 1000;
+  const hardCeiling = 50000;
+  let isCapped = false;
+  let offset = 0;
+
+  while (true) {
+    const { query } = await buildResultsQuery(brandId, opts);
+    const { data, error } = await query
+      .order('created_at', { ascending: false })
+      .range(offset, offset + pageSize - 1);
+
+    if (error) throw new Error(error.message);
+    const rows = (data ?? []) as Record<string, unknown>[];
+    allRows.push(...rows);
+
+    if (rows.length < pageSize) {
+      break; // Reached the end
+    }
+
+    offset += pageSize;
+    if (offset >= hardCeiling) {
+      isCapped = true;
+      break;
+    }
+  }
+
+  const { supabase } = await buildResultsQuery(brandId, opts);
+
+  const promptIds = [...new Set(allRows.map((r) => r.prompt_id as string))];
+  const promptRowsRaw: Record<string, unknown>[] = [];
+  const chunkSize = 500;
+
+  for (let i = 0; i < promptIds.length; i += chunkSize) {
+    const chunk = promptIds.slice(i, i + chunkSize);
+    if (chunk.length > 0) {
+      const { data: pRows } = await supabase
+        .from('prompts')
+        .select('id, text, category, topic_id')
+        .in('id', chunk);
+      if (pRows) {
+        promptRowsRaw.push(...(pRows as unknown as Record<string, unknown>[]));
+      }
+    }
+  }
+
+  const topicIds = [
+    ...new Set(promptRowsRaw.map((p) => p.topic_id as string | null).filter(Boolean) as string[]),
+  ];
+  const topicRowsRaw: Record<string, unknown>[] = [];
+
+  for (let i = 0; i < topicIds.length; i += chunkSize) {
+    const chunk = topicIds.slice(i, i + chunkSize);
+    if (chunk.length > 0) {
+      const { data: tRows } = await supabase.from('topics').select('id, name').in('id', chunk);
+      if (tRows) {
+        topicRowsRaw.push(...(tRows as Record<string, unknown>[]));
+      }
+    }
+  }
+
+  const topicMap = new Map(topicRowsRaw.map((t) => [t.id as string, t.name as string]));
+
+  const promptMap = new Map(
+    promptRowsRaw.map((p) => [
+      p.id as string,
+      {
+        text: p.text as string,
+        category: p.category as string | null,
+        topicId: p.topic_id as string | null,
+      },
+    ]),
+  );
+
+  const results = allRows.map((r) => {
+    const pm = promptMap.get(r.prompt_id as string);
+    return {
+      ...mapResultRow(r),
+      promptText: (pm?.text as string) ?? '',
+      promptCategory: (pm?.category as string | null) ?? undefined,
+      topicId: (pm?.topicId as string | null) ?? undefined,
+      topicName: pm?.topicId
+        ? (topicMap.get(pm.topicId) ?? (pm?.category as string | null) ?? undefined)
+        : ((pm?.category as string | null) ?? undefined),
+    };
+  });
+
+  return { results, isCapped };
+}
+
+/**
  * Fetch a single prompt result by its ID, joining prompt text.
  */
 export async function getPromptResultById(resultId: string): Promise<PromptResultWithText | null> {


### PR DESCRIPTION
## Summary

This PR fixes an issue where rapidly switching between the Topics, Prompts, and Settings tabs triggers a red "Failed to fetch" toast. The fix uses a cancellation flag (abort guard) within the `useEffect` cleanup function. By passing this flag to the async data loaders, we prevent the generic error toast from firing when Next.js naturally aborts the network requests during component unmount/navigation.

## Related issue

Closes #227 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
