### PR TITLE
fix(audit): hub recent-audits list survives a failing quota/trend call

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
@@ -54,23 +54,31 @@ export default function SiteAuditPage() {
   const [nowMs] = useState(() => Date.now());
 
   // Load recent audits + the monthly quota + the primary-domain trend.
+  // Each is fetched independently: recent audits are the core of the page, so a
+  // failing quota/trend call (e.g. during a deploy window where the web is live
+  // but the server doesn't yet have the /quota & /trend routes) must NOT blank
+  // the list — it just hides that one enhancement.
   useEffect(() => {
     if (!activeBrandId) return;
     let cancelled = false;
     (async () => {
       try {
-        const [data, q, tr] = await Promise.all([
-          getAudits(activeBrandId),
-          getAuditQuota(),
-          getAuditTrend(activeBrandId),
-        ]);
-        if (!cancelled) {
-          setHistory(data);
-          setQuota(q);
-          setTrend(tr);
-        }
+        const data = await getAudits(activeBrandId);
+        if (!cancelled) setHistory(data);
       } catch (err) {
-        console.error('Failed to load audit hub data:', err);
+        console.error('Failed to load audit history:', err);
+      }
+      try {
+        const q = await getAuditQuota();
+        if (!cancelled) setQuota(q);
+      } catch (err) {
+        console.error('Failed to load audit quota:', err);
+      }
+      try {
+        const tr = await getAuditTrend(activeBrandId);
+        if (!cancelled) setTrend(tr);
+      } catch (err) {
+        console.error('Failed to load audit trend:', err);
       }
     })();
     return () => {


### PR DESCRIPTION
## Problem

The Site Audit hub loaded recent audits, the monthly quota, and the trend in one `Promise.all`. If quota or trend failed — which happens during a deploy window where the **web is live but the server hasn't been redeployed** with the new `/api/audits/quota` & `/api/audits/trend` routes — the whole batch rejected and the page showed **neither the recent audits nor the chart** (data wasn't lost, just not rendered).

## Fix

Fetch each independently with its own try/catch: recent audits load on their own; quota and trend are best-effort enhancements that hide quietly if their (newer) endpoints aren't available yet. No more all-or-nothing.

Web-only.