### PR TITLE
Sort metric breakdown rows by current value

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_metric-breakdown-sheet.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_metric-breakdown-sheet.tsx
@@ -20,6 +20,7 @@ import {
   type BreakdownRow,
   type InsightsBreakdown,
 } from '@/lib/actions/tracking';
+import { sortBreakdownRowsForDisplay } from './breakdown-display';
 
 const METRIC_TITLE: Record<BreakdownMetric, string> = {
   mentions: 'Mentions',
@@ -259,7 +260,7 @@ function BreakdownTable({
           </tr>
         </thead>
         <tbody>
-          {rows.map((r) => (
+          {sortBreakdownRowsForDisplay(rows).map((r) => (
             <tr key={r.id} className="border-b last:border-b-0 hover:bg-muted/30">
               <td className="px-3 py-2.5 min-w-0">
                 {kind === 'prompts' ? (

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/breakdown-display.test.ts
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/breakdown-display.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { BreakdownRow } from '@/lib/actions/tracking';
+import { sortBreakdownRowsForDisplay } from './breakdown-display';
+
+function row(id: string, cur: number, delta = 0, label = id): BreakdownRow {
+  return {
+    id,
+    label,
+    prev: cur - delta,
+    cur,
+    delta,
+    deltaPct: null,
+    curRuns: cur,
+    prevRuns: cur - delta,
+  };
+}
+
+describe('sortBreakdownRowsForDisplay', () => {
+  it('sorts rows by current value descending without mutating the source order', () => {
+    const rows = [row('largest-drop', 3, -7), row('highest-current', 12, 1), row('middle', 8, -2)];
+
+    expect(sortBreakdownRowsForDisplay(rows).map((r) => r.id)).toEqual([
+      'highest-current',
+      'middle',
+      'largest-drop',
+    ]);
+    expect(rows.map((r) => r.id)).toEqual(['largest-drop', 'highest-current', 'middle']);
+  });
+
+  it('uses deterministic tie-breakers for equal current values', () => {
+    const rows = [row('b', 5, -1, 'Beta'), row('a', 5, 2, 'Alpha'), row('c', 5, 2, 'Gamma')];
+
+    expect(sortBreakdownRowsForDisplay(rows).map((r) => r.label)).toEqual([
+      'Alpha',
+      'Gamma',
+      'Beta',
+    ]);
+  });
+});

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/breakdown-display.ts
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/breakdown-display.ts
@@ -1,0 +1,13 @@
+import type { BreakdownRow } from '@/lib/actions/tracking';
+
+export function sortBreakdownRowsForDisplay(rows: BreakdownRow[]): BreakdownRow[] {
+  return [...rows].sort((a, b) => {
+    const currentDiff = b.cur - a.cur;
+    if (currentDiff !== 0) return currentDiff;
+
+    const deltaDiff = b.delta - a.delta;
+    if (deltaDiff !== 0) return deltaDiff;
+
+    return a.label.localeCompare(b.label);
+  });
+}


### PR DESCRIPTION
This fixes #316 by sorting the metric breakdown drawer rows by current value for display without changing the underlying breakdown order used by the top-driver summary.

What changed:
- Added a small display helper that returns a sorted copy of breakdown rows by `cur` descending, with deterministic tie-breakers.
- Updated the breakdown table to render that display order for prompts, platforms, and topics.
- Added focused coverage proving the helper sorts by current value and does not mutate the source row order.

Validation:
- `npm test -- breakdown-display.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `git diff --check`