### PR TITLE
feat(billing): extend free trial from 7 to 14 days

### DIFF
--- a/docs/guides/add-your-first-brand.mdx
+++ b/docs/guides/add-your-first-brand.mdx
@@ -71,7 +71,7 @@ The onboarding wizard has **5 steps for self-hosted** instances and **6 steps fo
 
   </Step>
   <Step title="6. Plan & checkout (cloud only)">
-    On the cloud, the final step picks your subscription plan (Starter, Growth, or Enterprise) and runs Stripe Checkout. All paid plans include a **7-day free trial** — you enter card details but no charge happens until day 8. Self-hosted instances skip this step entirely.
+    On the cloud, the final step picks your subscription plan (Starter, Growth, or Enterprise) and runs Stripe Checkout. All paid plans include a **14-day free trial** — you enter card details but no charge happens until day 15. Self-hosted instances skip this step entirely.
   </Step>
 </Steps>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -12,7 +12,7 @@ The fastest way to start. No infrastructure, no env files.
 
 <Steps>
   <Step title="Sign up for the cloud">
-    Create an account at [app.ansvisor.com/sign-up](https://app.ansvisor.com/sign-up). All paid plans include a 7-day free trial.
+    Create an account at [app.ansvisor.com/sign-up](https://app.ansvisor.com/sign-up). All paid plans include a 14-day free trial.
   </Step>
   <Step title="Add your first brand">
     On the onboarding screen, enter your brand name, primary domain, and industry. Ansvisor auto-suggests starter prompts based on your industry — you can edit them or accept all.

--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -1472,7 +1472,7 @@ export default function OnboardingPage() {
         <div className="mb-8 text-center">
           <h1 className="text-2xl font-bold tracking-tight">Choose your plan</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Start with a 7-day free trial. Cancel anytime.
+            Start with a 14-day free trial. Cancel anytime.
           </p>
         </div>
 

--- a/web/src/app/api/stripe/checkout/route.ts
+++ b/web/src/app/api/stripe/checkout/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
       customer: customerId,
       line_items: [{ price: priceId, quantity: 1 }],
       subscription_data: {
-        trial_period_days: 7,
+        trial_period_days: 14,
         metadata: { organization_id: organizationId, plan_id: planId },
       },
       success_url: `${appUrl}/api/stripe/success?session_id={CHECKOUT_SESSION_ID}`,


### PR DESCRIPTION
## Summary

Extends the free trial from **7 to 14 days**.

The trial length is set entirely in the Stripe Checkout session (`subscription_data.trial_period_days`); there's no DB field and no migration. This change is **forward-only** — existing/active trials keep the window they were created with; only new checkouts get 14 days. The session-level `trial_period_days` overrides any Price-level default, so no Stripe dashboard change is required.

**Changes**
- `web/src/app/api/stripe/checkout/route.ts` — `trial_period_days: 7 → 14` (the only functional change).
- `web/.../dashboard/onboarding/page.tsx` — plan step copy: "Start with a 14-day free trial."
- `docs/quickstart.mdx` — "All paid plans include a 14-day free trial."
- `docs/guides/add-your-first-brand.mdx` — "14-day free trial — no charge until day 15."

(The remaining "last 7 days" / "7-day delta" strings are analytics windows, unrelated to the trial, and were left untouched.)

## Type of change

- [x] `feat` — New feature

## How to test

1. In Stripe **test mode**, run a checkout through the onboarding plan step.
2. The created subscription should show `status = trialing` with `trial_end` ≈ **now + 14 days** (no charge until then).
3. Onboarding copy and the docs read "14-day free trial".

## Notes

- **Before merge/deploy**, confirm the trial behaves as expected with a real test-mode checkout (Stripe is the source of truth for the actual trial window).
- Optional housekeeping: if a 7-day default trial is configured on the Stripe Price/Product, align it to 14 for dashboard consistency — it doesn't affect behavior (the session value wins).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
