### PR TITLE
chore(server): structured logging Phase 2 — server.js + middleware

### DIFF
--- a/server/src/middleware/index.js
+++ b/server/src/middleware/index.js
@@ -1,4 +1,5 @@
 import supabaseAdmin from '../config/supabase.js';
+import logger from '../lib/logger.js';
 
 class Middleware {
   async decodeTokenForSocket(socket, next) {
@@ -15,14 +16,14 @@ class Middleware {
       } = await supabaseAdmin.auth.getUser(token);
 
       if (error || !user) {
-        console.log('Unauthorized Socket Request');
+        logger.warn('unauthorized socket request');
         return next(new Error('Unauthorized'));
       }
 
       socket.user = user;
       return next();
     } catch (e) {
-      console.log('Internal Error (Socket Middleware):', e.message);
+      logger.error({ err: e }, 'socket middleware internal error');
       return next(new Error('Internal Error'));
     }
   }
@@ -81,7 +82,7 @@ class Middleware {
 
       return res.status(403).json({ message: 'Forbidden' });
     } catch (error) {
-      console.log('Domain check error:', error.message);
+      logger.error({ err: error }, 'domain check error');
       return res.status(500).json({ message: 'Internal Error' });
     }
   }
@@ -116,7 +117,7 @@ class Middleware {
 
       return next(new Error('Forbidden Socket'));
     } catch (error) {
-      console.log('Socket domain check error:', error.message);
+      logger.error({ err: error }, 'socket domain check error');
       return next(new Error('Internal Error Socket'));
     }
   }

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -167,7 +167,7 @@ async function runDailyTracking() {
     triggered++;
   }
 
-  console.log(`[cron] Daily tracking: triggered=${triggered} total_brands=${brands.length}`);
+  logger.info({ triggered, total: brands.length }, 'daily tracking triggered');
   return { triggered, total: brands.length };
 }
 
@@ -182,7 +182,7 @@ app.post('/api/internal/daily-tracking', async (req, res) => {
     const result = await runDailyTracking();
     return res.json({ success: true, ...result });
   } catch (err) {
-    console.error('[cron] Daily tracking error:', err.message);
+    req.log.error({ err }, 'daily tracking error');
     return res.status(500).json({ success: false, message: err.message });
   }
 });
@@ -224,7 +224,7 @@ app.post('/api/internal/content/:id/brief', async (req, res) => {
         .status(err.statusCode)
         .json({ success: false, error: 'quota_exceeded', message: err.message });
     }
-    console.error('[internal] content brief error:', err.message);
+    req.log.error({ err }, 'internal content brief error');
     return res.status(500).json({ success: false, message: err.message });
   }
 });
@@ -259,7 +259,7 @@ app.post('/api/internal/site-audits', async (req, res) => {
         .status(err.statusCode)
         .json({ success: false, error: 'quota_exceeded', message: err.message });
     }
-    console.error('[internal] site audit error:', err.message);
+    req.log.error({ err }, 'internal site audit error');
     return res.status(500).json({ success: false, message: err.message });
   }
 });
@@ -291,7 +291,7 @@ app.get('/api/internal/site-audit-quota', async (req, res) => {
         .status(err.statusCode)
         .json({ success: false, error: 'quota_exceeded', message: err.message });
     }
-    console.error('[internal] site audit quota error:', err.message);
+    req.log.error({ err }, 'internal site audit quota error');
     return res.status(500).json({ success: false, message: err.message });
   }
 });
@@ -319,7 +319,7 @@ app.post('/api/internal/trigger-tracking', async (req, res) => {
 
     return res.json({ success: true, jobId: job.id });
   } catch (err) {
-    console.error('[internal] trigger-tracking error:', err.message);
+    req.log.error({ err }, 'internal trigger-tracking error');
     return res.status(500).json({ success: false, message: err.message });
   }
 });
