### PR TITLE
fix(insights): don't floor the visibility score to 0

### DIFF
--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -4,6 +4,11 @@ import { createClient } from '@/lib/supabase/server';
 import { expandDateToEndOfDay } from '@/lib/dates';
 import type { PromptResult, AIPlatform, Sentiment, Citation, CompetitorMention } from '@/types';
 
+/** Round to one decimal place (keeps sub-1 averages visible instead of flooring to 0). */
+function roundTo1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
 /**
  * Apply the `model` filter to a Supabase query against `prompt_results.model_used`.
  *
@@ -588,7 +593,12 @@ export async function getInsightsSummary(
   }
 
   const totalResults = cur.total_results;
-  const avgVisibilityScore = Math.round(cur.sum_visibility / totalResults);
+  // Average visibility across ALL runs (brand-mentioned or not) — the intended
+  // "absolute visibility" metric. Keep one decimal instead of rounding to a
+  // whole number: a brand that appears in a small fraction of answers can have
+  // a genuine sub-1 average (e.g. 0.4), and integer rounding collapsed that to
+  // a flat "0" that read like a broken metric next to non-zero mentions.
+  const avgVisibilityScore = roundTo1(cur.sum_visibility / totalResults);
   const totalMentions = cur.total_mentions;
   const totalCitations = cur.total_citations;
   const positiveSentimentPct = Math.round((cur.positive_count / totalResults) * 100);
@@ -647,17 +657,17 @@ export async function getInsightsSummary(
     const prevWin = prevRes.data as unknown as InsightsAggregates | null;
 
     if (curWin && prevWin && curWin.total_results > 0 && prevWin.total_results > 0) {
-      const curAvgVis = Math.round(curWin.sum_visibility / curWin.total_results);
+      const curAvgVis = roundTo1(curWin.sum_visibility / curWin.total_results);
       const curMentions = curWin.total_mentions;
       const curCitations = curWin.total_citations;
       const curSentimentPct = Math.round((curWin.positive_count / curWin.total_results) * 100);
 
-      const prevAvgVis = Math.round(prevWin.sum_visibility / prevWin.total_results);
+      const prevAvgVis = roundTo1(prevWin.sum_visibility / prevWin.total_results);
       const prevMentions = prevWin.total_mentions;
       const prevCitations = prevWin.total_citations;
       const prevSentimentPct = Math.round((prevWin.positive_count / prevWin.total_results) * 100);
 
-      visibilityChange = curAvgVis - prevAvgVis;
+      visibilityChange = roundTo1(curAvgVis - prevAvgVis);
       mentionsChange =
         curMentions > 0 && prevMentions > 0
           ? Math.round(((curMentions - prevMentions) / prevMentions) * 100)


### PR DESCRIPTION
## Summary

The Insights **Visibility Score** card could show **0** for a brand that clearly has mentions and citations (reported on a brand showing 67 mentions / 11 citations but a score of 0).

**Root cause — not a calculation bug.** The per-row visibility scores are correct (a row with a mention is always non-zero; verified `0` rows with a mention-but-zero-score). The headline number is the average score across **all** prompt runs:

```
avgVisibilityScore = Math.round(sum_visibility / total_results)
```

`total_results` is every prompt × platform × region run, the vast majority of which don't mention the brand (score 0). For the reported brand: `1370 / 3473 = 0.39`, and `Math.round(0.39) = 0`. The brand genuinely appears in only ~23 of 3473 answers (~0.7%), so its average visibility is a real ~0.4/100 — but flooring it to `0` reads like the metric is broken.

**Fix (display only — metric meaning unchanged).** Keep one decimal for the brand-level visibility score and its period-over-period delta, via a small `roundTo1` helper. The denominator and semantics are untouched (still an average over all runs); small-but-nonzero visibility now shows as `0.4` instead of `0`. Whole-number scores still render cleanly (e.g. `64`, not `64.0`).

Scope kept tight to the Insights summary headline + its delta. The same `Math.round(sum/count)` pattern exists for per-platform/competitor/topic averages — happy to extend if you want full consistency, but left out here to keep the change focused on the reported card.

## Related issue

_None — reported directly._

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open Insights for a brand that appears in a small fraction of answers (e.g. brand with ~0.4 average).
2. The Visibility Score card now reads `0.4` instead of `0`; mentions/citations are unchanged.
3. A brand with whole-number average still shows a clean integer (e.g. `64`).
4. The delta badge shows fractional pts where applicable (e.g. `+0.1 pts`).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
