### PR TITLE
feat(audit): show monthly quota (X/Y audits left) on the hub

### DIFF
--- a/server/src/routes/audits.js
+++ b/server/src/routes/audits.js
@@ -14,7 +14,13 @@
 import { Router } from 'express';
 import supabaseAdmin from '../config/supabase.js';
 import { assertBrandAccess } from '../lib/access.js';
-import { requireFeature, enforceSiteAuditQuota, PlanLimitError } from '../lib/plan-guard.js';
+import {
+  requireFeature,
+  enforceSiteAuditQuota,
+  getSiteAuditQuotaStatus,
+  getOrgIdForUser,
+  PlanLimitError,
+} from '../lib/plan-guard.js';
 import { buildAuditContext } from '../lib/audit/context.js';
 import { runSignals } from '../lib/audit/engine.js';
 import { evaluateLlmSignals } from '../lib/audit/llm-signals.js';
@@ -183,6 +189,24 @@ router.post('/', requireFeature('content_optimization'), async (req, res) => {
       return res.status(err.status).json({ success: false, message: err.message });
     }
     console.error('[audit] start failed:', err.message);
+    return res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// GET /api/audits/quota — the org's monthly audit allowance (used/limit/remaining).
+// Registered before /:id so "quota" isn't matched as an audit id.
+router.get('/quota', async (req, res) => {
+  try {
+    const orgId = await getOrgIdForUser(req.user?.id);
+    const quota = await getSiteAuditQuotaStatus(orgId);
+    return res.json({ success: true, quota });
+  } catch (err) {
+    if (err instanceof PlanLimitError) {
+      return res
+        .status(err.statusCode)
+        .json({ success: false, error: 'quota_exceeded', message: err.message });
+    }
+    console.error('[audit] quota failed:', err.message);
     return res.status(500).json({ success: false, message: err.message });
   }
 });

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -37,6 +37,7 @@
     "running": "Auditing…",
     "recent": "Recent Audits",
     "deleteAudit": "Delete audit",
+    "auditsLeft": "audits left this month",
     "noBrand": "Select a brand first.",
     "urlRequired": "Enter a URL to audit.",
     "failed": "Audit failed. Please try again.",

--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
@@ -9,7 +9,14 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useBrandStore } from '@/stores/use-brand-store';
-import { runAudit, getAudits, deleteAudit, type AuditSummary } from '@/lib/actions/audits';
+import {
+  runAudit,
+  getAudits,
+  getAuditQuota,
+  deleteAudit,
+  type AuditSummary,
+  type AuditQuota,
+} from '@/lib/actions/audits';
 import { pct, scoreColor } from '@/components/audit/audit-report';
 import { cn } from '@/lib/utils';
 
@@ -27,15 +34,19 @@ export default function SiteAuditPage() {
   });
   const [running, setRunning] = useState(false);
   const [history, setHistory] = useState<AuditSummary[]>([]);
+  const [quota, setQuota] = useState<AuditQuota | null>(null);
 
-  // Load recent audits for the active brand.
+  // Load recent audits + the monthly quota for the active brand.
   useEffect(() => {
     if (!activeBrandId) return;
     let cancelled = false;
     (async () => {
       try {
-        const data = await getAudits(activeBrandId);
-        if (!cancelled) setHistory(data);
+        const [data, q] = await Promise.all([getAudits(activeBrandId), getAuditQuota()]);
+        if (!cancelled) {
+          setHistory(data);
+          setQuota(q);
+        }
       } catch (err) {
         console.error('Failed to load audit history:', err);
       }
@@ -44,6 +55,8 @@ export default function SiteAuditPage() {
       cancelled = true;
     };
   }, [activeBrandId]);
+
+  const quotaExhausted = quota !== null && quota.limit !== -1 && quota.remaining <= 0;
 
   const handleRun = async () => {
     if (!activeBrandId) {
@@ -93,11 +106,21 @@ export default function SiteAuditPage() {
             placeholder="https://example.com/page"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && !running && handleRun()}
+            onKeyDown={(e) => e.key === 'Enter' && !running && !quotaExhausted && handleRun()}
             disabled={running}
             className="flex-1"
           />
-          <Button onClick={handleRun} disabled={running} className="shrink-0">
+          {quota && quota.limit !== -1 && (
+            <span
+              className={cn(
+                'shrink-0 text-xs tabular-nums',
+                quotaExhausted ? 'text-destructive' : 'text-muted-foreground',
+              )}
+            >
+              {quota.remaining}/{quota.limit} {t('auditsLeft')}
+            </span>
+          )}
+          <Button onClick={handleRun} disabled={running || quotaExhausted} className="shrink-0">
             {running ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/web/src/lib/actions/audits.ts
+++ b/web/src/lib/actions/audits.ts
@@ -52,6 +52,12 @@ export interface AuditResult {
   recommendations: AuditRecommendation[];
 }
 
+export interface AuditQuota {
+  used: number;
+  limit: number;
+  remaining: number;
+}
+
 export interface AuditSummary {
   id: string;
   url: string;
@@ -123,6 +129,23 @@ export async function deleteAudit(auditId: string): Promise<void> {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.message || `Server error: ${res.status}`);
   }
+}
+
+/** The org's monthly Site Audit allowance (used / limit / remaining; limit -1 = unlimited). */
+export async function getAuditQuota(): Promise<AuditQuota> {
+  const session = await getSession();
+
+  const res = await fetch(`${AEO_SERVER_URL}/api/audits/quota`, {
+    headers: { Authorization: `Bearer ${session.access_token}` },
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || `Server error: ${res.status}`);
+  }
+
+  const data = await res.json();
+  return data.quota;
 }
 
 /** List recent audits for a brand (summaries, no signal detail). */


### PR DESCRIPTION
## Summary

Surface the org's Site Audit allowance on the hub so users can see how many runs remain this month — same pattern as the "X/Y analyses left" badge on Prompts.

- **Server:** `GET /api/audits/quota` returns `{ used, limit, remaining }` via `getSiteAuditQuotaStatus` (registered before `/:id` so "quota" isn't matched as an audit id).
- **Web:** `getAuditQuota()` action + an `AuditQuota` type.
- **UI:** a `X/Y audits left this month` badge on the run bar. It turns red and **disables the Run button** when the quota is exhausted. Hidden entirely on unlimited plans (Enterprise / self-hosted, `limit === -1`).

The server already enforced the quota (429 on exhaustion); this just makes the remaining count visible up front instead of only surfacing it as an error after the fact.

## Notes

- Builds on the merged Site Audit feature; quota limits are Starter 100 / Growth 500 / Enterprise & self-hosted unlimited.
- Server + web; needs a server redeploy for the new `/quota` route.