### PR TITLE
chore(server): structured logging Phase 2 — lib job manager/runner

### DIFF
--- a/server/src/lib/job-manager.js
+++ b/server/src/lib/job-manager.js
@@ -5,6 +5,7 @@
  */
 
 import supabaseAdmin from '../config/supabase.js';
+import logger from './logger.js';
 
 /** @type {Map<string, AbortController>} */
 const activeJobs = new Map();
@@ -38,7 +39,7 @@ export async function updateJobProgress(jobId, progress) {
     .update({ progress, updated_at: new Date().toISOString() })
     .eq('id', jobId);
 
-  if (error) console.error(`[job-manager] Failed to update progress for ${jobId}:`, error.message);
+  if (error) logger.error({ err: error, jobId }, 'failed to update job progress');
 }
 
 /**
@@ -56,7 +57,7 @@ export async function completeJob(jobId, result) {
     })
     .eq('id', jobId);
 
-  if (error) console.error(`[job-manager] Failed to complete job ${jobId}:`, error.message);
+  if (error) logger.error({ err: error, jobId }, 'failed to complete job');
 }
 
 /**
@@ -72,7 +73,7 @@ export async function failJob(jobId, reason) {
     })
     .eq('id', jobId);
 
-  if (error) console.error(`[job-manager] Failed to fail job ${jobId}:`, error.message);
+  if (error) logger.error({ err: error, jobId }, 'failed to fail job');
 }
 
 /**
@@ -98,7 +99,7 @@ export async function markJobActive(jobId) {
     })
     .eq('id', jobId);
 
-  if (error) console.error(`[job-manager] Failed to mark job active ${jobId}:`, error.message);
+  if (error) logger.error({ err: error, jobId }, 'failed to mark job active');
 }
 
 /**
@@ -127,7 +128,7 @@ export async function cancelJob(jobId) {
     })
     .eq('id', jobId);
 
-  if (error) console.error(`[job-manager] Failed to cancel job ${jobId}:`, error.message);
+  if (error) logger.error({ err: error, jobId }, 'failed to cancel job');
 
   const controller = activeJobs.get(jobId);
   if (controller) controller.abort();
@@ -164,9 +165,9 @@ export async function cleanupStaleJobs() {
     .select('id');
 
   if (error) {
-    console.error('[job-manager] Failed to cleanup stale jobs:', error.message);
+    logger.error({ err: error }, 'failed to cleanup stale jobs');
   } else if (data && data.length > 0) {
-    console.log(`[job-manager] Cleaned up ${data.length} stale active jobs`);
+    logger.info({ count: data.length }, 'cleaned up stale active jobs');
   }
 }
 
@@ -178,7 +179,7 @@ export async function cleanupOldJobs() {
   const { error } = await supabaseAdmin.from('jobs').delete().lt('created_at', cutoff);
 
   if (error) {
-    console.error('[job-manager] Failed to cleanup old jobs:', error.message);
+    logger.error({ err: error }, 'failed to cleanup old jobs');
   }
 }
 
@@ -197,8 +198,8 @@ export async function cleanupStalePendingTasks() {
     .lt('submitted_at', cutoff);
 
   if (error) {
-    console.error('[job-manager] Failed to cleanup stale pending tasks:', error.message);
+    logger.error({ err: error }, 'failed to cleanup stale pending tasks');
   } else if (count && count > 0) {
-    console.log(`[job-manager] Cleaned up ${count} orphaned Cloro pending tasks`);
+    logger.info({ count }, 'cleaned up orphaned cloro pending tasks');
   }
 }

--- a/server/src/lib/job-runner.js
+++ b/server/src/lib/job-runner.js
@@ -15,6 +15,7 @@ import {
 } from './job-manager.js';
 import { processTrackingJob } from '../workers/tracking-worker.js';
 import { processContentJob } from '../workers/content-worker.js';
+import logger from './logger.js';
 
 // Concurrency counters (matches previous Bull concurrency of 2 per queue)
 let activeTrackingCount = 0;
@@ -69,18 +70,19 @@ export async function runTrackingJob(jobId, io) {
     }
   } catch (err) {
     if (abortController.signal.aborted) {
-      console.log(`[job-runner] Tracking job ${jobId} was cancelled`);
+      logger.info({ jobId }, 'tracking job was cancelled');
       return;
     }
 
-    console.error(`[job-runner] Tracking job ${jobId} failed:`, err.message);
+    logger.error({ err, jobId }, 'tracking job failed');
 
     // Re-fetch to get latest attempts count
     const latest = await getJob(jobId);
     if (latest && latest.attempts < latest.max_attempts) {
       const delay = latest.attempts * 30_000; // exponential-ish backoff
-      console.log(
-        `[job-runner] Retrying tracking job ${jobId} in ${delay / 1000}s (attempt ${latest.attempts}/${latest.max_attempts})`,
+      logger.info(
+        { jobId, delayMs: delay, attempt: latest.attempts, attempts: latest.max_attempts },
+        'retrying tracking job',
       );
 
       await failJob(jobId, err.message);
@@ -135,17 +137,18 @@ export async function runContentJob(jobId, io) {
     }
   } catch (err) {
     if (abortController.signal.aborted) {
-      console.log(`[job-runner] Content job ${jobId} was cancelled`);
+      logger.info({ jobId }, 'content job was cancelled');
       return;
     }
 
-    console.error(`[job-runner] Content job ${jobId} failed:`, err.message);
+    logger.error({ err, jobId }, 'content job failed');
 
     const latest = await getJob(jobId);
     if (latest && latest.attempts < latest.max_attempts) {
       const delay = latest.attempts * 15_000;
-      console.log(
-        `[job-runner] Retrying content job ${jobId} in ${delay / 1000}s (attempt ${latest.attempts}/${latest.max_attempts})`,
+      logger.info(
+        { jobId, delayMs: delay, attempt: latest.attempts, attempts: latest.max_attempts },
+        'retrying content job',
       );
 
       await failJob(jobId, err.message);


### PR DESCRIPTION
## Summary

Fourth incremental slice of #303 (structured logging Phase 2). Migrates the `console.*` calls in `lib/job-manager.js` and `lib/job-runner.js` to the module-level pino `logger`. Both run outside the request lifecycle, so they use the module `logger` (not `req.log`) with structured fields instead of interpolated strings.

**Files migrated (~16 calls):**
- `job-manager.js` (10): DB update failures → `logger.error({ err, jobId }, …)`; cleanup summaries → `logger.info({ count }, …)`
- `job-runner.js` (6): job failures → `logger.error({ err, jobId }, …)`; cancellations + retry-scheduling → `logger.info({ jobId, delayMs, attempt, attempts }, …)`

Level mapping per the issue (`console.error` → `error`, `console.log` → `info`). Behaviour unchanged.

## Related issue

Part of #303 (Phase 2 of #245), following #330, the routes slice, and the workers slice. `lib/cloro-scraper.js` is **intentionally left out** of this slice to avoid churn/conflicts with the query fan-out work (#332). `server.js` + `middleware/index.js` follow as the final slice.

## Type of change

- [x] `chore` — Maintenance

## How to test

1. From `server/`: `npm run lint`, `npm run format:check`, `npm run test` (93 tests) all pass.
2. `grep -n "console\." server/src/lib/job-manager.js server/src/lib/job-runner.js` returns nothing.
3. A failing/cancelled/retried job now emits a structured JSON log line (`error` for failures, `info` for cancellation + retry scheduling with `delayMs`/`attempt`) instead of a `console.*` string.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes (from `server/`)
- [x] `npm run format:check` passes (from `server/`)
- [x] Changes are focused — one concern per PR