### PR TITLE
perf(citations): make Domains/URLs tab switching instant (keepMounted + memo)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import dynamic from 'next/dynamic';
@@ -636,7 +636,7 @@ function KpiCard({
 
 // ─── Tables ───────────────────────────────────────────────────────────────────
 
-function DomainsTable({ rows }: { rows: CitationDomainRow[] }) {
+const DomainsTable = memo(function DomainsTable({ rows }: { rows: CitationDomainRow[] }) {
   if (rows.length === 0) return <EmptyRows />;
 
   return (
@@ -688,9 +688,9 @@ function DomainsTable({ rows }: { rows: CitationDomainRow[] }) {
       </TableBody>
     </Table>
   );
-}
+});
 
-function UrlsTable({ rows }: { rows: CitationUrlRow[] }) {
+const UrlsTable = memo(function UrlsTable({ rows }: { rows: CitationUrlRow[] }) {
   if (rows.length === 0) return <EmptyRows />;
 
   return (
@@ -740,7 +740,7 @@ function UrlsTable({ rows }: { rows: CitationUrlRow[] }) {
       </TableBody>
     </Table>
   );
-}
+});
 
 function EmptyRows() {
   return (
@@ -949,10 +949,12 @@ export default function CitationsPage() {
                       {t('tabUrls')} ({data?.totals.urls ?? 0})
                     </TabsTrigger>
                   </TabsList>
-                  <TabsContent value="domains" className="mt-4">
+                  {/* keepMounted: data is already in memory, so mount both panels
+                      once and make switching a pure CSS visibility toggle (#299). */}
+                  <TabsContent value="domains" keepMounted className="mt-4">
                     <DomainsTable rows={data?.rows ?? []} />
                   </TabsContent>
-                  <TabsContent value="urls" className="mt-4">
+                  <TabsContent value="urls" keepMounted className="mt-4">
                     <UrlsTable rows={data?.urlRows ?? []} />
                   </TabsContent>
                 </Tabs>


### PR DESCRIPTION
## Summary

Switching the **Domains ↔ URLs** tabs on the Citations page felt sluggish for brands with many cited domains/URLs. It's **not** a data fetch — both tables come from the same in-memory `getCitationsOverview()` result. The cost was unmount/re-mount: Base-UI's `Tabs.Panel` unmounts the inactive panel by default, so each switch destroyed one (uncapped) table and rebuilt the other from scratch.

**Fix** (`web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx`):
1. **`keepMounted`** on the Domains/URLs `TabsContent` → both panels mount once and switching is a pure CSS visibility toggle (instant). Since the data is already fetched, this is a one-time render cost, not per-switch.
2. **`React.memo`** around `DomainsTable` / `UrlsTable` → an unrelated parent re-render (e.g. filter state) doesn't re-render the whole table while its `rows` reference is unchanged.

No skeleton — the data is already loaded and the switch does no async work, so a skeleton would only flash an empty placeholder and make it feel worse.

`web/src/components/ui/tabs.tsx` needed no change: `keepMounted` already reaches `Tabs.Panel` via `{...props}` (confirmed by typecheck accepting it on `TabsContent`).

## Related issue

Closes #299

## Type of change

- [x] `feat` — New feature (performance)

## How to test

1. Open `/dashboard/citations` for a brand with many cited URLs.
2. Switch Domains ↔ URLs repeatedly → instant, no visible render delay.
3. DevTools/Network: no server action fires on tab switch (it already didn't).
4. Changing filters still re-fetches and re-renders both tables correctly (no regression).

## Notes

- Optional future follow-up (out of scope): row virtualization for tabs that reach hundreds/thousands of rows.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
