### PR TITLE
Show readable region names in the insights filter

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -56,6 +56,7 @@ import {
 } from '@/lib/actions/tracking';
 import { getTopics } from '@/lib/actions/topic';
 import { PLATFORM_LABELS } from '@/config/platform-labels';
+import { formatRegionDisplay } from '@/lib/region';
 import type { Topic } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -593,14 +594,18 @@ function FilterBar({
           value={filters.region || null}
           onValueChange={(v) => set({ region: !v || v === '__all__' ? '' : v })}
         >
-          <SelectTrigger className="h-8 w-32 text-xs">
-            <SelectValue placeholder="All Regions" />
+          <SelectTrigger className="h-8 w-48 text-xs">
+            <SelectValue placeholder="All Regions">
+              {(value) =>
+                value && value !== '__all__' ? formatRegionDisplay(String(value)) : 'All Regions'
+              }
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="__all__">All Regions</SelectItem>
             {availableRegions.map((r) => (
               <SelectItem key={r} value={r}>
-                {r}
+                {formatRegionDisplay(r)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/web/src/lib/region.test.ts
+++ b/web/src/lib/region.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRegionDisplay, regionFlag, regionLabel } from './region';
+
+describe('region display helpers', () => {
+  it('shows a known region as flag plus country name', () => {
+    const usFlag = String.fromCodePoint(0x1f1fa, 0x1f1f8);
+
+    expect(regionLabel('US')).toBe('United States');
+    expect(regionFlag('US')).toBe(usFlag);
+    expect(formatRegionDisplay('US')).toBe(`${usFlag} United States`);
+  });
+
+  it('normalizes lower-case known region codes', () => {
+    const gbFlag = String.fromCodePoint(0x1f1ec, 0x1f1e7);
+
+    expect(formatRegionDisplay('gb')).toBe(`${gbFlag} United Kingdom`);
+  });
+
+  it('falls back to the raw code without a flag for unknown values', () => {
+    expect(regionLabel('ZZ')).toBe('ZZ');
+    expect(regionFlag('ZZ')).toBe('');
+    expect(formatRegionDisplay('ZZ')).toBe('ZZ');
+    expect(formatRegionDisplay('USA')).toBe('USA');
+  });
+});

--- a/web/src/lib/region.ts
+++ b/web/src/lib/region.ts
@@ -1,0 +1,33 @@
+import { REGIONS } from '@/config/prompt-options';
+
+const REGION_LABELS: ReadonlyMap<string, string> = new Map(
+  REGIONS.map((region) => [region.code, region.label]),
+);
+
+function normalizeRegionCode(code: string): string {
+  return code.trim().toUpperCase();
+}
+
+export function regionLabel(code: string): string {
+  const normalized = normalizeRegionCode(code);
+  return REGION_LABELS.get(normalized) ?? code.trim();
+}
+
+export function regionFlag(code: string): string {
+  const normalized = normalizeRegionCode(code);
+  if (!REGION_LABELS.has(normalized) || !/^[A-Z]{2}$/.test(normalized)) {
+    return '';
+  }
+
+  const [first, second] = normalized;
+  return String.fromCodePoint(
+    0x1f1e6 + first.charCodeAt(0) - 65,
+    0x1f1e6 + second.charCodeAt(0) - 65,
+  );
+}
+
+export function formatRegionDisplay(code: string): string {
+  const label = regionLabel(code);
+  const flag = regionFlag(code);
+  return flag ? `${flag} ${label}` : label;
+}


### PR DESCRIPTION
Closes #314.

This adds a small region display helper backed by the existing `REGIONS` config and uses it in the insights Region filter. Known ISO region codes now render as flag plus country name in both the selected value and menu items, while unknown or invalid values fall back to the raw code.

Validation:
- `node_modules/.bin/vitest.cmd run src/lib/region.test.ts` -> 3 passed
- `node_modules/.bin/tsc.cmd --noEmit`
- `node_modules/.bin/prettier.cmd --check src/**/*.{ts,tsx}`
- `git diff --check`