### PR TITLE
fix(insights): clarify the queued-analysis message

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -736,7 +736,7 @@ function TrackingProgressBanner({
           <Loader2 className="h-4 w-4 animate-spin text-primary" />
           <span className="text-sm font-medium">
             {jobStatus.status === 'waiting'
-              ? 'Queued — waiting to start...'
+              ? 'Queued — starting automatically'
               : 'Analyzing prompts...'}
           </span>
           {progress && (
@@ -755,6 +755,13 @@ function TrackingProgressBanner({
           Stop
         </Button>
       </div>
+
+      {jobStatus.status === 'waiting' && (
+        <p className="text-xs text-muted-foreground">
+          Another analysis is running right now. Yours will begin the moment a slot opens up — no
+          need to wait here, it&apos;ll keep going in the background.
+        </p>
+      )}
 
       {progress && progress.total > 0 && (
         <>


### PR DESCRIPTION
## Summary

The insights loading banner shows when a tracking run is queued behind others
(the worker processes a small fixed number of jobs at a time, so a new run waits
when those slots are full). The old copy — "Queued — waiting to start..." — reads
like something stalled or failed.

This reword makes it clear the wait is expected and self-resolving:

- Title: **"Queued — starting automatically"**
- New one-line subtext (shown only while `waiting`): explains another analysis is
  running, this one begins the moment a slot opens, and the user can safely leave
  the page — it keeps going in the background.

No behavior change — copy only.

## Related issue

_None — UX copy improvement._

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Start enough analyses that one is queued (or simulate a `waiting` job status).
2. The banner reads "Queued — starting automatically" with the explanatory subtext.
3. Once a slot frees, it transitions to "Analyzing prompts..." with the progress bar as before.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
