### PR TITLE
fix(audit): collapse score trend to one point per day

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
@@ -89,18 +89,29 @@ export default function SiteAuditPage() {
     return points.filter((p) => new Date(p.createdAt).getTime() >= cutoff);
   }, [trend, range, nowMs]);
 
-  const chartData = rangePoints
+  // Collapse to one point per calendar day (the latest audit that day) so the
+  // x-axis doesn't repeat identical date labels when a page is audited several
+  // times in a day. rangePoints is ascending, so the last write per day wins.
+  const dailyPoints = useMemo(() => {
+    const byDay = new Map<string, (typeof rangePoints)[number]>();
+    for (const p of rangePoints) {
+      byDay.set(new Date(p.createdAt).toISOString().slice(0, 10), p);
+    }
+    return [...byDay.values()];
+  }, [rangePoints]);
+
+  const chartData = dailyPoints
     .filter((p) => p.totalScore !== null)
     .map((p) => ({
       date: new Date(p.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
       score: pct(p.totalScore) ?? 0,
     }));
 
-  const latestPoint = rangePoints[rangePoints.length - 1] ?? null;
+  const latestPoint = dailyPoints[dailyPoints.length - 1] ?? null;
   const delta =
-    rangePoints.length >= 2
-      ? (pct(rangePoints[rangePoints.length - 1].totalScore) ?? 0) -
-        (pct(rangePoints[0].totalScore) ?? 0)
+    dailyPoints.length >= 2
+      ? (pct(dailyPoints[dailyPoints.length - 1].totalScore) ?? 0) -
+        (pct(dailyPoints[0].totalScore) ?? 0)
       : null;
 
   const handleRun = async () => {


### PR DESCRIPTION
## Summary

Auditing the homepage multiple times in one day rendered several chart points with the same x-axis label (`Jun 16, Jun 16, Jun 16`) — indistinguishable and looks broken. Collapse the trend to **one point per calendar day** (the latest audit that day) so it reads as a clean day-by-day line with unique labels. The delta and headline score use the same daily series; the category-breakdown grid still reflects the latest audit.

## Related issue

<!-- none -->

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Run 2+ audits of your homepage **on the same day**.
2. Open the Site Audit hub → the score-over-time chart shows a **single** point for today (not duplicate `Jun 16` labels), and earlier days each appear once.

## Checklist

- [x] Branch follows the naming convention (`fix/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR