### PR TITLE
fix(audit): anchor AI recommendations to the current date

### DIFF
--- a/server/src/lib/audit/recommendations.js
+++ b/server/src/lib/audit/recommendations.js
@@ -76,6 +76,8 @@ When the fix is content the user can paste, put the ready-to-use text in "draft"
 - readability → a simplified rewrite of one representative paragraph (shorter sentences, plainer words)
 - length → which specific sections to expand or trim (draft can be null)
 
+When suggesting sources to cite (outbound-authority-links, citation-density, statistic-density), prefer the most recent, currently-authoritative references and do not present older material as if it were current. Never invent URLs or fabricate statistics/dates — only suggest sources you are confident exist.
+
 Keep "recommendation" to 1–3 sentences. Set "draft" to null when the fix isn't a paste-able snippet. Prioritize by impact. Only return items you can make genuinely specific and useful.`;
 
 /**
@@ -101,6 +103,15 @@ export async function generateRecommendations(ctx, { results } = {}) {
 
   const pageText = ctx.text.slice(0, 6000);
 
+  // Anchor the model to the real current date — without it, the LLM defaults to
+  // its training-data sense of "now" and suggests stale (e.g. 2024) sources for
+  // outbound-authority-links / citation-density.
+  const today = new Date(ctx.now ?? Date.now()).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
   try {
     const { object } = await withRetry(
       () =>
@@ -108,7 +119,9 @@ export async function generateRecommendations(ctx, { results } = {}) {
           model: resolveModel(modelString),
           schema: recommendationsSchema,
           system: SYSTEM_PROMPT,
-          prompt: `PAGE URL: ${ctx.url}
+          prompt: `Today's date is ${today}.
+
+PAGE URL: ${ctx.url}
 
 Improve THIS page for its own topic/intent (infer it from the content below). Never introduce subject matter the page isn't already about.
 


### PR DESCRIPTION
## Summary

Site Audit's AI recommendations could suggest **stale (e.g. 2024) sources** for the "Outbound authority links" signal (and other source-suggesting signals like citation density). The recommendation prompt never included the current date, so `gemini-3-flash` defaulted to its training-data sense of "now" and proposed outdated references as if they were current.

**Fix:** inject today's date (derived from `ctx.now`) at the top of the recommendation prompt, and instruct the model to:
- prefer the most recent, currently-authoritative sources, and not present older material as current;
- never invent URLs or fabricate statistics/dates (only suggest sources it's confident exist).

This mirrors the date injection the in-product Agent already does (#137). It's a prompt-only change — signal evaluation and scoring are untouched.

## Related issue

_None — reported directly._

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Run a Site Audit on a page that fails `outbound-authority-links` / `citation-density`.
2. The suggested sources should skew to current, recent references rather than 2024-era ones, and shouldn't present older material as if it were the latest.
3. `cd server && yarn test audit` → all audit tests pass (14/14).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `yarn lint` passes (run from `web/`)
- [ ] `yarn typecheck` passes (run from `web/`)
- [ ] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

> `web/` lint/typecheck/format:check skipped — server-side change only (`server/src/lib/audit/recommendations.js`). `node --check` + `npx prettier --check` pass on the file, and `server` audit tests are green.
