### PR TITLE
fix(insights): default date range to 24h

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -92,7 +92,7 @@ interface InsightsFilters {
 }
 
 const DEFAULT_FILTERS: InsightsFilters = {
-  datePreset: 'all',
+  datePreset: '24h',
   dateFrom: '',
   dateTo: '',
   region: '',


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

Changes the default date range on the Answer Engine Insights page from All to 24h.

## Related issue

Closes #262

## Type of change

<!-- Check all that apply -->

* [ ] `feat` — New feature
* [x] `fix` — Bug fix
* [ ] `chore` — Maintenance / dependencies
* [ ] `docs` — Documentation only
* [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
* [ ] `test` — Adding or updating tests

## Checklist

* [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [[CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
* [x] Commits follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)
* [x] `yarn lint` passes (run from `web/`)
* [x] `yarn typecheck` passes (run from `web/`)
* [ ] `yarn format:check` passes (run from `web/`)
* [x] Changes are focused — one concern per PR

### Notes

* Updated `DEFAULT_FILTERS.datePreset` from `'all'` to `'24h'` in `web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx`.
* `yarn lint` completed successfully with warnings only and no errors.
* `yarn typecheck` passed successfully.
* `yarn format:check` reports existing formatting issues across many files in the repository that are unrelated to this change.