### PR TITLE
chore(web): remove unused framer-motion dependency

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,6 @@
     "ai": "^6.0.116",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.35.2",
     "lucide-react": "^0.577.0",
     "marked": "^18.0.0",
     "next": "16.1.6",
@@ -58,8 +57,6 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "vitest": "^3.0.0",
-    "jsdom": "^26.0.0",
     "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -67,8 +64,10 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
+    "jsdom": "^26.0.0",
     "prettier": "^3.8.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.0.0"
   }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3985,15 +3985,6 @@ forwarded@0.2.0:
   resolved "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
-framer-motion@^12.35.2:
-  version "12.35.2"
-  resolved "https://registry.npmjs.org/framer-motion/-/framer-motion-12.35.2.tgz"
-  integrity sha512-dhfuEMaNo0hc+AEqyHiIfiJRNb9U9UQutE9FoKm5pjf7CMitp9xPEF1iWZihR1q86LBmo6EJ7S8cN8QXEy49AA==
-  dependencies:
-    motion-dom "^12.35.2"
-    motion-utils "^12.29.2"
-    tslib "^2.4.0"
-
 fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz"
@@ -5616,18 +5607,6 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-motion-dom@^12.35.2:
-  version "12.35.2"
-  resolved "https://registry.npmjs.org/motion-dom/-/motion-dom-12.35.2.tgz"
-  integrity sha512-pWXFMTwvGDbx1Fe9YL5HZebv2NhvGBzRtiNUv58aoK7+XrsuaydQ0JGRKK2r+bTKlwgSWwWxHbP5249Qr/BNpg==
-  dependencies:
-    motion-utils "^12.29.2"
-
-motion-utils@^12.29.2:
-  version "12.29.2"
-  resolved "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz"
-  integrity sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==
 
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
## Summary

- Remove the unused `framer-motion` dependency from the web application since it is not imported or referenced anywhere in the codebase.
- Clean up the dependency tree by removing the associated `motion-dom` and `motion-utils` lockfile entries that are no longer required.
- Reduce unnecessary install size and maintenance overhead without introducing any behavior changes.

## Related issue

Closes #239 

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR