### PR TITLE
docs: document SCRAPEDO_API_KEY + AUDIT_LLM_MODEL (Site Audit)

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -16,6 +16,8 @@ description: "Common questions about Ansvisor."
 
   <Accordion title="Why don't you scrape ChatGPT/Gemini directly?">
     For programmable AI engines (OpenAI, Anthropic, Google Gemini API), Ansvisor uses official APIs — most reliable, well-priced, and TOS-compliant. For *web* AI engines that don't have public APIs (like ChatGPT.com search results), Ansvisor uses Cloro as a managed scraping backend. Cloro handles browser fingerprinting, captcha bypass, and rate-limiting at scale.
+
+    These are two distinct fetchers: **Cloro** scrapes the AI answer engines, while **Scrape.do** (via `SCRAPEDO_API_KEY`) fetches your *own* pages for the **Site Audit** feature (proxy + JS render). Self-hosters who want Site Audit need a Scrape.do key.
   </Accordion>
 
   <Accordion title="How often does tracking run?">

--- a/docs/self-host/env-variables.mdx
+++ b/docs/self-host/env-variables.mdx
@@ -44,12 +44,14 @@ Fed to the Express API + workers.
 | `TOPIC_SUGGESTION_MODEL` | optional | LLM for topic suggestions |
 | `PROMPT_SUGGESTION_MODEL` | optional | LLM for prompt suggestions |
 | `COMPETITOR_SUGGESTION_MODEL` | optional | LLM for competitor suggestions |
+| `AUDIT_LLM_MODEL` | optional | LLM for the Site Audit's LLM-judged signals + AI recommendations (default: `google/gemini-3-flash-preview`) |
 | `ALLOWED_ORIGINS` | ✅ | Comma-separated list of web origins allowed to call the API (for CORS) |
 | `IS_CLOUD` | optional | `"true"` only for the official cloud build |
 | `DATAFORSEO_LOGIN` | optional | DataForSEO login (for prompt volume analysis) |
 | `DATAFORSEO_PASSWORD` | optional | DataForSEO password |
 | `CLORO_API_KEY` | optional | Cloro web scraper API key (for ChatGPT/Gemini/Perplexity web scraping) |
 | `PLATFORM_PROVIDER` | optional | Default `cloro`. Used to pick scraper backend |
+| `SCRAPEDO_API_KEY` | Site Audit | Scrape.do API key — required to run **Site Audit** (it fetches target pages via Scrape.do's proxy + JS render). Distinct from `CLORO_API_KEY`, which scrapes the AI answer engines. |
 | `AI_VOLUME_MULTIPLIER` | optional | Estimated AI search adoption rate (default `0.15` = 15% of Google volume) |
 | `CRON_SECRET` | cloud only | Shared secret with web's CRON_SECRET; protects internal cron endpoints |
 


### PR DESCRIPTION
## Summary

Documents the two Site Audit env vars that previously lived only in `server/.env.example`, so self-hosters enabling Site Audit know what they need.

- **`docs/self-host/env-variables.mdx`** (Server table):
  - `SCRAPEDO_API_KEY` — marked **"Site Audit"** (required to run it; fetches target pages via Scrape.do proxy + JS render), with a note that it's distinct from `CLORO_API_KEY`.
  - `AUDIT_LLM_MODEL` — optional, default `google/gemini-3-flash-preview`.
- **`docs/faq.mdx`** — extends the existing "Why don't you scrape ChatGPT/Gemini directly?" accordion with one line clarifying the two fetchers: **Cloro** scrapes the AI answer engines, **Scrape.do** fetches your own pages for Site Audit.

Verified the docs match the code: `AUDIT_LLM_MODEL` default is `google/gemini-3-flash-preview` (`recommendations.js` / `llm-signals.js`) and `SCRAPEDO_API_KEY` is required by `audit/fetcher.js`.

## Related issue

Closes #275

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [x] `docs` — Documentation only
- [ ] `refactor`
- [ ] `test`

## How to test

1. Open `docs/self-host/env-variables.mdx` → Server table lists `SCRAPEDO_API_KEY` (Site Audit) and `AUDIT_LLM_MODEL` (optional, default noted).
2. Open `docs/faq.mdx` → the scraping accordion distinguishes Scrape.do (Site Audit page fetch) from Cloro (AI-engine scraping).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `yarn lint` — n/a, docs only
- [ ] `yarn typecheck` — n/a
- [ ] `yarn format:check` — n/a
- [x] Changes are focused — one concern per PR

> Docs-only (`docs/*.mdx`); no source touched. Content verified against `server/.env.example` and the audit code.
