### PR TITLE
chore(release): v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-21
+
+### Added
+- Site Audit: AEO/GEO page scoring under Content Optimization — fetches any URL (Scrape.do proxy + JS render) and scores it across 47 weighted signals in five categories (structure, content, authority, E-E-A-T, trust) using deterministic evaluators plus a batched LLM pass, then returns prioritized, AI-written fix recommendations. Runs asynchronously with live progress, a per-audit detail page at `/dashboard/audit/[id]` (re-run + delete), a primary-domain score trend and category breakdown on the hub, and a monthly per-plan quota (#259, #261, #262, #263, #264, #265, #268)
+- Server: structured logging — a `pino`-based logger with levels (`LOG_LEVEL`), per-request correlation IDs (`x-request-id` + per-request child loggers), JSON output, and sensitive-header redaction; the per-request access log dropped to `debug` so it's off by default in production (#273, thanks @Pallavikumarimdb)
+- Citations: expanded the source-category domain lists so more citations classify into the right bucket (#276, thanks @BharadwajKanneveti)
+
+### Changed
+- Performance: dashboard charts (Recharts) are now lazy-loaded via `next/dynamic` with skeleton fallbacks, trimming the initial route JS across Insights, Shopping, Citations, Topics, Traffic, Prompts, and the Agent panel (#281, thanks @BharadwajKanneveti)
+- Insights: the date range now defaults to the last 24h instead of all-time (#274, thanks @Srija-65)
+- Insights: clearer "Queued — starting automatically" copy when an analysis is waiting behind another run (#280)
+- Web: dropped the unused `framer-motion` dependency (#266) and removed a deprecated unused `Project` type (#258) (both thanks @BharadwajKanneveti)
+
+### Fixed
+- Tracking: the "Analyze Prompts" action no longer re-analyzes prompts that already have results — closes a double-spend where the same prompts could be submitted several times during the async webhook window (#278)
+- Tracking: the analysis progress bar no longer freezes partway on webhook-mode runs — the drain loop now counts only the current run's tasks (not brand-wide orphans), gives up early if delivery stalls, and a periodic sweep clears orphaned pending-task rows (#279)
+- Shopping: Microsoft Copilot `shoppingProducts` wrappers are flattened into per-product cards instead of a single "Unknown Product" (#255)
+- Web: switching brand tabs no longer flashes a spurious "Failed to fetch" toast from the aborted in-flight request (#257, thanks @gitbasitmalik)
+
+### Tests
+- Server: closed the remaining server-side test gaps tracked in #125 (#256, thanks @Pallavikumarimdb)
+
+### Docs
+- Added `CRON_SECRET` to both `.env.example` files, with a note that it's cloud-only and must match on the web app and the server (#277, thanks @P-Maheswari)
+
+### Contributors
+Huge thanks to everyone who contributed to this release — and a special welcome to first-time contributors @gitbasitmalik, @Srija-65, and @P-Maheswari! 🎉 Thanks also to @Pallavikumarimdb and @BharadwajKanneveti. 🙌
+
 ## [0.1.3] - 2026-06-14
 
 ### Security

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/ansvisor/ansvisor/web:0.1.3
+    image: ghcr.io/ansvisor/ansvisor/web:0.1.4
     build: ./web
     ports:
       - "3000:3000"
@@ -11,7 +11,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: ghcr.io/ansvisor/ansvisor/server:0.1.3
+    image: ghcr.io/ansvisor/ansvisor/server:0.1.4
     build: ./server
     ports:
       - "80:80"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ansvisor",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Open source AI Engine Optimization platform",
   "repository": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansvisor/ansvisor-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Ansvisor - AI Engine Optimization Server",
   "main": "src/server.js",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansvisor/ansvisor-web",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Cuts **v0.1.4**. Bumps the version in the root, `web/`, and `server/` `package.json` files and the `docker-compose.yml` image tags (`0.1.3 → 0.1.4`), and adds the `0.1.4` CHANGELOG section.

Highlights since v0.1.3:

- **Site Audit** — 47-signal AEO/GEO page scoring under Content Optimization, with AI-written fixes, async runs, a per-audit detail page, a primary-domain trend + category breakdown, and a monthly per-plan quota (#259, #261–#265, #268).
- **Structured logging** on the server — `pino`, levels, request IDs, JSON (#273).
- **Recharts lazy-loading** to trim dashboard route JS (#281).
- **Tracking fixes** — no re-analysis of already-analyzed prompts (#278) and a progress bar that no longer freezes on webhook-mode runs (#279).
- Plus Insights defaults, Citations source lists, dependency cleanup, server tests, and docs.

First-time contributors this release: **@gitbasitmalik, @Srija-65, @P-Maheswari** 🎉

## Related issue

_None — release chore._

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. `grep version package.json web/package.json server/package.json` → all read `0.1.4`.
2. `grep image docker-compose.yml` → both tags read `:0.1.4`.
3. CHANGELOG renders a `[0.1.4] - 2026-06-21` section with Added / Changed / Fixed / Tests / Docs / Contributors.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `yarn lint` passes (run from `web/`)
- [ ] `yarn typecheck` passes (run from `web/`)
- [ ] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

> `lint`/`typecheck`/`format:check` skipped — release metadata only (CHANGELOG, `package.json` versions, compose image tags); no source files touched.
