### PR TITLE
fix(billing): block non-admin members from payment/onboarding when subscription lapses

### DIFF
--- a/web/src/app/[locale]/(dashboard)/layout.tsx
+++ b/web/src/app/[locale]/(dashboard)/layout.tsx
@@ -10,6 +10,8 @@ import { BrandLoader } from '@/components/providers/brand-loader';
 import { BrandGuard } from '@/components/providers/brand-guard';
 import { getBrands } from '@/lib/actions/brand';
 import { isCloud, type PlanId } from '@/config/plans';
+import { evaluateSubscriptionAccess } from '@/lib/billing/subscription-access';
+import { SubscriptionExpiredNotice } from '@/components/billing/subscription-expired-notice';
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
@@ -42,11 +44,23 @@ export default async function DashboardLayout({ children }: { children: React.Re
     getBrands(profile.organization_id),
   ]);
 
-  // Cloud mode: require active or trialing subscription
+  // Cloud mode: gate access when the subscription isn't active/trialing.
+  // Admins (incl. the owner) are routed to the renew/payment flow; everyone
+  // else is blocked with a contact-your-owner notice — so an invited member
+  // can neither reach the payment screen nor walk back into onboarding to
+  // re-create the brand / competitors.
   if (isCloud()) {
-    const subStatus = org?.subscription_status as string | null;
-    if (subStatus !== 'active' && subStatus !== 'trialing') {
+    const access = await evaluateSubscriptionAccess(
+      supabase,
+      profile.organization_id,
+      role,
+      (org?.subscription_status as string | null) ?? null,
+    );
+    if (access.state === 'needs_payment') {
       redirect('/dashboard/onboarding');
+    }
+    if (access.state === 'blocked') {
+      return <SubscriptionExpiredNotice ownerName={access.ownerName} />;
     }
   }
 

--- a/web/src/app/[locale]/(onboarding)/layout.tsx
+++ b/web/src/app/[locale]/(onboarding)/layout.tsx
@@ -2,6 +2,10 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { AuthProvider } from '@/components/providers/auth-provider';
 import { OnboardingSignOutButton } from '@/components/auth/onboarding-sign-out-button';
+import { isCloud } from '@/config/plans';
+import { evaluateSubscriptionAccess } from '@/lib/billing/subscription-access';
+import { SubscriptionExpiredNotice } from '@/components/billing/subscription-expired-notice';
+import type { TeamRole } from '@/components/providers/role-provider';
 
 export default async function OnboardingLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
@@ -11,6 +15,35 @@ export default async function OnboardingLayout({ children }: { children: React.R
 
   if (!user) {
     redirect('/sign-in');
+  }
+
+  // An already-onboarded non-admin whose org subscription has lapsed must not
+  // re-enter the wizard (they'd otherwise see the payment step and could
+  // re-create the brand / competitors on the org's existing setup). Admins keep
+  // the renew flow; not-yet-onboarded users (new org creators) pass through.
+  if (isCloud()) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('organization_id, onboarding_completed, role')
+      .eq('id', user.id)
+      .single();
+
+    if (profile?.onboarding_completed && profile.organization_id) {
+      const { data: org } = await supabase
+        .from('organizations')
+        .select('subscription_status')
+        .eq('id', profile.organization_id)
+        .single();
+      const access = await evaluateSubscriptionAccess(
+        supabase,
+        profile.organization_id,
+        (profile.role ?? 'analyst') as TeamRole,
+        (org?.subscription_status as string | null) ?? null,
+      );
+      if (access.state === 'blocked') {
+        return <SubscriptionExpiredNotice ownerName={access.ownerName} />;
+      }
+    }
   }
 
   return (

--- a/web/src/components/billing/subscription-expired-notice.tsx
+++ b/web/src/components/billing/subscription-expired-notice.tsx
@@ -1,0 +1,31 @@
+import { AlertCircle } from 'lucide-react';
+import { OnboardingSignOutButton } from '@/components/auth/onboarding-sign-out-button';
+
+/**
+ * Shown to a non-admin member when their org's subscription has lapsed.
+ * They can't renew or re-onboard, so instead of the payment / onboarding flow
+ * they get a clear "contact your account owner" message (plus a way out).
+ */
+export function SubscriptionExpiredNotice({ ownerName }: { ownerName?: string | null }) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6">
+      <div className="w-full max-w-md rounded-xl border bg-card p-8 text-center shadow-sm">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-amber-500/10">
+          <AlertCircle className="h-6 w-6 text-amber-600 dark:text-amber-400" />
+        </div>
+        <h1 className="mt-4 text-lg font-semibold">Subscription required</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This account&rsquo;s subscription has ended, so tracking and dashboard access are paused.
+          {ownerName
+            ? ` Please contact your account owner (${ownerName}) to renew it.`
+            : ' Please contact your account owner or an admin to renew it.'}
+        </p>
+        <p className="mt-3 text-xs text-muted-foreground">
+          You don&rsquo;t have billing access on this account, so you can&rsquo;t renew it or make
+          changes until it&rsquo;s active again.
+        </p>
+      </div>
+      <OnboardingSignOutButton />
+    </div>
+  );
+}

--- a/web/src/lib/billing/subscription-access.test.ts
+++ b/web/src/lib/billing/subscription-access.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { evaluateSubscriptionAccess } from './subscription-access';
+
+// Minimal Supabase stub: the chained query builder resolves to `ownerRow` at
+// `.maybeSingle()`. Only the blocked (non-admin, inactive) path touches it.
+function fakeSupabase(ownerRow: { full_name: string | null } | null) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    limit: () => builder,
+    maybeSingle: async () => ({ data: ownerRow, error: null }),
+  };
+  const from = vi.fn(() => builder);
+  // Cast through unknown — the helper only uses .from(...).select()....maybeSingle().
+  return { client: { from } as unknown as Parameters<typeof evaluateSubscriptionAccess>[0], from };
+}
+
+describe('evaluateSubscriptionAccess', () => {
+  it('returns ok for active/trialing regardless of role (no owner lookup)', async () => {
+    const { client, from } = fakeSupabase(null);
+    expect(await evaluateSubscriptionAccess(client, 'org', 'analyst', 'active')).toEqual({
+      state: 'ok',
+    });
+    expect(await evaluateSubscriptionAccess(client, 'org', 'admin', 'trialing')).toEqual({
+      state: 'ok',
+    });
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('routes admins to the payment flow when the subscription is inactive', async () => {
+    const { client, from } = fakeSupabase(null);
+    expect(await evaluateSubscriptionAccess(client, 'org', 'admin', 'past_due')).toEqual({
+      state: 'needs_payment',
+    });
+    expect(await evaluateSubscriptionAccess(client, 'org', 'admin', null)).toEqual({
+      state: 'needs_payment',
+    });
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('blocks non-admins when inactive and surfaces the owner name', async () => {
+    const { client } = fakeSupabase({ full_name: 'Jane Owner' });
+    expect(await evaluateSubscriptionAccess(client, 'org', 'manager', 'canceled')).toEqual({
+      state: 'blocked',
+      ownerName: 'Jane Owner',
+    });
+  });
+
+  it('falls back to a null owner name when the lookup returns nothing', async () => {
+    const { client } = fakeSupabase(null);
+    expect(await evaluateSubscriptionAccess(client, 'org', 'analyst', null)).toEqual({
+      state: 'blocked',
+      ownerName: null,
+    });
+  });
+});

--- a/web/src/lib/billing/subscription-access.ts
+++ b/web/src/lib/billing/subscription-access.ts
@@ -1,0 +1,57 @@
+import type { TeamRole } from '@/components/providers/role-provider';
+
+// Type-only reference to the server client — no runtime import, so this helper
+// stays free of server-module coupling.
+type ServerSupabase = Awaited<ReturnType<typeof import('@/lib/supabase/server').createClient>>;
+
+export type SubscriptionAccess =
+  | { state: 'ok' }
+  | { state: 'needs_payment' }
+  | { state: 'blocked'; ownerName: string | null };
+
+const ACTIVE_STATUSES = new Set(['active', 'trialing']);
+
+/**
+ * Decide what an authenticated, onboarded org member may do when their org's
+ * subscription is not active.
+ *
+ *   - active / trialing      → 'ok'              (full access)
+ *   - inactive + admin       → 'needs_payment'   (admins, incl. the owner, can renew)
+ *   - inactive + non-admin   → 'blocked'         (manager / analyst / agency_partner
+ *                                                 can't pay or re-onboard — they get a
+ *                                                 "contact your account owner" notice)
+ *
+ * This is the fix for the trial-ended invited-member case: previously *every*
+ * member was redirected into the onboarding wizard when the subscription
+ * lapsed, so a non-owner saw the payment screen and could walk back to step 1
+ * and re-create the brand / competitors on an already-set-up org.
+ *
+ * "Owner" is the org's first admin; we surface their name in the blocked
+ * message so a member knows who to contact. The lookup uses the caller's RLS
+ * client, so if it can't read the owner's row the message simply falls back to
+ * a generic wording (never throws).
+ */
+export async function evaluateSubscriptionAccess(
+  supabase: ServerSupabase,
+  organizationId: string,
+  role: TeamRole,
+  subscriptionStatus: string | null,
+): Promise<SubscriptionAccess> {
+  if (subscriptionStatus && ACTIVE_STATUSES.has(subscriptionStatus)) {
+    return { state: 'ok' };
+  }
+  if (role === 'admin') {
+    return { state: 'needs_payment' };
+  }
+
+  const { data: owner } = await supabase
+    .from('profiles')
+    .select('full_name')
+    .eq('organization_id', organizationId)
+    .eq('role', 'admin')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  return { state: 'blocked', ownerName: (owner?.full_name as string | null) ?? null };
+}


### PR DESCRIPTION
## Summary

Fixes a real bug a customer hit: when an org's trial/subscription **ended**, a non-owner member who joined via an invite link was shown the **payment screen** and could walk **back to onboarding step 1 and re-create the brand / competitors** on the org's already-set-up account.

**Root cause** — the inactive-subscription state had no role awareness:

- `web/src/app/[locale]/(dashboard)/layout.tsx` redirected **every** member to `/dashboard/onboarding` when `subscription_status` wasn't `active`/`trialing`.
- The onboarding page then placed any onboarded user on the plan/payment step regardless of role, and the wizard's "already created" guard is React state (not a DB check), so a member walking back to step 1 could create a **duplicate brand** + re-add competitors.

**Fix** — gate the inactive-subscription state **by role** in both server layouts:

- **admin** (incl. the org owner) → renew/payment flow (unchanged).
- **non-admin** (manager / analyst / agency_partner) → a blocking **"Subscription required — contact your account owner"** notice. No payment, no re-onboarding, no access to the wizard.

Both the dashboard layout (normal navigation) and the onboarding layout (direct `/dashboard/onboarding` access) enforce it, so a non-admin can't reach the payment screen or the wizard by any path.

"Owner" = the org's **first admin**, surfaced in the message so the member knows who to contact. The lookup uses the caller's RLS client and falls back to a generic wording if it can't read the owner's row (never throws).

## New files

- `web/src/lib/billing/subscription-access.ts` — `evaluateSubscriptionAccess(...)` returns `ok` / `needs_payment` (admin) / `blocked` (non-admin, with owner name).
- `web/src/components/billing/subscription-expired-notice.tsx` — the contact-your-owner screen (with sign-out).

## Type of change

- [x] `fix` — Bug fix

## How to test

1. Cloud mode, org with `subscription_status` set to an inactive value (e.g. `canceled`/`past_due`).
2. As an **admin** of that org → land on the renew/payment flow (unchanged).
3. As a **non-admin** member (manager/analyst) of that org → see the "Subscription required — contact your account owner (<name>)" notice; cannot reach the payment screen, and visiting `/dashboard/onboarding` directly shows the same notice (no wizard, no brand/competitor re-creation).
4. Active/trialing org → all members get normal access. Self-hosted (`isCloud()` false) → no gating.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
