### PR TITLE
chore(server): structured logging Phase 2 — lib/config module-level logger (part 1)

### DIFF
--- a/server/src/config/supabase.js
+++ b/server/src/config/supabase.js
@@ -1,12 +1,13 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+import { logger } from '../lib/logger.js';
 
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseServiceRoleKey) {
-  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables');
+  logger.fatal('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables');
   process.exit(1);
 }
 

--- a/server/src/lib/audit/llm-signals.js
+++ b/server/src/lib/audit/llm-signals.js
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import { resolveModel } from '../ai-provider.js';
 import { signalsByKey } from './rubric.js';
 import { withRetry } from './retry.js';
+import { logger } from '../logger.js';
 
 const DEFAULT_MODEL = 'google/gemini-3-flash-preview';
 
@@ -111,7 +112,7 @@ export async function evaluateLlmSignals(ctx) {
       };
     });
   } catch (err) {
-    console.error('[audit] LLM signals failed:', err.message, { model: modelString });
+    logger.error({ err, model: modelString }, '[audit] LLM signals failed');
     // Degrade gracefully — deterministic signals still score the page.
     return LLM_SIGNAL_KEYS.map((key) => ({
       key,

--- a/server/src/lib/audit/recommendations.js
+++ b/server/src/lib/audit/recommendations.js
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import { resolveModel } from '../ai-provider.js';
 import { signalsByKey } from './rubric.js';
 import { withRetry } from './retry.js';
+import { logger } from '../logger.js';
 
 const DEFAULT_MODEL = 'google/gemini-3-flash-preview';
 
@@ -149,7 +150,7 @@ Return prioritized, page-specific recommendations.`,
         draft: r.draft || null,
       }));
   } catch (err) {
-    console.error('[audit] recommendations failed:', err.message, { model: modelString });
+    logger.error({ err, model: modelString }, '[audit] recommendations failed');
     return [];
   }
 }

--- a/server/src/lib/audit/retry.js
+++ b/server/src/lib/audit/retry.js
@@ -11,6 +11,8 @@
  * @param {{ attempts?: number, baseDelayMs?: number, label?: string }} [opts]
  * @returns {Promise<T>}
  */
+import { logger } from '../logger.js';
+
 export async function withRetry(fn, { attempts = 3, baseDelayMs = 500, label = 'llm' } = {}) {
   let lastErr;
   for (let i = 0; i < attempts; i += 1) {
@@ -20,8 +22,9 @@ export async function withRetry(fn, { attempts = 3, baseDelayMs = 500, label = '
       lastErr = err;
       if (i < attempts - 1) {
         const delay = baseDelayMs * 2 ** i;
-        console.warn(
-          `[audit] ${label} attempt ${i + 1}/${attempts} failed: ${err.message}; retrying in ${delay}ms`,
+        logger.warn(
+          { label, attempt: i + 1, attempts, delayMs: delay, err: err.message },
+          `[audit] ${label} attempt ${i + 1}/${attempts} failed; retrying`,
         );
         await new Promise((resolve) => setTimeout(resolve, delay));
       }

--- a/server/src/lib/cloro-result-handler.js
+++ b/server/src/lib/cloro-result-handler.js
@@ -17,6 +17,7 @@ import supabaseAdmin from '../config/supabase.js';
 import { analyzeSentimentAI } from './ai-tracker.js';
 import { parseResponse, countBrandMentions } from './response-parser.js';
 import { normalizeShoppingCards, matchCardBrand } from './shopping-cards.js';
+import { logger } from './logger.js';
 
 /**
  * @param {object} args
@@ -69,7 +70,7 @@ export async function handleScraperResult({
     .single();
 
   if (error) {
-    console.error('[cloro-result] Failed to insert result:', error.message);
+    logger.error({ err: error }, '[cloro-result] failed to insert result');
     throw error;
   }
 
@@ -150,11 +151,10 @@ export async function persistShoppingCards({
     .upsert(rows, { onConflict: 'prompt_result_id,position', ignoreDuplicates: true });
 
   if (error) {
-    console.error('[cloro-result] Shopping card normalization failed:', error.message, {
-      promptResultId,
-      platform,
-      cardCount: rows.length,
-    });
+    logger.error(
+      { err: error, promptResultId, platform, cardCount: rows.length },
+      '[cloro-result] shopping card normalization failed',
+    );
     return 0;
   }
 

--- a/server/src/lib/openai-tracker.js
+++ b/server/src/lib/openai-tracker.js
@@ -4,6 +4,7 @@
  */
 
 import OpenAI from 'openai';
+import { logger } from './logger.js';
 
 const DEFAULT_MODEL = 'gpt-5-chat-latest';
 
@@ -104,7 +105,7 @@ export async function analyzeSentimentAI(responseText, brandName) {
 
     return { sentiment, confidence, reason: json.reason || '' };
   } catch (err) {
-    console.error('[sentiment-ai] Failed, falling back to neutral:', err.message);
+    logger.error({ err }, '[sentiment-ai] failed, falling back to neutral');
     return { sentiment: 'neutral', confidence: 0, reason: 'Analysis failed' };
   }
 }

--- a/server/src/lib/opportunity-generator.js
+++ b/server/src/lib/opportunity-generator.js
@@ -7,6 +7,7 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 import { resolveModel } from './ai-provider.js';
 import supabaseAdmin from '../config/supabase.js';
+import { logger } from './logger.js';
 
 const opportunitySchema = z.object({
   opportunities: z
@@ -50,7 +51,7 @@ function computeScore(volume, visibility, competitorGap, intent) {
 }
 
 export async function generateContentOpportunities(brandId) {
-  console.log(`[opportunities] Generating for brand ${brandId}`);
+  logger.info({ brandId }, '[opportunities] generating');
 
   const { data: brand } = await supabaseAdmin
     .from('brands')
@@ -205,7 +206,8 @@ Generate actionable content opportunities.`;
     }));
 
   if (rows.length > 0) await supabaseAdmin.from('content_opportunities').insert(rows);
-  console.log(
-    `[opportunities] Generated ${rows.length} new opportunities for brand ${brandId} (${(existing || []).length} already pending)`,
+  logger.info(
+    { brandId, generated: rows.length, alreadyPending: (existing || []).length },
+    '[opportunities] generated new opportunities',
   );
 }

--- a/server/src/lib/shopping-cards.js
+++ b/server/src/lib/shopping-cards.js
@@ -22,6 +22,7 @@
  */
 
 import { URL } from 'node:url';
+import { logger } from './logger.js';
 
 // Loose set of currency codes Perplexity / Copilot embed in price strings
 // like "$29.99", "EUR 19,90", "₺499". Anything else falls back to null —
@@ -332,7 +333,7 @@ export function normalizeShoppingCards(platform, cards) {
         return parser(card, i);
       } catch (err) {
         // A bad card shouldn't kill the whole batch — log and drop.
-        console.error('[shopping-cards] parser failed:', err.message, { platform, position: i });
+        logger.error({ err, platform, position: i }, '[shopping-cards] parser failed');
         return null;
       }
     })


