### PR TITLE
ux(content): reorder KPI cards — Avg. Score before Sent to Workflow

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -416,13 +416,13 @@ export default function ContentPage() {
               value={highImpact}
               sub="opportunities"
             />
+            <KpiCard title={t('kpi.avgScore')} icon={BarChart3} value={avgScore} sub="out of 100" />
             <KpiCard
               title={t('kpi.sentToWorkflow')}
               icon={Send}
               value={sentCount}
               sub="sent or in progress"
             />
-            <KpiCard title={t('kpi.avgScore')} icon={BarChart3} value={avgScore} sub="out of 100" />
           </div>
 
           <Card>


### PR DESCRIPTION
## Summary

Reorders the last two KPI cards on the Content Optimization dashboard (`/dashboard/content`) so the row reads **Total → High Impact → Avg. Score → Sent to Workflow** (previously Avg. Score and Sent to Workflow were swapped). Card order only — no logic changes.

## Related issue

Closes #289

## Type of change

- [x] `feat` — New feature (UI tweak)

## How to test

1. Open `/dashboard/content` — the four KPI cards read left-to-right: Total, High Impact, Avg. Score, Sent to Workflow.
2. No other behavior changes.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
