### PR TITLE
docs(readme): list Scrape.do under Optional Services (Site Audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ We're incredibly excited to shape what's next alongside our amazing community.
 | Service | Purpose | Where to get |
 |---------|---------|--------------|
 | **DataForSEO** | Keyword volume data for prompt analysis | [dataforseo.com](https://dataforseo.com/) |
+| **Scrape.do** | Page fetching for Site Audit (proxy + JS render); required only if you use Site Audit | [scrape.do](https://scrape.do/) |
 | **Stripe** | Payments (cloud mode only, not needed for self-hosted) | [stripe.com](https://stripe.com/) |
 
 ### Setup


### PR DESCRIPTION
## Summary

Follow-up to #294 (which documented `SCRAPEDO_API_KEY` / `AUDIT_LLM_MODEL` in the docs site). That PR was merged before the README was updated, so this adds the matching README entry.

Lists **Scrape.do** under **Optional Services** in the README — it's required only if you use Site Audit (it fetches target pages via proxy + JS render), so it sits alongside DataForSEO rather than under Required Services. Consistent with how `env-variables.mdx` marks `SCRAPEDO_API_KEY` as conditional ("Site Audit") rather than a hard requirement.

## Related issue

Part of #275 (docs README follow-up).

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [x] `docs` — Documentation only
- [ ] `refactor`
- [ ] `test`

## How to test

1. Open `README.md` → the **Optional Services** table lists **Scrape.do** with "Page fetching for Site Audit … required only if you use Site Audit".

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `yarn lint` — n/a, docs only
- [ ] `yarn typecheck` — n/a
- [ ] `yarn format:check` — n/a
- [x] Changes are focused — one concern per PR

> Docs-only (`README.md`); no source touched.
