### PR TITLE
docs(env): add CRON_SECRET to both .env.example files

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -62,6 +62,17 @@ PLATFORM_PROVIDER=cloro
 # AI Volume Multiplier (AI search adoption rate, e.g. 0.15 = 15%)
 AI_VOLUME_MULTIPLIER=0.15
 
+# Cron / Internal-endpoint secret (cloud only — not needed for self-hosted)
+# Guards three internal server endpoints:
+#   /api/internal/daily-tracking
+#   /api/internal/content/:id/brief
+#   /api/internal/trigger-tracking
+# The web app sends this as "Authorization: Bearer <value>"; the server
+# compares against its own copy. MUST be the same value on both sides.
+# Generate: openssl rand -hex 32
+# CRON_SECRET=
+
 # Stripe (cloud only — not needed for self-hosted)
 # STRIPE_SECRET_KEY=sk_test_...
 # STRIPE_WEBHOOK_SECRET=whsec_...
+

--- a/web/.env.example
+++ b/web/.env.example
@@ -59,6 +59,19 @@ NEXT_PUBLIC_IS_CLOUD=false
 NEXT_PUBLIC_API_URL=http://localhost:80
 
 # -----------------------------------------------------------------------------
+# Cron / Internal-endpoint secret (cloud only — not needed for self-hosted)
+# -----------------------------------------------------------------------------
+# Shared secret that authenticates calls from the web layer to the server's
+# internal endpoints. Used by:
+#   - Vercel Cron  →  /api/cron/daily-tracking
+#   - Stripe success route  →  post-checkout tracking trigger
+#   - MCP layer  →  content-brief generation (throws if unset)
+# Web sends:  Authorization: Bearer ${CRON_SECRET}
+# Server checks its own CRON_SECRET copy — both values MUST match.
+# Generate: openssl rand -hex 32
+# CRON_SECRET=
+
+# -----------------------------------------------------------------------------
 # Stripe (cloud only — not needed for self-hosted)
 # -----------------------------------------------------------------------------
 # NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...


### PR DESCRIPTION
Fixes #244. CRON_SECRET guards three internal server endpoints but was missing from both example files, causing silent 401s in cloud deployments. Added with a comment explaining it is cloud-only and must be set to the same value on both the web app and the server.

<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

Added `CRON_SECRET` to both `.env.example` files with a descriptive comment.
Without this entry, cloud operators have no indication they need to set this
variable, causing permanent 401s on three internal endpoints and failures in
daily tracking, content-brief generation, and post-checkout tracking.


## Related issue

Closes #244

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [x] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `yarn lint` passes (run from `web/`)
- [ ] `yarn typecheck` passes (run from `web/`)
- [ ] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

> `lint`, `typecheck`, `format:check` skipped — docs/config only change, no source files modified.