### PR TITLE
Perf/lazy load recharts

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
@@ -3,7 +3,17 @@
 import { useEffect, useRef, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, type UIMessage } from 'ai';
-import { AgentChart, type AgentChartSpec } from '@/components/agent/agent-chart';
+import type { AgentChartSpec } from '@/components/agent/agent-chart';
+import dynamic from 'next/dynamic';
+import { Skeleton } from '@/components/ui/skeleton';
+const AgentChart = dynamic(
+  () =>
+    import('@/components/agent/agent-chart').then((m) => m.AgentChart),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-64 w-full" />,
+  }
+);
 import { useFeatureGate } from '@/hooks/use-feature-gate';
 import { Link } from '@/i18n/navigation';
 import { Button, buttonVariants } from '@/components/ui/button';

--- a/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
@@ -7,12 +7,11 @@ import type { AgentChartSpec } from '@/components/agent/agent-chart';
 import dynamic from 'next/dynamic';
 import { Skeleton } from '@/components/ui/skeleton';
 const AgentChart = dynamic(
-  () =>
-    import('@/components/agent/agent-chart').then((m) => m.AgentChart),
+  () => import('@/components/agent/agent-chart').then((m) => m.AgentChart),
   {
     ssr: false,
     loading: () => <Skeleton className="h-64 w-full" />,
-  }
+  },
 );
 import { useFeatureGate } from '@/hooks/use-feature-gate';
 import { Link } from '@/i18n/navigation';

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/citations_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/citations_charts.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { PieChart, Pie, Cell, Tooltip } from 'recharts';
+
+type SourceTypeDonutChartData = {
+  category: string;
+  count: number;
+  pct: number;
+  fill: string;
+  label: string;
+};
+
+type SourceTypeDonutChartViewProps = {
+  width: number;
+  chartData: SourceTypeDonutChartData[];
+};
+
+export function SourceTypeDonutChartView({
+  width,
+  chartData,
+}: SourceTypeDonutChartViewProps) {
+  const size = Math.min(width, 220);
+
+  return (
+    <PieChart width={width} height={200}>
+      <Pie
+        data={chartData}
+        cx={width / 2}
+        cy={100}
+        innerRadius={size * 0.28}
+        outerRadius={size * 0.44}
+        paddingAngle={2}
+        dataKey="count"
+        nameKey="label"
+      >
+        {chartData.map((entry) => (
+          <Cell key={entry.category} fill={entry.fill} stroke="none" />
+        ))}
+      </Pie>
+
+      <Tooltip
+        isAnimationActive={false}
+        content={({ active, payload }) => {
+          if (!active || !payload || payload.length === 0) {
+            return null;
+          }
+
+          const p = payload[0].payload as {
+            label: string;
+            count: number;
+            pct: number;
+          };
+
+          return (
+            <div className="rounded-md border bg-popover px-2.5 py-1.5 text-xs shadow-sm">
+              <div className="font-medium">{p.label}</div>
+              <div className="text-muted-foreground">
+                {p.count} · {p.pct.toFixed(1)}%
+              </div>
+            </div>
+          );
+        }}
+      />
+    </PieChart>
+  );
+}

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/citations_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/citations_charts.tsx
@@ -15,10 +15,7 @@ type SourceTypeDonutChartViewProps = {
   chartData: SourceTypeDonutChartData[];
 };
 
