### PR TITLE
feat(brands): pause a brand — add is_active and skip inactive brands in daily tracking

### DIFF
--- a/server/src/routes/tracking.js
+++ b/server/src/routes/tracking.js
@@ -23,7 +23,7 @@ router.post('/check', async (req, res) => {
     // Verify the user owns this brand
     const { data: brand, error: brandErr } = await supabaseAdmin
       .from('brands')
-      .select('id, organization_id')
+      .select('id, organization_id, is_active')
       .eq('id', brandId)
       .single();
 
@@ -39,6 +39,15 @@ router.post('/check', async (req, res) => {
 
     if (!profile || profile.organization_id !== brand.organization_id) {
       return res.status(403).json({ success: false, message: 'Unauthorized' });
+    }
+
+    // A paused brand spends nothing — block on-demand runs too, not just the
+    // daily cron. Resume the brand to track it again.
+    if (brand.is_active === false) {
+      return res.status(409).json({
+        success: false,
+        message: 'This brand is paused. Resume it to run tracking.',
+      });
     }
 
     // Same cloud-mode cost controls as /analyze-new — this endpoint also
@@ -84,7 +93,7 @@ router.post('/analyze-new', async (req, res) => {
 
     const { data: brand, error: brandErr } = await supabaseAdmin
       .from('brands')
-      .select('id, organization_id')
+      .select('id, organization_id, is_active')
       .eq('id', brandId)
       .single();
 
@@ -100,6 +109,15 @@ router.post('/analyze-new', async (req, res) => {
 
     if (!profile || profile.organization_id !== brand.organization_id) {
       return res.status(403).json({ success: false, message: 'Unauthorized' });
+    }
+
+    // A paused brand spends nothing — block on-demand runs too, not just the
+    // daily cron. Resume the brand to track it again.
+    if (brand.is_active === false) {
+      return res.status(409).json({
+        success: false,
+        message: 'This brand is paused. Resume it to run tracking.',
+      });
     }
 
     // Build the candidate set: either the specific IDs the client picked

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -109,7 +109,12 @@ async function runDailyTracking() {
   // self-hosted, since both paths funnel through here).
   await cleanupStalePendingTasks();
 
-  const { data: brands, error } = await supabaseAdmin.from('brands').select('id, organization_id');
+  // Skip paused brands (is_active = false): the user has explicitly suspended
+  // tracking for them, so they should not spend Cloro / LLM credits daily.
+  const { data: brands, error } = await supabaseAdmin
+    .from('brands')
+    .select('id, organization_id')
+    .eq('is_active', true);
 
   if (error || !brands || brands.length === 0) {
     return { triggered: 0, total: 0 };

--- a/supabase/migrations/00020_brand_is_active.sql
+++ b/supabase/migrations/00020_brand_is_active.sql
@@ -1,0 +1,14 @@
+-- 00020_brand_is_active.sql
+-- Add a pause/resume switch to brands.
+--
+-- A brand can now be temporarily paused: pausing suspends daily tracking
+-- (and all on-demand tracking spend) while keeping every bit of historical
+-- data viewable. Resuming re-enables tracking on the next cron run.
+--
+-- Existing brands default to active so behavior is unchanged on rollout.
+
+ALTER TABLE brands
+  ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN brands.is_active IS
+  'When false, the brand is paused: the daily tracking cron and on-demand tracking skip it. Historical data stays viewable. Defaults to true.';

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -4,7 +4,12 @@ import { use, useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter, Link } from '@/i18n/navigation';
 import { useBrandStore } from '@/stores/use-brand-store';
-import { updateBrand, deleteBrand, setBrandShoppingMode } from '@/lib/actions/brand';
+import {
+  updateBrand,
+  deleteBrand,
+  setBrandShoppingMode,
+  setBrandActive,
+} from '@/lib/actions/brand';
 import { syncDomains } from '@/lib/actions/brand-domain';
 import { getCompetitors, addCompetitor, deleteCompetitor } from '@/lib/actions/competitor';
 import { getFaviconUrl } from '@/lib/favicon';
@@ -32,7 +37,9 @@ import {
   Copy,
   Globe,
   Loader2,
+  Pause,
   Pencil,
+  Play,
   Plus,
   Save,
   ShoppingBag,
@@ -96,6 +103,10 @@ export default function BrandSettingsPage({ params }: PageProps) {
         <TabsContent value="general" className="space-y-6">
           <GeneralTab brand={brand} onUpdate={(updated) => updateBrandStore(brand.id, updated)} />
           <ShoppingModeCard
+            brand={brand}
+            onUpdate={(updated) => updateBrandStore(brand.id, updated)}
+          />
+          <PauseBrandCard
             brand={brand}
             onUpdate={(updated) => updateBrandStore(brand.id, updated)}
           />
@@ -289,6 +300,84 @@ function ShoppingModeCard({
             )}
           </div>
           {saving && <Loader2 className="ml-auto h-4 w-4 animate-spin text-muted-foreground" />}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Pause / resume tracking (#286) ──────────────────────────────────────────
+
+function PauseBrandCard({
+  brand,
+  onUpdate,
+}: {
+  brand: Brand;
+  onUpdate: (updates: Partial<Brand>) => void;
+}) {
+  const { canAdmin } = useUserRole();
+  const paused = !brand.isActive;
+  const [saving, setSaving] = useState(false);
+
+  async function handleToggle(nextActive: boolean) {
+    if (!canAdmin) return;
+    setSaving(true);
+    try {
+      await setBrandActive(brand.id, nextActive);
+      onUpdate({ isActive: nextActive });
+      toast.success(nextActive ? 'Tracking resumed' : 'Tracking paused');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className={paused ? 'border-amber-500/40' : undefined}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {paused ? (
+            <Pause className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+          ) : (
+            <Play className="h-4 w-4" />
+          )}
+          Tracking
+          {paused && (
+            <Badge
+              variant="secondary"
+              className="gap-1 border-amber-500/30 bg-amber-500/15 text-[10px] text-amber-700 dark:text-amber-400"
+            >
+              Paused
+            </Badge>
+          )}
+        </CardTitle>
+        <CardDescription>
+          {paused
+            ? 'Tracking is paused — historical data is kept and stays viewable, but daily tracking is suspended and on-demand runs are blocked. No credits are spent until you resume.'
+            : 'Pause this brand to stop daily tracking and all on-demand runs. Historical data is preserved and stays viewable; resume any time to pick tracking back up on the next run.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-3">
+          <Button
+            variant={paused ? 'default' : 'outline'}
+            disabled={saving || !canAdmin}
+            onClick={() => handleToggle(paused)}
+            className="gap-2"
+          >
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : paused ? (
+              <Play className="h-4 w-4" />
+            ) : (
+              <Pause className="h-4 w-4" />
+            )}
+            {paused ? 'Resume tracking' : 'Pause tracking'}
+          </Button>
+          {!canAdmin && (
+            <p className="text-xs text-muted-foreground">Only admins can change this setting.</p>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -392,6 +392,7 @@ export default function OnboardingPage() {
               region: b.region ?? undefined,
               language: b.language ?? undefined,
               shoppingModeEnabled: !!b.shopping_mode_enabled,
+              isActive: (b as { is_active?: boolean }).is_active ?? true,
               domains: (b.brand_domains || []).map((d: Record<string, unknown>) => ({
                 id: d.id as string,
                 brandId: d.brand_id as string,

--- a/web/src/components/dashboard/brand-card.tsx
+++ b/web/src/components/dashboard/brand-card.tsx
@@ -17,7 +17,9 @@ export function BrandCard({ brand }: BrandCardProps) {
   const tNav = useTranslations('nav');
   const tCard = useTranslations('brands.card');
   const { activeBrandId, setActiveBrand } = useBrandStore();
-  const isActive = brand.id === activeBrandId;
+  // Whether this is the currently-selected brand — distinct from brand.isActive,
+  // which is the tracking (paused/active) state.
+  const isSelected = brand.id === activeBrandId;
 
   const initials = brand.name
     .split(' ')
@@ -35,7 +37,7 @@ export function BrandCard({ brand }: BrandCardProps) {
       className={cn(
         'overflow-hidden rounded-xl border bg-card transition-all',
         'hover:border-primary/40 hover:shadow-sm',
-        isActive && 'ring-1 ring-primary/40 border-primary/40',
+        isSelected && 'ring-1 ring-primary/40 border-primary/40',
       )}
     >
       <div className="flex items-start gap-3 px-4 py-3.5">
@@ -48,13 +50,21 @@ export function BrandCard({ brand }: BrandCardProps) {
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <h3 className="truncate text-sm font-semibold leading-tight">{brand.name}</h3>
-            {isActive && (
+            {isSelected && brand.isActive && (
               <Badge
                 variant="secondary"
                 className="gap-1 border-primary/30 bg-primary/15 text-[10px] text-primary"
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-primary" />
                 Active
+              </Badge>
+            )}
+            {!brand.isActive && (
+              <Badge
+                variant="secondary"
+                className="gap-1 border-amber-500/30 bg-amber-500/15 text-[10px] text-amber-700 dark:text-amber-400"
+              >
+                Paused
               </Badge>
             )}
           </div>

--- a/web/src/components/layout/brand-switcher.tsx
+++ b/web/src/components/layout/brand-switcher.tsx
@@ -110,7 +110,14 @@ export function BrandSwitcher({ collapsed = false }: BrandSwitcherProps) {
                 </AvatarFallback>
               </Avatar>
               <div className="flex-1 overflow-hidden">
-                <p className="truncate text-sm font-medium">{brand.name}</p>
+                <p className="flex items-center gap-1.5 truncate text-sm font-medium">
+                  <span className="truncate">{brand.name}</span>
+                  {!brand.isActive && (
+                    <span className="shrink-0 rounded bg-amber-500/15 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400">
+                      Paused
+                    </span>
+                  )}
+                </p>
                 {primaryDomain && (
                   <p className="truncate text-xs text-muted-foreground">{primaryDomain.domain}</p>
                 )}

--- a/web/src/lib/actions/brand.ts
+++ b/web/src/lib/actions/brand.ts
@@ -38,6 +38,7 @@ function mapBrandRow(brand: Record<string, unknown>, domains: Record<string, unk
     language: (brand.language as string | null) ?? undefined,
     trackingCode: (brand.tracking_code as string | null) ?? undefined,
     shoppingModeEnabled: !!brand.shopping_mode_enabled,
+    isActive: brand.is_active === undefined ? true : !!brand.is_active,
     domains: domains.map(mapDomainRow),
     createdAt: brand.created_at as string,
     updatedAt: brand.updated_at as string,
@@ -261,6 +262,37 @@ export async function setBrandShoppingMode(
 
   revalidatePath('/dashboard/brands');
   return { promptsUpdated };
+}
+
+/**
+ * Pause / resume a brand (#286).
+ *
+ * Sets `brands.is_active`. When `false`, the daily tracking cron skips the
+ * brand (`runDailyTracking` filters on `is_active = true`) and the on-demand
+ * tracking endpoints reject it — so a paused brand stops all Cloro / LLM spend
+ * while keeping its historical data fully viewable. Resuming flips it back and
+ * the next cron run picks tracking up again.
+ *
+ * RLS gates this — the calling user must already have write access to the
+ * brand via their org membership.
+ */
+export async function setBrandActive(brandId: string, isActive: boolean): Promise<void> {
+  const supabase = await createClient();
+
+  // Return the updated row so a no-op (invalid id, or RLS silently denying the
+  // write) surfaces as an error instead of a false success — `update().eq()`
+  // without `select()` does not error on a 0-row match.
+  const { data, error } = await supabase
+    .from('brands')
+    .update({ is_active: isActive })
+    .eq('id', brandId)
+    .select('id');
+  if (error) throw new Error(error.message);
+  if (!data || data.length === 0) {
+    throw new Error('Brand not found or you do not have permission to update it.');
+  }
+
+  revalidatePath('/dashboard/brands');
 }
 
 export interface BrandCardSummary {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -23,6 +23,7 @@ export interface Brand {
   language?: string;
   trackingCode?: string;
   shoppingModeEnabled: boolean;
+  isActive: boolean;
   domains: BrandDomain[];
   createdAt: string;
   updatedAt: string;

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -287,6 +287,7 @@ export type Database = {
           description: string | null;
           id: string;
           industry: string | null;
+          is_active: boolean;
           language: string | null;
           logo_url: string | null;
           name: string;
@@ -302,6 +303,7 @@ export type Database = {
           description?: string | null;
           id?: string;
           industry?: string | null;
+          is_active?: boolean;
           language?: string | null;
           logo_url?: string | null;
           name: string;
@@ -317,6 +319,7 @@ export type Database = {
           description?: string | null;
           id?: string;
           industry?: string | null;
+          is_active?: boolean;
           language?: string | null;
           logo_url?: string | null;
           name?: string;


### PR DESCRIPTION
## Summary

Adds an **active / inactive (paused)** state to a brand so it can be temporarily suspended without deleting it (which would destroy all history). Pausing suspends tracking and all related spend; resuming picks it back up on the next run.

- **Data** — migration `00020_brand_is_active.sql`: `brands.is_active boolean NOT NULL DEFAULT true`. Existing brands default to active, so behavior is unchanged on rollout.
- **Daily tracking** — `runDailyTracking` (`server/src/server.js`) filters the brands query to `.eq('is_active', true)`, so paused brands are skipped by the cron. The existing per-brand subscription / feature / prompt-count guards are untouched.
- **On-demand tracking** — `POST /api/tracking/check` and `/analyze-new` (`server/src/routes/tracking.js`) reject a paused brand with `409` after the ownership check, so "paused" means no spend at all (per the issue's suggested decision).
- **Server action** — `setBrandActive(brandId, isActive)` mirroring `setBrandShoppingMode`; `isActive` is surfaced on the `Brand` type and `getBrands` / `getBrandById` mappers.
- **UI** — a Pause / Resume "Tracking" card in brand settings (admin-only) with a clear "historical data is kept, daily tracking is suspended" state, plus a "Paused" badge in the brand switcher and brand cards.

A paused brand keeps all historical data and stays selectable/viewable. The hosted migration has already been applied (column verified: `boolean`, `NOT NULL`, default `true`).

> **Deploy ordering:** the migration must be applied before deploying the server code (the cron and on-demand queries reference `is_active`). The migration is already live on hosted.

Out of scope (per issue): exposing pause state via MCP, and seat/quota accounting changes.

## Related issue

Closes #286

## Type of change

- [x] `feat` — New feature

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
