### PR TITLE
fix(tracking): never re-analyze an already-analyzed prompt in analyze-new

### DIFF
--- a/server/src/routes/tracking.js
+++ b/server/src/routes/tracking.js
@@ -102,20 +102,23 @@ router.post('/analyze-new', async (req, res) => {
       return res.status(403).json({ success: false, message: 'Unauthorized' });
     }
 
-    let newPromptIds;
+    // Build the candidate set: either the specific IDs the client picked
+    // (validated against this brand) or every active prompt for the brand.
+    let candidateIds;
+
+    const { data: promptSets } = await supabaseAdmin
+      .from('prompt_sets')
+      .select('id')
+      .eq('brand_id', brandId);
+
+    if (!promptSets || promptSets.length === 0) {
+      return res.json({ success: true, newCount: 0, message: 'No prompt sets found' });
+    }
+
+    const setIds = promptSets.map((s) => s.id);
 
     if (Array.isArray(clientPromptIds) && clientPromptIds.length > 0) {
-      // Client sent specific prompt IDs — validate they belong to this brand
-      const { data: promptSets } = await supabaseAdmin
-        .from('prompt_sets')
-        .select('id')
-        .eq('brand_id', brandId);
-
-      if (!promptSets || promptSets.length === 0) {
-        return res.json({ success: true, newCount: 0, message: 'No prompt sets found' });
-      }
-
-      const setIds = promptSets.map((s) => s.id);
+      // Client sent specific prompt IDs — validate they belong to this brand.
       const { data: validPrompts } = await supabaseAdmin
         .from('prompts')
         .select('id')
@@ -123,19 +126,9 @@ router.post('/analyze-new', async (req, res) => {
         .in('id', clientPromptIds)
         .eq('is_active', true);
 
-      newPromptIds = (validPrompts || []).map((p) => p.id);
+      candidateIds = (validPrompts || []).map((p) => p.id);
     } else {
-      // Auto-detect unanalyzed prompts
-      const { data: promptSets } = await supabaseAdmin
-        .from('prompt_sets')
-        .select('id')
-        .eq('brand_id', brandId);
-
-      if (!promptSets || promptSets.length === 0) {
-        return res.json({ success: true, newCount: 0, message: 'No prompt sets found' });
-      }
-
-      const setIds = promptSets.map((s) => s.id);
+      // Auto-detect: start from every active prompt for the brand.
       const { data: allPrompts } = await supabaseAdmin
         .from('prompts')
         .select('id')
@@ -146,16 +139,25 @@ router.post('/analyze-new', async (req, res) => {
         return res.json({ success: true, newCount: 0, message: 'No active prompts' });
       }
 
-      const allPromptIds = allPrompts.map((p) => p.id);
+      candidateIds = allPrompts.map((p) => p.id);
+    }
 
+    // Never (re)analyze a prompt that already has results for this brand — this
+    // endpoint is "analyze NEW prompts" only (full re-runs go through /check and
+    // the daily scheduled job). Applying the filter to BOTH branches is what
+    // stops the client from re-submitting IDs read from a stale "unanalyzed"
+    // dialog while an earlier on-demand run's async webhook results are still
+    // landing, which previously caused duplicate Cloro/LLM spend.
+    let newPromptIds = candidateIds;
+    if (candidateIds.length > 0) {
       const { data: existingResults } = await supabaseAdmin
         .from('prompt_results')
         .select('prompt_id')
         .eq('brand_id', brandId)
-        .in('prompt_id', allPromptIds);
+        .in('prompt_id', candidateIds);
 
       const analyzedIds = new Set((existingResults || []).map((r) => r.prompt_id));
-      newPromptIds = allPromptIds.filter((id) => !analyzedIds.has(id));
+      newPromptIds = candidateIds.filter((id) => !analyzedIds.has(id));
     }
 
     if (newPromptIds.length === 0) {


### PR DESCRIPTION
## Summary

`POST /api/tracking/analyze-new` ("Analyze Prompts" on the brand prompts page) could
re-analyze prompts that already had results, double-spending Cloro/LLM credits.

The handler had two branches:

- **auto-detect** (no `promptIds`) — excluded already-analyzed prompts via `prompt_results`.
- **explicit IDs** (client sends `promptIds`) — only validated brand membership + `is_active`, **never** checked `prompt_results`.

The client always sends specific IDs, so the explicit branch was the live path and the
exclusion was effectively bypassed. In cloud, Cloro runs asynchronously via webhook and
result rows land over several minutes; reopening the dialog during that window showed the
prompts as still "unanalyzed", letting them be re-submitted. Observed in production: the
same set of prompts analyzed three times within ~75 minutes.

This moves the `prompt_results` exclusion into a single shared block that runs for **both**
branches, so the endpoint only ever analyzes prompts with no results for the brand —
regardless of what the client sends. Full re-analysis remains available via
`POST /api/tracking/check` and the daily scheduled job, both unchanged.

## Related issue

_None — direct production bug fix (credit double-spend)._

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Pick a brand with at least one analyzed prompt.
2. From the prompts page, open **Analyze Prompts**, select an already-analyzed prompt, and submit.
3. Before: a new on-demand tracking job is created for it. After: the endpoint returns
   `{ success: true, newCount: 0, message: "All prompts already analyzed" }` and no job is queued.
4. Confirm a genuinely new (never-analyzed) prompt still gets analyzed normally.
5. Confirm the daily scheduled job and `POST /api/tracking/check` still re-run all prompts as before.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `yarn lint` passes (run from `web/`)
- [ ] `yarn typecheck` passes (run from `web/`)
- [ ] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

> `lint`/`typecheck`/`format:check` skipped — server-side change only (`server/src/routes/tracking.js`), no `web/` source touched. `node --check` passes on the modified file.