@@ -339,8 +339,13 @@ app.post('/cloro/callback', async (req, res) => {
       secret: webhookSecret,
     });
     if (!verdict.ok) {
-      console.warn(
-        `[cloro/callback] Rejected delivery: ${verdict.reason} | webhook_id: ${req.headers['x-cloro-webhook-id'] || 'n/a'} | ip: ${req.ip}`,
+      req.log.warn(
+        {
+          reason: verdict.reason,
+          webhookId: req.headers['x-cloro-webhook-id'] || null,
+          ip: req.ip,
+        },
+        'cloro callback rejected delivery',
       );
       return res.status(verdict.status).json({ error: verdict.reason });
     }
@@ -351,7 +356,7 @@ app.post('/cloro/callback', async (req, res) => {
   try {
     payload = Buffer.isBuffer(req.body) ? JSON.parse(req.body.toString('utf8') || '{}') : req.body;
   } catch {
-    console.warn(`[cloro/callback] Rejected delivery: malformed JSON body | ip: ${req.ip}`);
+    req.log.warn({ ip: req.ip }, 'cloro callback rejected: malformed JSON body');
     return res.status(400).json({ error: 'malformed JSON body' });
   }
 
@@ -364,7 +369,7 @@ app.post('/cloro/callback', async (req, res) => {
     const status = task?.status;
 
     if (!taskId) {
-      console.warn('[cloro/callback] Missing task.id in payload');
+      req.log.warn('cloro callback missing task.id in payload');
       return;
     }
 
@@ -375,23 +380,23 @@ app.post('/cloro/callback', async (req, res) => {
       .maybeSingle();
 
     if (!pending) {
-      console.log(`[cloro/callback] No pending task for ${taskId} (already processed?)`);
+      req.log.info({ taskId }, 'cloro callback: no pending task (already processed?)');
       return;
     }
 
     if (status === 'FAILED') {
-      console.error(`[cloro/callback] Task ${taskId} (${pending.scraper_id}) FAILED`);
+      req.log.error({ taskId, scraperId: pending.scraper_id }, 'cloro callback: task failed');
       await supabaseAdmin.from('cloro_pending_tasks').delete().eq('task_id', taskId);
       return;
     }
 
     if (status !== 'COMPLETED') {
-      console.log(`[cloro/callback] Task ${taskId} status=${status}, ignoring`);
+      req.log.info({ taskId, status }, 'cloro callback: task status ignored');
       return;
     }
 
     if (!response) {
-      console.error(`[cloro/callback] Task ${taskId} COMPLETED but missing response`);
+      req.log.error({ taskId }, 'cloro callback: task completed but missing response');
       await supabaseAdmin.from('cloro_pending_tasks').delete().eq('task_id', taskId);
       return;
     }
@@ -404,8 +409,9 @@ app.post('/cloro/callback', async (req, res) => {
     ]);
 
     if (!brand) {
-      console.error(
-        `[cloro/callback] Brand ${pending.brand_id} for task ${taskId} not found — dropping`,
+      req.log.error(
+        { taskId, brandId: pending.brand_id },
+        'cloro callback: brand not found — dropping',
       );
       await supabaseAdmin.from('cloro_pending_tasks').delete().eq('task_id', taskId);
       return;
@@ -435,9 +441,12 @@ app.post('/cloro/callback', async (req, res) => {
 
     await supabaseAdmin.from('cloro_pending_tasks').delete().eq('task_id', taskId);
 
-    console.log(`[cloro/callback] Task ${taskId} (${pending.scraper_id}) processed and inserted`);
+    req.log.info(
+      { taskId, scraperId: pending.scraper_id },
+      'cloro callback: task processed and inserted',
+    );
   } catch (err) {
-    console.error('[cloro/callback] Error processing webhook:', err?.message || err);
+    req.log.error({ err }, 'cloro callback: error processing webhook');
   }
 });
 
@@ -456,7 +465,9 @@ app.get('/', (req, res) => {
 
 // --- Global error handler ---
 app.use((err, req, res, _next) => {
-  console.error('Unhandled error:', err.message);
+  // Module logger, not req.log: an error thrown before requestIdMiddleware
+  // (e.g. in the public traffic routes or body parser) has no req.log.
+  logger.error({ err }, 'unhandled error');
   res.status(err.status || 500).json({
     success: false,
     message: process.env.NODE_ENV === 'development' ? err.message : 'Internal Server Error',
@@ -467,7 +478,7 @@ app.use((err, req, res, _next) => {
 const PORT = process.env.PORT || 80;
 
 server.listen(PORT, async () => {
-  console.log(`AEO Server running on port ${PORT} [${process.env.NODE_ENV}]`);
+  logger.info({ port: PORT, env: process.env.NODE_ENV }, 'server running');
 
   await cleanupStaleJobs();
   await cleanupStalePendingTasks();
@@ -475,15 +486,15 @@ server.listen(PORT, async () => {
   if (!isCloud()) {
     const schedule = process.env.DAILY_CRON_SCHEDULE || '0 6 * * *';
     cron.schedule(schedule, async () => {
-      console.log('[cron] Self-hosted daily tracking triggered');
+      logger.info('self-hosted daily tracking triggered');
       try {
         await runDailyTracking();
         await cleanupOldJobs();
       } catch (err) {
-        console.error('[cron] Self-hosted daily tracking failed:', err.message);
+        logger.error({ err }, 'self-hosted daily tracking failed');
       }
     });
-    console.log(`[cron] Self-hosted daily cron active (schedule: ${schedule})`);
+    logger.info({ schedule }, 'self-hosted daily cron active');
   }
 });
 


### PR DESCRIPTION
## Summary

Fifth slice of #303 (structured logging Phase 2). Migrates the remaining `console.*` calls in `server.js` and `middleware/index.js` to the pino `logger` (server.js already imported it in Phase 1).

**Files migrated (~25 calls):**
- `server.js` (21):
  - request handlers (internal CRON_SECRET endpoints, `/cloro/callback`) → `req.log.*` with structured fields (`taskId`, `scraperId`, `ip`, `status`, …)
  - module-scope lines (`runDailyTracking` summary, `server.listen`, self-hosted cron trigger/schedule) → module `logger`
  - **global error handler** uses the module `logger`, *not* `req.log` — an error thrown before `requestIdMiddleware` (public traffic routes / body parser) has no `req.log`, so `req.log.error` there would itself throw
- `middleware/index.js` (4): socket auth + domain-check paths → module `logger.error({ err })` / `logger.warn` (sockets carry no `requestId`, and the HTTP domain-check variant isn't guaranteed to run after `requestIdMiddleware`)

Level mapping per the issue. Behaviour unchanged; lines are now leveled + JSON.

## Related issue

Part of #303 (Phase 2 of #245) — the **final** slice, following #330, and the routes / workers / lib-jobs slices. The only file left after this is `lib/cloro-scraper.js` (10 calls), **intentionally deferred** to land together with the query fan-out work (#332) to avoid churn/conflicts. Once #332 lands, #303 can be closed.

## Type of change

- [x] `chore` — Maintenance

## How to test

1. From `server/`: `npm run lint`, `npm run format:check`, `npm run test` (93 tests) all pass.
2. `grep -n "console\." server/src/server.js server/src/middleware/index.js` returns nothing.
3. Booting the server logs a structured `server running` line; a `/cloro/callback` delivery logs structured request-scoped lines (`req.log`) carrying `taskId`/`scraperId`; an unhandled error logs via the module logger with `{ err }`.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes (from `server/`)
- [x] `npm run format:check` passes (from `server/`)
- [x] Changes are focused — one concern per PR