### PR TITLE
feat(citations): show full prompt text on hover in the prompt filter dropdown

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -176,6 +176,8 @@ interface PromptOption {
 interface PromptComboboxItem {
   value: string;
   label: string;
+  /** Untruncated prompt text, shown as a native tooltip on hover (#298). */
+  fullText: string;
 }
 
 interface PlatformOption {
@@ -393,7 +395,10 @@ function FilterBar({
     () =>
       prompts.map((p) => ({
         value: p.id,
-        label: p.text.length > 80 ? `${p.text.slice(0, 80)}…` : p.text,
+        // Let the combobox's CSS `truncate` handle visual overflow; keep the
+        // full text for the hover tooltip instead of slicing it away (#298).
+        label: p.text,
+        fullText: p.text,
       })),
     [prompts],
   );
@@ -497,7 +502,7 @@ function FilterBar({
                 <ComboboxEmpty>No prompts match.</ComboboxEmpty>
                 <ComboboxCollection>
                   {(item: PromptComboboxItem) => (
-                    <ComboboxItem key={item.value} value={item}>
+                    <ComboboxItem key={item.value} value={item} title={item.fullText}>
                       {item.label}
                     </ComboboxItem>
                   )}


### PR DESCRIPTION
## Summary

On the Citations page, the **Prompt** filter dropdown truncated long prompts with no way to read the full text. The combobox items only kept a pre-sliced `label`, so the original prompt text was discarded before render.

**Change** (`web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx`):
- Keep the full prompt on each item as `fullText: p.text`.
- Drop the manual `slice(0, 80)` — `ComboboxItem` already truncates visually via the CSS `truncate` class, so the slice only threw the full text away.
- Pass `title={item.fullText}` to `ComboboxItem`, which spreads `{...props}` onto the underlying element → native browser tooltip on hover (also read by screen readers). No new dependency or tooltip component.

`web/src/components/ui/combobox.tsx` needed no change — `title` already reaches the DOM node via `{...props}`.

## Related issue

Closes #298

## Type of change

- [x] `feat` — New feature

## How to test

1. Open `/dashboard/citations` for a brand with a long prompt (>80 chars).
2. Open the **Prompt** filter dropdown — long options are still visually truncated with an ellipsis.
3. Hover a truncated option → the full prompt text appears as a native tooltip.
4. Short prompts behave exactly as before. No new runtime dependency.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
