### PR TITLE
fix(plans): treat trialing subscriptions as active in web plan-guard

### DIFF
--- a/web/src/config/plans.ts
+++ b/web/src/config/plans.ts
@@ -222,6 +222,16 @@ export function getPlan(planId: string | null | undefined): Plan {
   return PLANS[(planId as PlanId) ?? 'starter'] ?? PLANS.starter;
 }
 
+/**
+ * Whether a Stripe subscription_status entitles the org to its paid plan.
+ * `trialing` counts — it's a paid plan inside its free-trial window — so it must
+ * NOT be downgraded to starter limits. Mirrors the server's isSubscriptionActive
+ * (server/src/config/plans.js); keep the two in sync.
+ */
+export function isSubscriptionActive(status: string | null | undefined): boolean {
+  return status === 'active' || status === 'trialing';
+}
+
 export function hasFeature(plan: Plan, feature: Feature): boolean {
   return plan.limits.features.includes(feature);
 }

--- a/web/src/lib/guards/plan-guard.ts
+++ b/web/src/lib/guards/plan-guard.ts
@@ -6,6 +6,7 @@ import {
   getPlan,
   hasFeature,
   isCloud,
+  isSubscriptionActive,
   isWithinLimit,
 } from '@/config/plans';
 
@@ -19,7 +20,10 @@ export async function getOrgPlan(organizationId: string): Promise<Plan> {
     .eq('id', organizationId)
     .single();
 
-  if (data?.subscription_status !== 'active') {
+  // `trialing` is a paid plan in its trial window — treat it as active so
+  // trial customers get their actual plan's limits (seats, brands, prompts…)
+  // instead of being silently dropped to starter.
+  if (!isSubscriptionActive(data?.subscription_status)) {
     return getPlan('starter');
   }
 


### PR DESCRIPTION
## Summary

A customer on a **Growth** plan in their **free trial** couldn't invite teammates — the Team section showed **Starter** with 1 seat, even though billing (and the DB) correctly showed Growth.

**Root cause.** `getOrgPlan()` in `web/src/lib/guards/plan-guard.ts` gated on `subscription_status === 'active'`:

```ts
if (data?.subscription_status !== 'active') {
  return getPlan('starter');
}
```

A paid plan inside its trial window has `subscription_status === 'trialing'`, which fails that check and falls through to **starter** limits. The server already treats trialing as active (`isSubscriptionActive` in `server/src/config/plans.js` = `active || trialing`, with a comment saying exactly this) — the web side had drifted.

Because `getOrgPlan` backs every web-side entitlement gate, the downgrade wasn't limited to team seats — it also affected `maxBrands`, `maxPrompts`, `maxPlatforms`, and the `daily_monitoring` feature for any trialing org.

**Fix.** Add `isSubscriptionActive(status)` to `web/src/config/plans.ts` (mirroring the server), and use it in `getOrgPlan` so trialing orgs get their real plan's limits. Keeps web and server entitlement logic in sync.

## Related issue

_None — reported by a customer (trialing Growth org couldn't invite)._

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. An org with `plan = 'growth'` and `subscription_status = 'trialing'`.
2. Before: Settings → Team shows "Starter", 1 seat, invite blocked. After: shows "Growth", 3 seats, invite works.
3. Same org can now create brands/prompts/platforms up to the Growth limits during the trial.
4. A `canceled`/`past_due`/`inactive` org still correctly falls back to starter limits.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
