### PR TITLE
chore(types): remove unused deprecated Project interface

### DIFF
--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -36,17 +36,6 @@ export interface BrandDomain {
   isPrimary: boolean;
 }
 
-/** @deprecated Use Brand + BrandDomain instead */
-export interface Project {
-  id: string;
-  organizationId: string;
-  brandId?: string;
-  name: string;
-  domain: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
 export interface PromptSet {
   id: string;
   brandId: string;


### PR DESCRIPTION
## Summary

- Remove the unused deprecated `Project` interface from `web/src/types/index.ts`.
- Clean up dead code now that the migration to `Brand` and `BrandDomain` is complete and no references remain.
- Preserve existing behavior while reducing unused type definitions and maintenance overhead.

## Related issue

Closes #226

## Type of change

- [ ] feat — New feature
- [ ] fix — Bug fix
- [x] chore — Maintenance / dependencies
- [ ] docs — Documentation only
- [ ] refactor — Code change that neither fixes a bug nor adds a feature
- [ ] test — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see CONTRIBUTING.md
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] Changes are focused — one concern per PR