### PR TITLE
perf(topics): collapse 6 serialized topic-detail server actions into one

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
@@ -4,18 +4,13 @@ import { useCallback, useEffect, useRef, useState, use } from 'react';
 import { Link, useRouter } from '@/i18n/navigation';
 import { useBrandStore } from '@/stores/use-brand-store';
 import {
-  getInsightsSummary,
-  getVisibilityTrend,
-  getShareOfVoiceData,
-  getCompetitorComparison,
-  getPromptResults,
+  getTopicDetail,
   type InsightsSummary,
   type VisibilityTrendPoint,
   type ShareOfVoiceData,
   type CompetitorComparisonData,
   type PromptResultWithText,
 } from '@/lib/actions/tracking';
-import { getTopics } from '@/lib/actions/topic';
 import type { Topic } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -161,20 +156,16 @@ export default function TopicDetailPage({ params }: { params: Promise<{ id: stri
     if (!activeBrandId || !topicId) return;
     setLoading(true);
     try {
-      const [topics, summ, tr, sv, cmp, res] = await Promise.all([
-        getTopics(activeBrandId),
-        getInsightsSummary(activeBrandId, { topicId }),
-        getVisibilityTrend(activeBrandId, { topicId }),
-        getShareOfVoiceData(activeBrandId, { topicId }),
-        getCompetitorComparison(activeBrandId, { topicId }),
-        getPromptResults(activeBrandId, { topicId, limit: 50 }),
-      ]);
-      setTopic(topics.find((t) => t.id === topicId) ?? null);
-      setSummary(summ);
-      setTrend(tr);
-      setSov(sv);
-      setCompetitors(cmp);
-      setResults(res.results);
+      // One server action (#312): Next.js runs server actions sequentially, so
+      // the old six-call Promise.all paid the sum of all six. This is one round
+      // trip whose body runs the work in a real server-side Promise.all.
+      const detail = await getTopicDetail(activeBrandId, topicId);
+      setTopic(detail.topic);
+      setSummary(detail.summary);
+      setTrend(detail.trend);
+      setSov(detail.sov);
+      setCompetitors(detail.competitors);
+      setResults(detail.results);
     } catch (err) {
       console.error('Failed to load topic detail', err);
     } finally {

--- a/web/src/lib/actions/topic.ts
+++ b/web/src/lib/actions/topic.ts
@@ -46,18 +46,21 @@ export async function getTopics(brandId: string): Promise<Topic[]> {
 }
 
 /**
- * Fetch a single topic by id, scoped to the brand. Returns null when the topic
- * doesn't exist (or isn't this brand's) — the detail page renders "not found".
- * Cheaper than getTopics(brandId) + client-side .find() just to read one name.
+ * Fetch a single active topic by id, scoped to the brand. Returns null when the
+ * topic doesn't exist, isn't this brand's, or is inactive — the detail page
+ * renders "not found". The `is_active = true` filter mirrors getTopics(), which
+ * the page used before (via .find() over the active list), so inactive topics
+ * stay hidden. Cheaper than fetching the whole list just to read one name.
  */
 export async function getTopicById(brandId: string, topicId: string): Promise<Topic | null> {
   const supabase = await createClient();
 
   const { data, error } = await supabase
     .from('topics')
-    .select('*')
+    .select('id, brand_id, name, is_active, created_at')
     .eq('brand_id', brandId)
     .eq('id', topicId)
+    .eq('is_active', true)
     .maybeSingle();
 
   if (error) throw new Error(error.message);

--- a/web/src/lib/actions/topic.ts
+++ b/web/src/lib/actions/topic.ts
@@ -45,6 +45,25 @@ export async function getTopics(brandId: string): Promise<Topic[]> {
   return (data ?? []).map((r) => mapTopicRow(r as Record<string, unknown>));
 }
 
+/**
+ * Fetch a single topic by id, scoped to the brand. Returns null when the topic
+ * doesn't exist (or isn't this brand's) — the detail page renders "not found".
+ * Cheaper than getTopics(brandId) + client-side .find() just to read one name.
+ */
+export async function getTopicById(brandId: string, topicId: string): Promise<Topic | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('topics')
+    .select('*')
+    .eq('brand_id', brandId)
+    .eq('id', topicId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data ? mapTopicRow(data as Record<string, unknown>) : null;
+}
+
 export async function createTopic(brandId: string, name: string): Promise<Topic> {
   const supabase = await createClient();
 

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -2,8 +2,16 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { expandDateToEndOfDay } from '@/lib/dates';
-import type { PromptResult, AIPlatform, Sentiment, Citation, CompetitorMention } from '@/types';
+import type {
+  PromptResult,
+  AIPlatform,
+  Sentiment,
+  Citation,
+  CompetitorMention,
+  Topic,
+} from '@/types';
 import { API_BASE_URL } from '@/config/api';
+import { getTopicById } from './topic';
 
 /** Round to one decimal place (keeps sub-1 averages visible instead of flooring to 0). */
 function roundTo1(n: number): number {
@@ -1993,4 +2001,40 @@ function formatTotalMagnitude(
   if (deltaPct === null) return core;
   const sign = deltaPct < 0 ? '−' : '+';
   return `${core} (${sign}${Math.abs(deltaPct)}%)`;
+}
+
+// ─── Topic detail bundle (#312) ───────────────────────────────────────────
+
+export interface TopicDetailData {
+  topic: Topic | null;
+  summary: InsightsSummary;
+  trend: VisibilityTrendPoint[];
+  sov: ShareOfVoiceData;
+  competitors: CompetitorComparisonData;
+  results: PromptResultWithText[];
+}
+
+/**
+ * One server action for the whole topic detail page (#312).
+ *
+ * The page previously fired six separate server-action calls from the client.
+ * Next.js runs server actions **sequentially** (each is its own queued POST),
+ * so that cost was roughly the sum of all six, not the slowest. Collapsing them
+ * into one action means a single round trip whose body runs the work in a real
+ * server-side `Promise.all` (genuinely parallel). The topic is fetched by id
+ * instead of pulling the whole topics list just to read one name.
+ *
+ * Output is identical to the old per-call results — this is a perf refactor.
+ */
+export async function getTopicDetail(brandId: string, topicId: string): Promise<TopicDetailData> {
+  const [topic, summary, trend, sov, competitors, results] = await Promise.all([
+    getTopicById(brandId, topicId),
+    getInsightsSummary(brandId, { topicId }),
+    getVisibilityTrend(brandId, { topicId }),
+    getShareOfVoiceData(brandId, { topicId }),
+    getCompetitorComparison(brandId, { topicId }),
+    getPromptResults(brandId, { topicId, limit: 50 }),
+  ]);
+
+  return { topic, summary, trend, sov, competitors, results: results.results };
 }

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -11,7 +11,7 @@ import type {
   Topic,
 } from '@/types';
 import { API_BASE_URL } from '@/config/api';
-import { getTopicById } from './topic';
+import { getTopicById } from '@/lib/actions/topic';
 
 /** Round to one decimal place (keeps sub-1 averages visible instead of flooring to 0). */
 function roundTo1(n: number): number {


### PR DESCRIPTION
## Summary

The topic detail page (`/dashboard/topics/[id]`) felt slow because it fired **six server-action calls** from the client inside one `Promise.all`. Next.js runs server actions **sequentially** (each is its own queued POST), so the wait was ~the **sum** of all six, not the slowest — the dominant cost (#312).

This collapses them into **one** server action whose body runs the reads in a real server-side `Promise.all` (genuinely parallel, one round trip).

## Changes

- **`actions/tracking.ts`** — add `getTopicDetail(brandId, topicId)`: one action that runs the six reads in a server-side `Promise.all` and returns a single bundle `{ topic, summary, trend, sov, competitors, results }` (new `TopicDetailData` type).
- **`actions/topic.ts`** — add `getTopicById(brandId, topicId)`; the page now fetches **only the one topic's row** instead of `getTopics()` (whole list) just to read one name.
- **`topics/[id]/page.tsx`** — calls the single action and unpacks the bundle; the six imports drop to one.

Output is **identical** to before — this is a performance refactor, not a behaviour change.

## Related issue

Closes #312 (the **core fix**). The stretch items in the issue — sharing the single `prompt_results` scan across summary/competitors/prompt rollup, per-section progressive render, and reading from the `*_aggregates` tables / short-TTL cache — are left as optional follow-ups.

## Type of change

- [x] `refactor` — Code change that neither fixes a bug nor adds a feature (performance)

## How to test

1. Open a topic from `/dashboard/topics`; the detail page renders meaningfully faster (one round trip instead of six serialized ones).
2. Every section (KPI strip, visibility trend, SoV by platform, competitor table, top/weak prompts) shows the **same numbers as before**.
3. A topic with no data still shows the correct empty states; an unknown/foreign topic id renders "Topic not found".
4. `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn test` all pass from `web/`.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (from `web/`)
- [x] `yarn typecheck` passes (from `web/`)
- [x] `yarn format:check` passes (from `web/`)
- [x] Changes are focused — one concern per PR