### PR TITLE
chore(citations): trim Competitor Gaps query + decouple its refetch from domain-list flags

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -1068,7 +1068,10 @@ export default function CitationsPage() {
   const [gaps, setGaps] = useState<CitationGaps | null>(null);
   const [gapsLoading, setGapsLoading] = useState(false);
 
-  const apiFilters = useMemo<CitationsFilters>(() => {
+  // Shared scoping filters (date / platform / region / topic / prompt). The
+  // domain-list flags below don't apply to Competitor Gaps, so keeping them out
+  // of this memo means toggling them doesn't refetch the Gaps tab.
+  const gapFilters = useMemo<CitationsFilters>(() => {
     const { dateFrom, dateTo } = getDateRange(filters.datePreset, {
       from: filters.dateFrom,
       to: filters.dateTo,
@@ -1081,9 +1084,6 @@ export default function CitationsPage() {
       regions: filters.region ? [filters.region] : undefined,
       topicIds: filters.topic ? [filters.topic] : undefined,
       promptIds: filters.prompt ? [filters.prompt] : undefined,
-      excludeOwnDomain: filters.excludeOwnDomain,
-      competitorOnly: filters.competitorOnly,
-      ownOnly: filters.ownOnly,
     };
   }, [
     filters.datePreset,
@@ -1093,10 +1093,17 @@ export default function CitationsPage() {
     filters.region,
     filters.topic,
     filters.prompt,
-    filters.excludeOwnDomain,
-    filters.competitorOnly,
-    filters.ownOnly,
   ]);
+
+  const apiFilters = useMemo<CitationsFilters>(
+    () => ({
+      ...gapFilters,
+      excludeOwnDomain: filters.excludeOwnDomain,
+      competitorOnly: filters.competitorOnly,
+      ownOnly: filters.ownOnly,
+    }),
+    [gapFilters, filters.excludeOwnDomain, filters.competitorOnly, filters.ownOnly],
+  );
 
   useEffect(() => {
     if (!activeBrandId) return;
@@ -1145,12 +1152,13 @@ export default function CitationsPage() {
   }, [loadData]);
 
   // Lazy-load Competitor Gaps only when its tab is active; re-fetch when the
-  // shared filters change while it's open.
+  // shared scoping filters change while it's open. Uses `gapFilters` (not
+  // `apiFilters`) so the domain-list flags don't trigger a no-op refetch.
   useEffect(() => {
     if (sourceTab !== 'gaps' || !activeBrandId) return;
     let cancelled = false;
     setGapsLoading(true);
-    getCitationGaps(activeBrandId, apiFilters)
+    getCitationGaps(activeBrandId, gapFilters)
       .then((res) => {
         if (!cancelled) setGaps(res);
       })
@@ -1163,7 +1171,7 @@ export default function CitationsPage() {
     return () => {
       cancelled = true;
     };
-  }, [sourceTab, activeBrandId, apiFilters]);
+  }, [sourceTab, activeBrandId, gapFilters]);
 
   const totals = data?.totals;
   const kpis = useMemo(

--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -458,7 +458,7 @@ export async function getCitationGaps(
 
   let query = supabase
     .from('prompt_results')
-    .select('id, model_used, region, created_at, citations, competitor_mentions, mention_count')
+    .select('id, citations, competitor_mentions, mention_count')
     .eq('brand_id', brandId);
 
   const { from, to } = resolveDateRange(filters);


### PR DESCRIPTION
## Summary

Follow-up to #326 addressing the two Copilot review comments (the PR was already merged, so this is a separate small PR):

1. **Trim the gaps query select.** `getCitationGaps` selected `model_used`, `region`, `created_at` but never reads them from the returned rows — they're only used in the `WHERE` clause (date/region/model filters), which is independent of the `select`. Narrowed to `id, citations, competitor_mentions, mention_count` to keep the lazy-loaded tab lean.
2. **Decouple the Gaps refetch from domain-list flags.** The Gaps tab fetch was keyed off `apiFilters`, which includes the *Exclude own domain / Competitors only / Own domain only* flags. Those are domain-list filters that `getCitationGaps` doesn't apply, so toggling them while on the Gaps tab triggered a no-op refetch. Split out a `gapFilters` memo (date / platform / region / topic / prompt only) and `apiFilters` now builds on top of it; the gaps effect keys off `gapFilters`.

No behavior change to results — purely less wasted payload/refetch.

## Type of change

- [x] `chore` — Maintenance

## How to test

1. Citations → **Competitor Gaps** works exactly as before (same gap list / by-competitor results).
2. On the Gaps tab, toggling *Exclude own domain / Competitors only / Own domain only* no longer refetches gaps; changing date / platform / region / topic / prompt does.
3. The Domains / URLs tabs still apply those flags as before.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
