### PR TITLE
fix(audit): retry LLM calls so transient failures don't drop recommendations

### DIFF
--- a/server/src/lib/audit/audit.test.js
+++ b/server/src/lib/audit/audit.test.js
@@ -5,6 +5,7 @@ import { fleschReadingEase, classifyLinks, jsonLd, countPhrases } from './signal
 import { jsonLdPresence, h1Quality } from './signals/structure.js';
 import { https, metaDescription } from './signals/trust.js';
 import { length } from './signals/content.js';
+import { withRetry } from './retry.js';
 
 /** Build a minimal audit context from an HTML string (no network). */
 function ctxFromHtml(html, extra = {}) {
@@ -85,6 +86,49 @@ describe('helpers', () => {
 
   it('countPhrases counts case-insensitive occurrences', () => {
     expect(countPhrases('We tested it. Then WE TESTED again.', ['we tested'])).toBe(2);
+  });
+});
+
+describe('withRetry', () => {
+  it('returns the value on first success without retrying', async () => {
+    let calls = 0;
+    const out = await withRetry(
+      async () => {
+        calls += 1;
+        return 'ok';
+      },
+      { attempts: 3, baseDelayMs: 0 },
+    );
+    expect(out).toBe('ok');
+    expect(calls).toBe(1);
+  });
+
+  it('retries transient failures then succeeds', async () => {
+    let calls = 0;
+    const out = await withRetry(
+      async () => {
+        calls += 1;
+        if (calls < 3) throw new Error('transient');
+        return 'recovered';
+      },
+      { attempts: 3, baseDelayMs: 0 },
+    );
+    expect(out).toBe('recovered');
+    expect(calls).toBe(3);
+  });
+
+  it('throws the last error after exhausting attempts', async () => {
+    let calls = 0;
+    await expect(
+      withRetry(
+        async () => {
+          calls += 1;
+          throw new Error('always');
+        },
+        { attempts: 2, baseDelayMs: 0 },
+      ),
+    ).rejects.toThrow('always');
+    expect(calls).toBe(2);
   });
 });
 

--- a/server/src/lib/audit/llm-signals.js
+++ b/server/src/lib/audit/llm-signals.js
@@ -14,6 +14,7 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 import { resolveModel } from '../ai-provider.js';
 import { signalsByKey } from './rubric.js';
+import { withRetry } from './retry.js';
 
 const DEFAULT_MODEL = 'google/gemini-3-flash-preview';
 
@@ -86,12 +87,16 @@ export async function evaluateLlmSignals(ctx) {
   const modelString = process.env.AUDIT_LLM_MODEL || DEFAULT_MODEL;
 
   try {
-    const { object } = await generateObject({
-      model: resolveModel(modelString),
-      schema: responseSchema,
-      system: SYSTEM_PROMPT,
-      prompt: buildPrompt(ctx),
-    });
+    const { object } = await withRetry(
+      () =>
+        generateObject({
+          model: resolveModel(modelString),
+          schema: responseSchema,
+          system: SYSTEM_PROMPT,
+          prompt: buildPrompt(ctx),
+        }),
+      { label: 'llm-signals' },
+    );
 
     return LLM_SIGNAL_KEYS.map((key) => {
       const v = object[key];

--- a/server/src/lib/audit/recommendations.js
+++ b/server/src/lib/audit/recommendations.js
@@ -14,6 +14,7 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 import { resolveModel } from '../ai-provider.js';
 import { signalsByKey } from './rubric.js';
+import { withRetry } from './retry.js';
 
 const DEFAULT_MODEL = 'google/gemini-3-flash-preview';
 
@@ -101,11 +102,13 @@ export async function generateRecommendations(ctx, { results } = {}) {
   const pageText = ctx.text.slice(0, 6000);
 
   try {
-    const { object } = await generateObject({
-      model: resolveModel(modelString),
-      schema: recommendationsSchema,
-      system: SYSTEM_PROMPT,
-      prompt: `PAGE URL: ${ctx.url}
+    const { object } = await withRetry(
+      () =>
+        generateObject({
+          model: resolveModel(modelString),
+          schema: recommendationsSchema,
+          system: SYSTEM_PROMPT,
+          prompt: `PAGE URL: ${ctx.url}
 
 Improve THIS page for its own topic/intent (infer it from the content below). Never introduce subject matter the page isn't already about.
 
@@ -118,7 +121,9 @@ ${pageText}
 """
 
 Return prioritized, page-specific recommendations.`,
-    });
+        }),
+      { label: 'recommendations' },
+    );
 
     return (object.recommendations || [])
       .filter((r) => RECOMMENDABLE_SIGNALS.has(r.signalKey))

--- a/server/src/lib/audit/retry.js
+++ b/server/src/lib/audit/retry.js
@@ -1,0 +1,31 @@
+/**
+ * Retry wrapper for the audit's LLM calls. Provider blips (rate limits,
+ * transient 5xx, the occasional malformed structured-output response) should
+ * not silently drop a whole audit's LLM verdicts or recommendations — one bad
+ * round-trip is usually fixed by trying again a moment later.
+ */
+
+/**
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {{ attempts?: number, baseDelayMs?: number, label?: string }} [opts]
+ * @returns {Promise<T>}
+ */
+export async function withRetry(fn, { attempts = 3, baseDelayMs = 500, label = 'llm' } = {}) {
+  let lastErr;
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) {
+        const delay = baseDelayMs * 2 ** i;
+        console.warn(
+          `[audit] ${label} attempt ${i + 1}/${attempts} failed: ${err.message}; retrying in ${delay}ms`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary

A Site Audit can complete with **no AI recommendations** even when there are plenty of fixable failing signals. Root cause: a transient provider error (rate limit, a blip, or the occasional malformed structured-output response) on the recommendations call — or the LLM-signals call — was caught and turned into `[]` / `na` with **no retry**, silently dropping that part of the audit.

Confirmed in practice: one stored audit had 9 recommendable failing signals but `recommendations: []`; re-running the exact same page produced recommendations fine — i.e. the original run hit a one-off failure.

## Fix

Add a small `withRetry(fn, { attempts, baseDelayMs })` helper (3 attempts, exponential backoff) and wrap both `generateObject` calls:
- `evaluateLlmSignals` (the 13 LLM-judged signals)
- `generateRecommendations` (the AI fix recommendations)

A single transient hiccup now retries instead of silently dropping the whole call's output. The outer fallback (`na` / `[]`) still applies only after all attempts are exhausted.

## Tests

Adds 3 unit tests for `withRetry` (first-try success, retry-then-succeed, throw-after-exhaustion). Full server suite green (93 tests).

## Notes

- Server-only runtime change — needs a server redeploy to take effect.
- Pure reliability fix; no schema or API changes.