### PR DESCRIPTION
## Summary

First incremental slice of #303 (structured logging Phase 2). Migrates the `console.*` calls in the single-owner `lib/` and `config` files to the module-level pino `logger` from `lib/logger.js`, using structured fields instead of interpolated strings.

None of these run inside request handlers, so they all use the module `logger` (the `req.log` request-scoped lines belong to the routes / middleware slices, which will follow as separate PRs per the issue's "do it incrementally" guidance).

**Files migrated (~10 calls):**
- `lib/audit/retry.js` — retry warning → `logger.warn({ label, attempt, attempts, delayMs, err }, …)`
- `lib/audit/recommendations.js`, `lib/audit/llm-signals.js` — failure → `logger.error({ err, model }, …)`
- `lib/opportunity-generator.js` — 2× `console.log` → `logger.info({ brandId, … }, …)`
- `lib/cloro-result-handler.js` — 2× `console.error` → `logger.error({ err, … }, …)`
- `lib/shopping-cards.js`, `lib/openai-tracker.js` — `console.error` → `logger.error({ err, … }, …)`
- `config/supabase.js` — missing-env startup fatal → `logger.fatal(…)` before `process.exit(1)`

Level mapping follows the issue: `console.error` → `error`, `console.warn` → `warn`, `console.log` → `info`. Behaviour is unchanged — lines are now leveled + JSON-formatted.

## Related issue

Part of #303 (Phase 2 of #245). This is **part 1**; routes (`req.log`), workers, and `server.js` / `middleware` remain for follow-up PRs.

## Type of change

- [x] `chore` — Maintenance

## How to test

1. `yarn lint` / `yarn test` from `server/` pass (93 tests).
2. `grep -Rn "console\." server/src/lib/audit server/src/lib/opportunity-generator.js server/src/lib/cloro-result-handler.js server/src/lib/shopping-cards.js server/src/lib/openai-tracker.js server/src/config/supabase.js` returns nothing.
3. Triggering any of these paths (e.g. an audit LLM retry) now emits a structured JSON log line at the right level instead of a `console.*` string.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Changes are focused — one concern per PR
