### PR TITLE
fix(tracking): stop progress bar freezing on webhook-mode runs

### DIFF
--- a/server/src/lib/job-manager.js
+++ b/server/src/lib/job-manager.js
@@ -181,3 +181,25 @@ export async function cleanupOldJobs() {
     console.error('[job-manager] Failed to cleanup old jobs:', error.message);
   }
 }
+
+/**
+ * Delete orphaned Cloro pending tasks — rows for which Cloro never delivered a
+ * webhook. They sit forever otherwise; left unchecked they accumulate and (with
+ * a brand-wide count) used to poison every future run's drain loop. Two hours is
+ * well past the worker's 60-minute drain deadline and any realistic Cloro
+ * delivery window, so anything older is safe to drop.
+ */
+export async function cleanupStalePendingTasks() {
+  const cutoff = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await supabaseAdmin
+    .from('cloro_pending_tasks')
+    .delete()
+    .lt('submitted_at', cutoff)
+    .select('task_id');
+
+  if (error) {
+    console.error('[job-manager] Failed to cleanup stale pending tasks:', error.message);
+  } else if (data && data.length > 0) {
+    console.log(`[job-manager] Cleaned up ${data.length} orphaned Cloro pending tasks`);
+  }
+}

--- a/server/src/lib/job-manager.js
+++ b/server/src/lib/job-manager.js
@@ -191,15 +191,14 @@ export async function cleanupOldJobs() {
  */
 export async function cleanupStalePendingTasks() {
   const cutoff = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
-  const { data, error } = await supabaseAdmin
+  const { count, error } = await supabaseAdmin
     .from('cloro_pending_tasks')
-    .delete()
-    .lt('submitted_at', cutoff)
-    .select('task_id');
+    .delete({ count: 'exact' })
+    .lt('submitted_at', cutoff);
 
   if (error) {
     console.error('[job-manager] Failed to cleanup stale pending tasks:', error.message);
-  } else if (data && data.length > 0) {
-    console.log(`[job-manager] Cleaned up ${data.length} orphaned Cloro pending tasks`);
+  } else if (count && count > 0) {
+    console.log(`[job-manager] Cleaned up ${count} orphaned Cloro pending tasks`);
   }
 }

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -13,7 +13,12 @@ import { apiLimiter } from './middleware/rate-limiter.js';
 import requestIdMiddleware from './middleware/request-id.js';
 import routes from './routes/index.js';
 import trafficRoutes from './routes/traffic.js';
-import { createJob, cleanupStaleJobs, cleanupOldJobs } from './lib/job-manager.js';
+import {
+  createJob,
+  cleanupStaleJobs,
+  cleanupOldJobs,
+  cleanupStalePendingTasks,
+} from './lib/job-manager.js';
 import { runTrackingJob } from './lib/job-runner.js';
 import { parseScraperResponse } from './lib/cloro-scraper.js';
 import { handleScraperResult } from './lib/cloro-result-handler.js';
@@ -97,6 +102,10 @@ app.set('io', io);
 // --- Daily tracking logic (shared by internal endpoint and self-hosted cron) ---
 async function runDailyTracking() {
   const isCloudMode = isCloud();
+
+  // Sweep orphaned Cloro pending tasks daily (runs in both cloud and
+  // self-hosted, since both paths funnel through here).
+  await cleanupStalePendingTasks();
 
   const { data: brands, error } = await supabaseAdmin.from('brands').select('id, organization_id');
 
@@ -387,6 +396,7 @@ server.listen(PORT, async () => {
   console.log(`AEO Server running on port ${PORT} [${process.env.NODE_ENV}]`);
 
   await cleanupStaleJobs();
+  await cleanupStalePendingTasks();
 
   if (!isCloud()) {
     const schedule = process.env.DAILY_CRON_SCHEDULE || '0 6 * * *';

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -218,10 +218,19 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
         while (Date.now() < drainDeadline) {
           // Brand-scoped read (a handful of rows at most), intersected in memory
           // with our own task_ids — avoids a giant `.in(...)` URL.
-          const { data: rows } = await supabaseAdmin
+          const { data: rows, error: drainErr } = await supabaseAdmin
             .from('cloro_pending_tasks')
             .select('task_id')
             .eq('brand_id', brandId);
+
+          // A transient read failure must NOT be read as "0 pending" — that would
+          // break the loop early and report the run as finished while tasks are
+          // still in flight. Skip this tick and retry on the next poll.
+          if (drainErr) {
+            console.warn(`[tracking] Pending-task poll failed, retrying: ${drainErr.message}`);
+            await new Promise((r) => setTimeout(r, drainPollMs));
+            continue;
+          }
 
           const pending = (rows || []).filter((r) => submittedTaskIds.has(r.task_id)).length;
           const processed = expectedSubmitted - pending;

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -190,39 +190,69 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
         }
       }
 
-      // Wait for the webhook handler to drain cloro_pending_tasks for this brand.
-      // The worker stays alive (cheap DB poll) so the job's `active` status drives
-      // the UI loading banner until results actually arrive. Hard cap at 60 minutes
-      // so a stuck Cloro queue doesn't keep workers running indefinitely.
-      const drainDeadline = Date.now() + 60 * 60 * 1000;
-      const drainPollMs = 15_000;
-      const expectedSubmitted = submitted.length;
+      // Wait for the webhook handler to drain THIS job's pending tasks. The
+      // worker stays alive (cheap DB poll) so the job's `active` status drives
+      // the UI loading banner until results actually arrive.
+      //
+      // We count only the task_ids THIS run submitted — not every pending row
+      // for the brand. A brand-wide count is poisoned by orphan rows from tasks
+      // Cloro never delivered a webhook for (and by concurrent runs), so it
+      // never reaches zero: the drain loop runs to the deadline and the progress
+      // bar freezes partway even though results keep landing. Counting our own
+      // task_ids lets the loop finish as soon as this run's results are in.
+      const submittedTaskIds = new Set(submitted.map((s) => s.taskId));
+      const expectedSubmitted = submittedTaskIds.size;
 
-      while (Date.now() < drainDeadline) {
-        const { count: remaining } = await supabaseAdmin
-          .from('cloro_pending_tasks')
-          .select('*', { count: 'exact', head: true })
-          .eq('brand_id', brandId);
+      if (expectedSubmitted > 0) {
+        // Hard cap so a stuck Cloro queue can't keep a worker alive forever.
+        const drainDeadline = Date.now() + 60 * 60 * 1000;
+        const drainPollMs = 15_000;
+        // Give up early if delivery stalls — no new result for this many
+        // consecutive polls (~10 min) means the rest were almost certainly
+        // dropped, so don't hold the bar (and a concurrency slot) for an hour.
+        const stallPollLimit = 40;
 
-        const pending = remaining ?? 0;
-        const processed = expectedSubmitted - pending;
+        let lastPending = expectedSubmitted;
+        let stalledPolls = 0;
 
-        if (job) {
-          job.progress({
-            current: completedTasks + processed,
-            total: totalTasks,
-            promptText:
-              pending > 0
-                ? `Receiving platform results — ${pending} task(s) still processing...`
-                : 'All platform results received',
-            model: null,
-            platform: 'cloro',
-          });
+        while (Date.now() < drainDeadline) {
+          // Brand-scoped read (a handful of rows at most), intersected in memory
+          // with our own task_ids — avoids a giant `.in(...)` URL.
+          const { data: rows } = await supabaseAdmin
+            .from('cloro_pending_tasks')
+            .select('task_id')
+            .eq('brand_id', brandId);
+
+          const pending = (rows || []).filter((r) => submittedTaskIds.has(r.task_id)).length;
+          const processed = expectedSubmitted - pending;
+
+          if (job) {
+            job.progress({
+              current: completedTasks + processed,
+              total: totalTasks,
+              promptText:
+                pending > 0
+                  ? `Receiving platform results — ${pending} task(s) still processing...`
+                  : 'All platform results received',
+              model: null,
+              platform: 'cloro',
+            });
+          }
+
+          if (pending === 0) break;
+
+          if (pending < lastPending) {
+            lastPending = pending;
+            stalledPolls = 0;
+          } else if (++stalledPolls >= stallPollLimit) {
+            console.warn(
+              `[tracking] Cloro delivery stalled for brand ${brandId} — ${pending} of ${expectedSubmitted} task(s) never returned; continuing.`,
+            );
+            break;
+          }
+
+          await new Promise((r) => setTimeout(r, drainPollMs));
         }
-
-        if (pending === 0) break;
-
-        await new Promise((r) => setTimeout(r, drainPollMs));
       }
 
       completedTasks += expectedSubmitted;

--- a/web/src/lib/tracking-job-store.ts
+++ b/web/src/lib/tracking-job-store.ts
@@ -17,7 +17,9 @@ export function loadTrackingJob(): TrackingJob | null {
     const raw = localStorage.getItem(TRACKING_STORAGE_KEY);
     if (!raw) return null;
     const job = JSON.parse(raw) as TrackingJob;
-    if (Date.now() - job.startedAt > 10 * 60 * 1000) {
+    // Large brands legitimately take ~45 min to finish; keep restoring the
+    // progress banner across refreshes until the worker's 60-min drain deadline.
+    if (Date.now() - job.startedAt > 60 * 60 * 1000) {
       localStorage.removeItem(TRACKING_STORAGE_KEY);
       return null;
     }


### PR DESCRIPTION
## Summary

The analysis progress bar (insights page loading banner) could freeze partway
on webhook-mode tracking runs while results kept arriving in the background —
refreshing the page then showed the saved results. Most visible on large brands
whose runs take ~45 minutes.

Root cause is in the webhook-mode drain loop in `tracking-worker.js`. While
waiting for Cloro to push results, it counted **every** `cloro_pending_tasks`
row for the brand:

```js
.from('cloro_pending_tasks').eq('brand_id', brandId)   // brand-wide, not this run
```

Tasks Cloro never delivers a webhook for are never cleaned up, so they pile up
as orphan rows (found rows 9–28 days old in production). A brand-wide count is
poisoned by those orphans (and by concurrent runs): it never reaches zero, the
loop runs to its 60-minute deadline, and `processed = expected - pending`
plateaus below the real value — the bar freezes. The `/cloro/callback` handler
keeps inserting the genuine results into `prompt_results` independently, which
is why a refresh shows them.

## Changes

- **Job-scoped drain count** — count only the `task_id`s this run submitted.
  Brand-scoped read (a handful of rows) intersected in memory with the run's own
  ids, avoiding an oversized `.in(...)` URL. The loop now finishes as soon as
  *this* run's results are in.
- **Stall guard** — give up after ~10 min of no new delivery instead of holding
  a worker (and a concurrency slot) for the full hour when Cloro drops tasks.
- **Orphan sweep** — new `cleanupStalePendingTasks()` deletes pending rows older
  than 2h (well past the 60-min drain deadline). Runs at startup and from
  `runDailyTracking`, so it covers both cloud and self-hosted.
- **Client banner TTL** — bump the saved-job TTL in `tracking-job-store.ts` from
  10 min to 60 min so the progress banner survives a refresh during a long run.

## Related issue

_None — production bug fix (frozen progress bar / orphaned pending tasks)._

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Trigger an analysis for a brand with many prompts (webhook mode, `CLORO_WEBHOOK_URL` set).
2. Watch the insights progress banner: it should advance to completion as results land, not stall partway.
3. Refresh mid-run (after >10 min): the banner is restored and keeps updating (previously it disappeared at 10 min).
4. Leave an undelivered task in `cloro_pending_tasks` older than 2h; after a server restart / daily run it is swept and no longer affects future runs' counts.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

> Mostly server-side (`server/src/...`); `node --check` + `npx prettier --check` pass on the changed server files. The one `web/` change (`tracking-job-store.ts`) passes lint/typecheck/format:check.
