### PR TITLE
chore(brands): remove unused imports in brand settings page

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -38,13 +38,11 @@ import {
   Globe,
   Loader2,
   Pause,
-  Pencil,
   Play,
   Plus,
   Save,
   ShoppingBag,
   Trash2,
-  X,
 } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useUserRole } from '@/hooks/use-user-role';
@@ -55,8 +53,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
-  DialogClose,
 } from '@/components/ui/dialog';
 import { getPublicApiBaseUrl } from '@/config/api';
 
@@ -738,7 +734,6 @@ function CompetitorsTab({ brandId }: { brandId: string }) {
 
 function TrackingTab({ brand }: { brand: Brand }) {
   const [copied, setCopied] = useState<'code' | 'snippet' | null>(null);
-  const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
   const apiUrl = getPublicApiBaseUrl();
   const snippet = apiUrl
     ? `<script src="${apiUrl}/t.js" data-t="${brand.trackingCode || ''}" defer></script>`


### PR DESCRIPTION
## Summary

Removes dead imports from the brand settings page (`web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx`):

- `Pencil`, `X` (from `lucide-react`)
- `DialogTrigger`, `DialogClose` (from `@/components/ui/dialog`)

These were flagged as `@typescript-eslint/no-unused-vars` warnings (not errors, so they slipped through CI).

While in the file, I also removed a **pre-existing** unused `isCloud` local in `TrackingTab` (`const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true'` — assigned but never used). The issue's goal is a quiet lint output for this file, and leaving it would have kept one `no-unused-vars` warning; it's the same class of dead code and zero-use, so removing it is safe. The file now lints clean.

No behavior change.

## Related issue

Closes #293

## Type of change

- [x] `chore` — Maintenance / dependencies

## How to test

1. `yarn lint` from `web/` → no `no-unused-vars` warnings for `settings/page.tsx`.
2. Open a brand's settings page — every tab (General, Domains, Tracking, Competitors, Danger) renders and behaves exactly as before.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