-export function SourceTypeDonutChartView({
-  width,
-  chartData,
-}: SourceTypeDonutChartViewProps) {
+export function SourceTypeDonutChartView({ width, chartData }: SourceTypeDonutChartViewProps) {
   const size = Math.min(width, 220);
 
   return (

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -3,7 +3,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import { PieChart, Pie, Cell, Tooltip } from 'recharts';
+import dynamic from 'next/dynamic';
+const DynamicSourceTypeDonutChart = dynamic(
+  () =>
+    import('./citations_charts').then(
+      (m) => m.SourceTypeDonutChartView
+    ),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-[200px] w-full" />,
+  }
+);
 import { Quote, Globe, ExternalLink, Filter as FilterIcon, Layers } from 'lucide-react';
 import { useBrandStore } from '@/stores/use-brand-store';
 import {
@@ -342,43 +352,11 @@ function SourceTypeDonut({
     <div className="flex flex-col gap-4">
       <ChartContainer height={200}>
         {(width) => {
-          const size = Math.min(width, 220);
           return (
-            <PieChart width={width} height={200}>
-              <Pie
-                data={chartData}
-                cx={width / 2}
-                cy={100}
-                innerRadius={size * 0.28}
-                outerRadius={size * 0.44}
-                paddingAngle={2}
-                dataKey="count"
-                nameKey="label"
-              >
-                {chartData.map((entry) => (
-                  <Cell key={entry.category} fill={entry.fill} stroke="none" />
-                ))}
-              </Pie>
-              <Tooltip
-                isAnimationActive={false}
-                content={({ active, payload }) => {
-                  if (!active || !payload || payload.length === 0) return null;
-                  const p = payload[0].payload as {
-                    label: string;
-                    count: number;
-                    pct: number;
-                  };
-                  return (
-                    <div className="rounded-md border bg-popover px-2.5 py-1.5 text-xs shadow-sm">
-                      <div className="font-medium">{p.label}</div>
-                      <div className="text-muted-foreground">
-                        {p.count} · {p.pct.toFixed(1)}%
-                      </div>
-                    </div>
-                  );
-                }}
-              />
-            </PieChart>
+           <DynamicSourceTypeDonutChart
+              width={width}
+              chartData={chartData}
+            />
           );
         }}
       </ChartContainer>

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -5,14 +5,11 @@ import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import dynamic from 'next/dynamic';
 const DynamicSourceTypeDonutChart = dynamic(
-  () =>
-    import('./citations_charts').then(
-      (m) => m.SourceTypeDonutChartView
-    ),
+  () => import('./citations_charts').then((m) => m.SourceTypeDonutChartView),
   {
     ssr: false,
     loading: () => <Skeleton className="h-[200px] w-full" />,
-  }
+  },
 );
 import { Quote, Globe, ExternalLink, Filter as FilterIcon, Layers } from 'lucide-react';
 import { useBrandStore } from '@/stores/use-brand-store';
@@ -352,12 +349,7 @@ function SourceTypeDonut({
     <div className="flex flex-col gap-4">
       <ChartContainer height={200}>
         {(width) => {
-          return (
-           <DynamicSourceTypeDonutChart
-              width={width}
-              chartData={chartData}
-            />
-          );
+          return <DynamicSourceTypeDonutChart width={width} chartData={chartData} />;
         }}
       </ChartContainer>
       <ul className="grid grid-cols-2 gap-x-3 gap-y-1.5">

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -4,12 +4,39 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from '@/i18n/navigation';
 import { useSearchParams } from 'next/navigation';
 import { createPortal } from 'react-dom';
-import {
-  CompetitorChart,
-  CompetitorLeaderboard,
-  ShareOfVoicePlatformChart,
-  ShareOfVoiceTrendChart,
-} from './_charts';
+import dynamic from 'next/dynamic';
+import { Skeleton } from '@/components/ui/skeleton';
+const CompetitorChart = dynamic(
+  () => import('./_charts').then((m) => m.CompetitorChart),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-64 w-full" />,
+  }
+);
+
+const CompetitorLeaderboard = dynamic(
+  () => import('./_charts').then((m) => m.CompetitorLeaderboard),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-64 w-full" />,
+  }
+);
+
+const ShareOfVoicePlatformChart = dynamic(
+  () => import('./_charts').then((m) => m.ShareOfVoicePlatformChart),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-64 w-full" />,
+  }
+);
+
+const ShareOfVoiceTrendChart = dynamic(
+  () => import('./_charts').then((m) => m.ShareOfVoiceTrendChart),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-64 w-full" />,
+  }
+);
 import { MetricBreakdownSheet } from './_metric-breakdown-sheet';
 import { groupResultsByTopic, type PlatformGroup, type PromptGroup } from './grouping';
 import { useBrandStore } from '@/stores/use-brand-store';
@@ -37,7 +64,6 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
-import { Skeleton } from '@/components/ui/skeleton';
 import {
   BarChart3,
   CalendarX2,

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -6,20 +6,17 @@ import { useSearchParams } from 'next/navigation';
 import { createPortal } from 'react-dom';
 import dynamic from 'next/dynamic';
 import { Skeleton } from '@/components/ui/skeleton';
-const CompetitorChart = dynamic(
-  () => import('./_charts').then((m) => m.CompetitorChart),
-  {
-    ssr: false,
-    loading: () => <Skeleton className="h-64 w-full" />,
-  }
-);
+const CompetitorChart = dynamic(() => import('./_charts').then((m) => m.CompetitorChart), {
+  ssr: false,
+  loading: () => <Skeleton className="h-64 w-full" />,
+});
 
 const CompetitorLeaderboard = dynamic(
   () => import('./_charts').then((m) => m.CompetitorLeaderboard),
   {
     ssr: false,
     loading: () => <Skeleton className="h-64 w-full" />,
-  }
+  },
 );
 
 const ShareOfVoicePlatformChart = dynamic(
@@ -27,7 +24,7 @@ const ShareOfVoicePlatformChart = dynamic(
   {
     ssr: false,
     loading: () => <Skeleton className="h-64 w-full" />,
-  }
+  },
 );
 
 const ShareOfVoiceTrendChart = dynamic(
@@ -35,7 +32,7 @@ const ShareOfVoiceTrendChart = dynamic(
   {
     ssr: false,
     loading: () => <Skeleton className="h-64 w-full" />,
-  }
+  },
 );
 import { MetricBreakdownSheet } from './_metric-breakdown-sheet';
 import { groupResultsByTopic, type PlatformGroup, type PromptGroup } from './grouping';

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -4,7 +4,16 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { useSearchParams } from 'next/navigation';
 import { Link, useRouter } from '@/i18n/navigation';
-import { PlatformVolumeChart } from './_charts';
+import dynamic from 'next/dynamic';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const PlatformVolumeChart = dynamic(
+  () => import('./_charts').then((m) => m.PlatformVolumeChart),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-64 w-full" />,
+  }
+);
 import { SuggestionsCard } from './_suggestions-card';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -7,13 +7,10 @@ import { Link, useRouter } from '@/i18n/navigation';
 import dynamic from 'next/dynamic';
 import { Skeleton } from '@/components/ui/skeleton';
 
-const PlatformVolumeChart = dynamic(
-  () => import('./_charts').then((m) => m.PlatformVolumeChart),
-  {
-    ssr: false,
-    loading: () => <Skeleton className="h-64 w-full" />,
-  }
-);
+const PlatformVolumeChart = dynamic(() => import('./_charts').then((m) => m.PlatformVolumeChart), {
+  ssr: false,
+  loading: () => <Skeleton className="h-64 w-full" />,
+});
 import { SuggestionsCard } from './_suggestions-card';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';

--- a/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
@@ -2,17 +2,22 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Legend,
-  Line,
-  LineChart,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
+import dynamic from 'next/dynamic';
+const DynamicPlatformCardRateChart = dynamic(
+  () => import('./shopping_charts').then((m) => m.PlatformCardRateChartView),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-[220px] w-full" />,
+  }
+);
+
+const DynamicShoppingTrendChart = dynamic(
+  () => import('./shopping_charts').then((m) => m.ShoppingTrendChartView),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-[220px] w-full" />,
+  }
+);
 import {
   ShoppingBag,
   Store,
@@ -88,14 +93,6 @@ const DATE_PRESETS: ShoppingDatePreset[] = ['7d', '30d', '90d', 'all'];
 // Theme tokens in globals.css ship as full oklch values; reference them
 // directly with var(--…). Wrapping in hsl() yields invalid CSS, so chart
 // text turns black on dark mode (lesson learned from #138).
-const AXIS_TICK = { fill: 'var(--muted-foreground)', fontSize: 11 } as const;
-const TOOLTIP_STYLE = {
-  background: 'var(--card)',
-  border: '1px solid var(--border)',
-  borderRadius: '0.5rem',
-  fontSize: '0.75rem',
-  color: 'var(--foreground)',
-} as const;
 
 function getDomainName(url: string): string {
   try {
@@ -978,24 +975,10 @@ function ResponsiveBarChart({ data }: { data: Array<{ platform: string; rate: nu
   return (
     <div ref={ref} style={{ width: '100%', height: 220 }}>
       {width > 0 && (
-        <BarChart
-          width={width}
-          height={220}
-          data={data}
-          margin={{ top: 8, right: 8, bottom: 0, left: -8 }}
-        >
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
-          <XAxis dataKey="platform" stroke="var(--border)" tick={AXIS_TICK} tickLine={false} />
-          <YAxis
-            stroke="var(--border)"
-            tick={AXIS_TICK}
-            tickLine={false}
-            axisLine={false}
-            unit="%"
-          />
-          <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'var(--muted)', opacity: 0.3 }} />
-          <Bar dataKey="rate" name="Card rate" fill="var(--chart-2)" radius={[4, 4, 0, 0]} />
-        </BarChart>
+       <DynamicPlatformCardRateChart
+         width={width}
+         data={data}
+        />
       )}
     </div>
   );
@@ -1041,40 +1024,10 @@ function ResponsiveLineChart({
   return (
     <div ref={ref} style={{ width: '100%', height: 220 }}>
       {width > 0 && (
-        <LineChart
+        <DynamicShoppingTrendChart
           width={width}
-          height={220}
           data={data}
-          margin={{ top: 8, right: 8, bottom: 0, left: -8 }}
-        >
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
-          <XAxis
-            dataKey="date"
-            stroke="var(--border)"
-            tick={AXIS_TICK}
-            tickLine={false}
-            tickFormatter={(v: string) => v.slice(5)}
           />
-          <YAxis stroke="var(--border)" tick={AXIS_TICK} tickLine={false} axisLine={false} />
-          <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ stroke: 'var(--border)' }} />
-          <Legend wrapperStyle={{ fontSize: 11, color: 'var(--muted-foreground)' }} />
-          <Line
-            type="monotone"
-            dataKey="ownCards"
-            name="Your cards"
-            stroke="var(--chart-2)"
-            strokeWidth={2}
-            dot={{ r: 2 }}
-          />
-          <Line
-            type="monotone"
-            dataKey="totalCards"
-            name="All cards"
-            stroke="var(--chart-4)"
-            strokeWidth={2}
-            dot={{ r: 2 }}
-          />
-        </LineChart>
       )}
     </div>
   );

--- a/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
@@ -8,7 +8,7 @@ const DynamicPlatformCardRateChart = dynamic(
   {
     ssr: false,
     loading: () => <Skeleton className="h-[220px] w-full" />,
-  }
+  },
 );
 
 const DynamicShoppingTrendChart = dynamic(
@@ -16,7 +16,7 @@ const DynamicShoppingTrendChart = dynamic(
   {
     ssr: false,
     loading: () => <Skeleton className="h-[220px] w-full" />,
-  }
+  },
 );
 import {
   ShoppingBag,
@@ -974,12 +974,7 @@ function ResponsiveBarChart({ data }: { data: Array<{ platform: string; rate: nu
   }, []);
   return (
     <div ref={ref} style={{ width: '100%', height: 220 }}>
-      {width > 0 && (
-       <DynamicPlatformCardRateChart
-         width={width}
-         data={data}
-        />
-      )}
+      {width > 0 && <DynamicPlatformCardRateChart width={width} data={data} />}
     </div>
   );
 }
@@ -1023,12 +1018,7 @@ function ResponsiveLineChart({
   }, []);
   return (
     <div ref={ref} style={{ width: '100%', height: 220 }}>
-      {width > 0 && (
-        <DynamicShoppingTrendChart
-          width={width}
-          data={data}
-          />
-      )}
+      {width > 0 && <DynamicShoppingTrendChart width={width} data={data} />}
     </div>
   );
 }

--- a/web/src/app/[locale]/(dashboard)/dashboard/shopping/shopping_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/shopping/shopping_charts.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+const AXIS_TICK = {
+  fill: 'var(--muted-foreground)',
+  fontSize: 11,
+} as const;
+
+const TOOLTIP_STYLE = {
+  background: 'var(--card)',
+  border: '1px solid var(--border)',
+  borderRadius: '0.5rem',
+  fontSize: '0.75rem',
+  color: 'var(--foreground)',
+} as const;
+
+type PlatformCardRateChartViewProps = {
+  width: number;
+  data: Array<{
+    platform: string;
+    rate: number;
+  }>;
+};
+
+export function PlatformCardRateChartView({
+  width,
+  data,
+}: PlatformCardRateChartViewProps) {
+  return (
+    <BarChart
+      width={width}
+      height={220}
+      data={data}
+      margin={{ top: 8, right: 8, bottom: 0, left: -8 }}
+    >
+      <CartesianGrid
+        stroke="var(--border)"
+        strokeDasharray="3 3"
+        vertical={false}
+      />
+
+      <XAxis
+        dataKey="platform"
+        stroke="var(--border)"
+        tick={AXIS_TICK}
+        tickLine={false}
+      />
+
+      <YAxis
+        stroke="var(--border)"
+        tick={AXIS_TICK}
+        tickLine={false}
+        axisLine={false}
+        unit="%"
+      />
+
+      <Tooltip
+        contentStyle={TOOLTIP_STYLE}
+        cursor={{ fill: 'var(--muted)', opacity: 0.3 }}
+      />
+
+      <Bar
+        dataKey="rate"
+        name="Card rate"
+        fill="var(--chart-2)"
+        radius={[4, 4, 0, 0]}
+      />
+    </BarChart>
+  );
+}
+
+type ShoppingTrendChartViewProps = {
+  width: number;
+  data: Array<{
+    date: string;
+    ownCards: number;
+    totalCards: number;
+  }>;
+};
+
+export function ShoppingTrendChartView({
+  width,
+  data,
+}: ShoppingTrendChartViewProps) {
+  return (
+    <LineChart
+      width={width}
+      height={220}
+      data={data}
+      margin={{ top: 8, right: 8, bottom: 0, left: -8 }}
+    >
+      <CartesianGrid
+        stroke="var(--border)"
+        strokeDasharray="3 3"
+        vertical={false}
+      />
+
+      <XAxis
+        dataKey="date"
+        stroke="var(--border)"
+        tick={AXIS_TICK}
+        tickLine={false}
+        tickFormatter={(v: string) => v.slice(5)}
+      />
+
+      <YAxis
+        stroke="var(--border)"
+        tick={AXIS_TICK}
+        tickLine={false}
+        axisLine={false}
+      />
+
+      <Tooltip
+        contentStyle={TOOLTIP_STYLE}
+        cursor={{ stroke: 'var(--border)' }}
+      />
+
+      <Legend
+        wrapperStyle={{
+          fontSize: 11,
+          color: 'var(--muted-foreground)',
+        }}
+      />
+
+      <Line
+        type="monotone"
+        dataKey="ownCards"
+        name="Your cards"
+        stroke="var(--chart-2)"
+        strokeWidth={2}
+        dot={{ r: 2 }}
+      />
+
+      <Line
+        type="monotone"
+        dataKey="totalCards"
+        name="All cards"
+        stroke="var(--chart-4)"
+        strokeWidth={2}
+        dot={{ r: 2 }}
+      />
+    </LineChart>
+  );
+}

--- a/web/src/app/[locale]/(dashboard)/dashboard/shopping/shopping_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/shopping/shopping_charts.tsx
@@ -33,10 +33,7 @@ type PlatformCardRateChartViewProps = {
   }>;
 };
 
-export function PlatformCardRateChartView({
-  width,
-  data,
-}: PlatformCardRateChartViewProps) {
+export function PlatformCardRateChartView({ width, data }: PlatformCardRateChartViewProps) {
   return (
     <BarChart
       width={width}
@@ -44,38 +41,15 @@ export function PlatformCardRateChartView({
       data={data}
       margin={{ top: 8, right: 8, bottom: 0, left: -8 }}
     >
-      <CartesianGrid
-        stroke="var(--border)"
-        strokeDasharray="3 3"
-        vertical={false}
-      />
+      <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
 
-      <XAxis
-        dataKey="platform"
-        stroke="var(--border)"
-        tick={AXIS_TICK}
-        tickLine={false}
-      />
+      <XAxis dataKey="platform" stroke="var(--border)" tick={AXIS_TICK} tickLine={false} />
 
-      <YAxis
-        stroke="var(--border)"
-        tick={AXIS_TICK}
-        tickLine={false}
-        axisLine={false}
-        unit="%"
-      />
+      <YAxis stroke="var(--border)" tick={AXIS_TICK} tickLine={false} axisLine={false} unit="%" />
 
-      <Tooltip
-        contentStyle={TOOLTIP_STYLE}
-        cursor={{ fill: 'var(--muted)', opacity: 0.3 }}
-      />
+      <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'var(--muted)', opacity: 0.3 }} />
 
-      <Bar
-        dataKey="rate"
-        name="Card rate"
-        fill="var(--chart-2)"
-        radius={[4, 4, 0, 0]}
-      />
+      <Bar dataKey="rate" name="Card rate" fill="var(--chart-2)" radius={[4, 4, 0, 0]} />
     </BarChart>
   );
 }
@@ -89,10 +63,7 @@ type ShoppingTrendChartViewProps = {
   }>;
 };
 
-export function ShoppingTrendChartView({
-  width,
-  data,
-}: ShoppingTrendChartViewProps) {
+export function ShoppingTrendChartView({ width, data }: ShoppingTrendChartViewProps) {
   return (
     <LineChart
       width={width}
@@ -100,11 +71,7 @@ export function ShoppingTrendChartView({
       data={data}
       margin={{ top: 8, right: 8, bottom: 0, left: -8 }}
     >
-      <CartesianGrid
-        stroke="var(--border)"
-        strokeDasharray="3 3"
-        vertical={false}
-      />
+      <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
 
       <XAxis
         dataKey="date"
@@ -114,17 +81,9 @@ export function ShoppingTrendChartView({
         tickFormatter={(v: string) => v.slice(5)}
       />
 
-      <YAxis
-        stroke="var(--border)"
-        tick={AXIS_TICK}
-        tickLine={false}
-        axisLine={false}
-      />
+      <YAxis stroke="var(--border)" tick={AXIS_TICK} tickLine={false} axisLine={false} />
 
-      <Tooltip
-        contentStyle={TOOLTIP_STYLE}
-        cursor={{ stroke: 'var(--border)' }}
-      />
+      <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ stroke: 'var(--border)' }} />
 
       <Legend
         wrapperStyle={{

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
@@ -33,7 +33,17 @@ import {
 } from 'lucide-react';
 import { ShareOfVoicePlatformChart } from '../../insights/_charts';
 import { cn } from '@/lib/utils';
-import { AreaChart, Area, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+import dynamic from 'next/dynamic';
+const DynamicVisibilityTrendChart = dynamic(
+  () =>
+    import('./topic_charts').then(
+      (m) => m.VisibilityTrendChartView
+    ),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-[260px] w-full" />,
+  }
+);
 
 function ChartContainer({
   height,
@@ -131,68 +141,10 @@ function VisibilityTrendChart({ data }: { data: VisibilityTrendPoint[] }) {
   return (
     <ChartContainer height={260}>
       {(width) => (
-        <AreaChart
-          width={width}
-          height={260}
-          data={data}
-          margin={{ top: 8, right: 12, left: -12, bottom: 0 }}
-        >
-          <defs>
-            <linearGradient id="brandTopic" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#6366f1" stopOpacity={0.25} />
-              <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
-            </linearGradient>
-            <linearGradient id="compTopic" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#94a3b8" stopOpacity={0.15} />
-              <stop offset="95%" stopColor="#94a3b8" stopOpacity={0} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid strokeDasharray="3 3" className="stroke-border" vertical={false} />
-          <XAxis
-            dataKey="date"
-            tick={{ fontSize: 11 }}
-            tickLine={false}
-            axisLine={false}
-            className="fill-muted-foreground"
-          />
-          <YAxis
-            tick={{ fontSize: 11 }}
-            tickLine={false}
-            axisLine={false}
-            className="fill-muted-foreground"
-            domain={[0, 100]}
-            tickFormatter={(v: number) => `${v}%`}
-          />
-          <Tooltip
-            contentStyle={{
-              fontSize: 11,
-              borderRadius: 6,
-              border: '1px solid hsl(var(--border))',
-              background: 'hsl(var(--popover))',
-            }}
-          />
-          <Area
-            type="monotone"
-            dataKey="competitors"
-            stroke="#94a3b8"
-            strokeOpacity={0.8}
-            strokeWidth={1.5}
-            fill="url(#compTopic)"
-            name="Competitors avg"
-            strokeDasharray="4 4"
-            dot={false}
-          />
-          <Area
-            type="monotone"
-            dataKey="score"
-            stroke="#6366f1"
-            strokeWidth={2}
-            fill="url(#brandTopic)"
-            name="Brand"
-            dot={false}
-            activeDot={{ r: 4 }}
-          />
-        </AreaChart>
+       <DynamicVisibilityTrendChart
+         width={width}
+         data={data}
+       />
       )}
     </ChartContainer>
   );

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
@@ -35,14 +35,11 @@ import { ShareOfVoicePlatformChart } from '../../insights/_charts';
 import { cn } from '@/lib/utils';
 import dynamic from 'next/dynamic';
 const DynamicVisibilityTrendChart = dynamic(
-  () =>
-    import('./topic_charts').then(
-      (m) => m.VisibilityTrendChartView
-    ),
+  () => import('./topic_charts').then((m) => m.VisibilityTrendChartView),
   {
     ssr: false,
     loading: () => <Skeleton className="h-[260px] w-full" />,
-  }
+  },
 );
 
 function ChartContainer({
@@ -140,12 +137,7 @@ function VisibilityTrendChart({ data }: { data: VisibilityTrendPoint[] }) {
   }
   return (
     <ChartContainer height={260}>
-      {(width) => (
-       <DynamicVisibilityTrendChart
-         width={width}
-         data={data}
-       />
-      )}
+      {(width) => <DynamicVisibilityTrendChart width={width} data={data} />}
     </ChartContainer>
   );
 }

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/topic_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/topic_charts.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { VisibilityTrendPoint } from '@/lib/actions/tracking';
+
+export function VisibilityTrendChartView({
+  width,
+  data,
+}: {
+  width: number;
+  data: VisibilityTrendPoint[];
+}) {
+  return (
+    <AreaChart
+      width={width}
+      height={260}
+      data={data}
+      margin={{ top: 8, right: 12, left: -12, bottom: 0 }}
+    >
+      <defs>
+        <linearGradient id="brandTopic" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stopColor="#6366f1" stopOpacity={0.25} />
+          <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+        </linearGradient>
+
+        <linearGradient id="compTopic" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stopColor="#94a3b8" stopOpacity={0.15} />
+          <stop offset="95%" stopColor="#94a3b8" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+
+      <CartesianGrid
+        strokeDasharray="3 3"
+        className="stroke-border"
+        vertical={false}
+      />
+
+      <XAxis
+        dataKey="date"
+        tick={{ fontSize: 11 }}
+        tickLine={false}
+        axisLine={false}
+        className="fill-muted-foreground"
+      />
+
+      <YAxis
+        tick={{ fontSize: 11 }}
+        tickLine={false}
+        axisLine={false}
+        className="fill-muted-foreground"
+        domain={[0, 100]}
+        tickFormatter={(v: number) => `${v}%`}
+      />
+
+      <Tooltip
+        contentStyle={{
+          fontSize: 11,
+          borderRadius: 6,
+          border: '1px solid hsl(var(--border))',
+          background: 'hsl(var(--popover))',
+        }}
+      />
+
+      <Area
+        type="monotone"
+        dataKey="competitors"
+        stroke="#94a3b8"
+        strokeOpacity={0.8}
+        strokeWidth={1.5}
+        fill="url(#compTopic)"
+        name="Competitors avg"
+        strokeDasharray="4 4"
+        dot={false}
+      />
+
+      <Area
+        type="monotone"
+        dataKey="score"
+        stroke="#6366f1"
+        strokeWidth={2}
+        fill="url(#brandTopic)"
+        name="Brand"
+        dot={false}
+        activeDot={{ r: 4 }}
+      />
+    </AreaChart>
+  );
+}

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/topic_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/topic_charts.tsx
@@ -1,13 +1,6 @@
 'use client';
 
-import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
+import { Area, AreaChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
 
 import type { VisibilityTrendPoint } from '@/lib/actions/tracking';
 
@@ -37,11 +30,7 @@ export function VisibilityTrendChartView({
         </linearGradient>
       </defs>
 
-      <CartesianGrid
-        strokeDasharray="3 3"
-        className="stroke-border"
-        vertical={false}
-      />
+      <CartesianGrid strokeDasharray="3 3" className="stroke-border" vertical={false} />
 
       <XAxis
         dataKey="date"

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -1,7 +1,24 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { ReferralTrendChart, PlatformBreakdownChart, getPlatformName } from './_charts';
+import { getPlatformName } from './_charts';
+import dynamic from 'next/dynamic';
+import { Skeleton } from '@/components/ui/skeleton';
+const ReferralTrendChart = dynamic(
+  () => import('./_charts').then((m) => m.ReferralTrendChart),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-64 w-full" />,
+  }
+);
+
+const PlatformBreakdownChart = dynamic(
+  () => import('./_charts').then((m) => m.PlatformBreakdownChart),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-64 w-full" />,
+  }
+);
 import { useBrandStore } from '@/stores/use-brand-store';
 import {
   getTrafficSummary,
@@ -21,7 +38,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Skeleton } from '@/components/ui/skeleton';
 import {
   Globe,
   TrendingUp,

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -4,20 +4,17 @@ import { useState, useEffect, useCallback } from 'react';
 import { getPlatformName } from './_charts';
 import dynamic from 'next/dynamic';
 import { Skeleton } from '@/components/ui/skeleton';
-const ReferralTrendChart = dynamic(
-  () => import('./_charts').then((m) => m.ReferralTrendChart),
-  {
-    ssr: false,
-    loading: () => <Skeleton className="h-64 w-full" />,
-  }
-);
+const ReferralTrendChart = dynamic(() => import('./_charts').then((m) => m.ReferralTrendChart), {
+  ssr: false,
+  loading: () => <Skeleton className="h-64 w-full" />,
+});
 
 const PlatformBreakdownChart = dynamic(
   () => import('./_charts').then((m) => m.PlatformBreakdownChart),
   {
     ssr: false,
     loading: () => <Skeleton className="h-64 w-full" />,
-  }
+  },
 );
 import { useBrandStore } from '@/stores/use-brand-store';
 import {


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

This PR optimizes dashboard route performance by lazy-loading Recharts-based visualizations instead of eagerly bundling them into the initial client-side JavaScript.

- Replaced static chart imports with `next/dynamic` imports using `ssr: false`.
- Added skeleton loading fallbacks for dynamically loaded chart components.
- Extracted inline Recharts chart implementations into dedicated child components:
  - `shopping/shopping_charts.tsx`
  - `citations/citations_charts.tsx`
  - `topics/[id]/topic_charts.tsx`
- Updated dashboard pages to dynamically load chart components instead of importing Recharts directly.
- Updated pages consuming shared chart components (`_charts.tsx` and `agent-chart.tsx`) to load them through `next/dynamic`.
- Removed direct Recharts imports from dashboard route pages where chart rendering was moved into dynamically loaded child components.

## Related issue

Closes #220 

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [x] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
