### PR TITLE
feat(prompts): banner for unanalyzed keywords with one-click Analyze

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -423,6 +423,13 @@ export default function PromptsPage() {
     return m;
   }, [volumes]);
 
+  // Active prompts that have no volume row yet — their Volume/Competition cells
+  // render blank. Drives the "unanalyzed keywords" banner + one-click Analyze.
+  const unanalyzedCount = useMemo(
+    () => allPrompts.filter((p) => p.isActive && !volumeByPromptId.has(p.id)).length,
+    [allPrompts, volumeByPromptId],
+  );
+
   const canExport = !loading && allPrompts.length > 0;
 
   const handleExportCsv = useCallback(() => {
@@ -518,7 +525,43 @@ export default function PromptsPage() {
         </div>
 
         {/* ─── All Prompts tab ─────────────────────────────────────────── */}
-        <TabsContent value="all" className="mt-4">
+        <TabsContent value="all" className="mt-4 space-y-4">
+          {!loading && unanalyzedCount > 0 && (
+            <div className="flex flex-col gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 sm:flex-row sm:items-center sm:justify-between dark:border-amber-900/50 dark:bg-amber-950/30">
+              <div className="flex items-start gap-2.5">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-500" />
+                <div className="text-sm">
+                  <p className="font-medium text-amber-900 dark:text-amber-200">
+                    {unanalyzedCount} keyword{unanalyzedCount === 1 ? '' : 's'} haven&apos;t been
+                    analyzed yet
+                  </p>
+                  <p className="text-amber-800/80 dark:text-amber-300/80">
+                    {quotaExhausted
+                      ? 'Their Volume & Competition stay empty until analyzed — but your monthly volume analysis limit is reached. Upgrade your plan to analyze more.'
+                      : 'Run volume analysis to fill in their Volume & Competition.'}
+                  </p>
+                </div>
+              </div>
+              <Button
+                size="sm"
+                className="shrink-0"
+                onClick={handleAnalyzeNew}
+                disabled={analyzing || quotaExhausted}
+              >
+                {analyzing ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Analyzing...
+                  </>
+                ) : (
+                  <>
+                    <BarChart3 className="mr-2 h-4 w-4" />
+                    Analyze {unanalyzedCount} keyword{unanalyzedCount === 1 ? '' : 's'}
+                  </>
+                )}
+              </Button>
+            </div>
+          )}
           <AllPromptsTab
             loading={loading}
             prompts={allPrompts}


### PR DESCRIPTION
## Summary

On the **All Prompts** tab (`/dashboard/prompts?tab=all`), prompts that haven't had volume analysis run show blank **Volume** / **Competition** cells with no explanation — and the analyze action only lived on the Insights tab, so there was no way to act from here.

Adds a contextual banner above the table:

- Shown only when there are active prompts with no volume row (`unanalyzedCount > 0`), with the correct count and pluralization.
- An **Analyze N keyword(s)** button that runs volume analysis for just those (reuses `handleAnalyzeNew`, which already targets the unanalyzed set first). After it completes, the data reloads and the banner disappears.
- Respects the monthly volume quota: when exhausted, the CTA is disabled and the copy switches to a "limit reached — upgrade" hint, consistent with the existing quota messaging.

Uses the same amber-callout style as other in-app warning banners (no new deps/icons).

## Related issue

Closes #290

## Type of change

- [x] `feat` — New feature
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`

## How to test

1. Open `/dashboard/prompts?tab=all` for a brand with at least one active prompt that has no volume data.
2. A banner shows "{n} keywords haven't been analyzed yet" with an **Analyze {n} keywords** button.
3. Click it → volume analysis runs for those prompts; once done, Volume/Competition fill in and the banner disappears.
4. With all prompts analyzed → no banner.
5. With the monthly volume quota exhausted → the CTA is disabled and the copy shows the upgrade/limit hint.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
