### PR TITLE
feat(agent): use Site Audit from the in-product assistant

### DIFF
--- a/web/src/lib/agent/system-prompt.ts
+++ b/web/src/lib/agent/system-prompt.ts
@@ -41,6 +41,9 @@ You have these tools, all scoped to the authenticated user's organization:
 - **list_prompts** — prompts being tracked for a brand. Use when the user asks what is being tracked or wants to drill into a specific topic.
 - **get_prompt_performance** — aggregates performance (average visibility, total mentions, citations, appearances, and competitor score) grouped by prompt over a date range. Use to answer questions like "what is the best-performing prompt today?" or "which prompts dropped this week?".
 - **list_content_opportunities** — content gaps for a brand sorted by opportunity score. Use for "what should I write?" questions.
+- **run_site_audit** — run a Site Audit (AEO/GEO page score + AI fix recommendations) for a URL under a brand. Returns immediately with status "running"; poll get_site_audit for the result. **This is a write that spends one of the org's monthly Site Audit credits** — only run it when the user explicitly asks to audit a page.
+- **get_site_audit** — read a Site Audit's result (status, total + per-category scores, signals, AI fix recommendations) by id. No credit consumed.
+- **list_site_audits** — list a brand's recent audits (id, url, status, score, date) to find a past one by url/date. No credit consumed.
 - **render_chart** — render a chart inline in the chat (line / bar / pie). Call this *after* a data tool when the answer is meaningfully easier to read as a chart than as a sentence. See "Visualization" below.
 
 ## Visualization (render_chart)
@@ -66,6 +69,7 @@ Hard rules:
 5. **Be concrete about what to do next.** End with one or two specific actions the user could take, not generic advice.
 6. **Acknowledge tool gaps.** If you'd want to answer a question but lack a tool for it (e.g., the user asks about something only an upcoming tool would expose), say what's missing rather than guessing.
 7. **Respect the user's window.** If they ask about "this week," compute it from today's date (above) and pass an explicit \`date_from\` to the time-aware tools; don't fall back to all-time.
+8. **run_site_audit spends a credit — only on explicit intent.** Treat \`run_site_audit\` as a write: call it only when the user explicitly asks to audit a specific page/URL, never as part of exploratory analysis or unprompted. To audit, call \`run_site_audit\`, then poll \`get_site_audit\` with the returned id until status is "completed", then summarize the total score, the weakest categories, and the top AI-written fixes. If the run returns a quota/limit message (monthly audit credits exhausted), relay that message to the user instead of retrying.
 
 ## Scoring reference
 

--- a/web/src/lib/agent/tools.ts
+++ b/web/src/lib/agent/tools.ts
@@ -12,6 +12,9 @@ import {
   listPromptsFor,
   listTopicsFor,
   getPromptPerformanceFor,
+  runSiteAuditFor,
+  getSiteAuditFor,
+  listSiteAuditsFor,
 } from '@/lib/mcp/data';
 
 /**
@@ -196,6 +199,34 @@ export function buildAgentTools(auth: McpAuthContext) {
           model: args.model,
           region: args.region,
         }),
+    }),
+
+    run_site_audit: tool({
+      description:
+        'Run a Site Audit (AEO/GEO page score + AI fix recommendations) for a page URL under a brand. WARNING: this consumes one of the org\'s monthly Site Audit credits (shared with the dashboard) and runs asynchronously (~30s). It returns the new audit id with status "running" — then call get_site_audit with that id until status is "completed" (or "failed") to read the result. Only run on explicit user intent to audit a specific URL; never audit unprompted.',
+      inputSchema: z.object({
+        brand_id: z.string().uuid(),
+        url: z.string().url(),
+      }),
+      execute: async (args) => runSiteAuditFor(auth, args.brand_id, args.url),
+    }),
+
+    get_site_audit: tool({
+      description:
+        'Fetch a Site Audit by id — status, total score, per-category scores, evaluated signals, and AI fix recommendations. Use after run_site_audit to poll for the result: while status is "running" the scores are not yet populated; once "completed" (or "failed") the full result is available. Read — no credit consumed.',
+      inputSchema: z.object({
+        audit_id: z.string().uuid(),
+      }),
+      execute: async (args) => getSiteAuditFor(auth, args.audit_id),
+    }),
+
+    list_site_audits: tool({
+      description:
+        "List a brand's recent Site Audits (newest first) — id, url, status, total score, signals, and created date. Use to find a past audit by url/date (then read it with get_site_audit) without needing the id. Read — no credit consumed.",
+      inputSchema: z.object({
+        brand_id: z.string().uuid(),
+      }),
+      execute: async (args) => listSiteAuditsFor(auth, args.brand_id),
     }),
 
     render_chart: tool({


### PR DESCRIPTION
## Summary

Lets the in-product AI assistant (`/dashboard/agent`) run and read **Site Audits** in chat — e.g. "audit my homepage" → it triggers an audit, polls for completion, then summarizes the score, weak categories, and the top AI-written fixes.

Pure wiring: the agent keeps its own tool registry (`buildAgentTools` in `web/src/lib/agent/tools.ts`) that wraps the shared `web/src/lib/mcp/data.ts` functions, with names matching the MCP tool ids. This PR reuses the site-audit data functions landed in #269/#270 (`runSiteAuditFor`, `getSiteAuditFor`, `listSiteAuditsFor`) the same way the agent already reuses `getVisibilitySummaryFor` — no aggregation logic is duplicated, and ownership/quota stay server-side.

## Changes

- **`web/src/lib/agent/tools.ts`** — register three tools:
  - `run_site_audit` (brand_id, url) — **write**: triggers an audit, returns `status: "running"`. Consumes one of the org's monthly Site Audit credits (shared pool with the dashboard).
  - `get_site_audit` (audit_id) — read: status + total/category scores + signals + AI recommendations.
  - `list_site_audits` (brand_id) — read: recent audits to find one by url/date.
- **`web/src/lib/agent/system-prompt.ts`** — add the three tools to the "Tools available" list, plus a rule that `run_site_audit` is a credit-spending write: only fire on explicit user intent, then poll `get_site_audit` until `completed` and summarize score / weak categories / top fixes; relay the quota-limit message instead of retrying. (The chat loop already multi-steps via `stepCountIs(20)`, so trigger → poll → summarize completes in one turn.)

## Related issue

Closes #271

## Type of change

- [x] `feat` — New feature

## How to test

In the dashboard chat (`/dashboard/agent`):

1. "Audit https://example.com/page for <brand>" → the assistant calls `run_site_audit`, polls `get_site_audit`, and reports the total score, weakest categories, and top AI fixes.
2. It does **not** audit unprompted during exploratory questions (e.g. "how is my brand doing?" uses only the read tools).
3. When the monthly audit credits are exhausted, the assistant relays the limit/upgrade message rather than retrying.
4. "Show my recent audits for <brand>" → `list_site_audits`, no credit consumed.

## Checklist

- [x] Branch follows the naming convention (`feature/`)
- [x] Commits follow Conventional Commits
- [x] `yarn typecheck`, `eslint`, `prettier --check` pass on changed files
- [x] Changes are focused — one concern per PR
