### PR TITLE
fix(team): return the direct invite link so shared invites don't 404

### DIFF
--- a/web/src/components/settings/team-section.tsx
+++ b/web/src/components/settings/team-section.tsx
@@ -417,11 +417,13 @@ function InviteDialog({ canInvite, onInvited }: { canInvite: boolean; onInvited:
   const [role, setRole] = useState<TeamRole>('analyst');
   const [submitting, setSubmitting] = useState(false);
   const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [emailSent, setEmailSent] = useState(true);
 
   function reset() {
     setEmail('');
     setRole('analyst');
     setInviteLink(null);
+    setEmailSent(true);
   }
 
   async function handleSubmit() {
@@ -431,9 +433,10 @@ function InviteDialog({ canInvite, onInvited }: { canInvite: boolean; onInvited:
     }
     setSubmitting(true);
     try {
-      const { inviteLink: link } = await inviteMember(email.trim(), role);
+      const { inviteLink: link, emailSent: sent } = await inviteMember(email.trim(), role);
       setInviteLink(link);
-      toast.success('Invitation sent');
+      setEmailSent(sent);
+      toast.success(sent ? 'Invitation sent' : 'Invite created — share the link');
       onInvited();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to send invitation');
@@ -475,7 +478,9 @@ function InviteDialog({ canInvite, onInvited }: { canInvite: boolean; onInvited:
         {inviteLink ? (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground">
-              Invitation sent. You can also share this link directly:
+              {emailSent
+                ? 'Invitation sent. You can also share this link directly:'
+                : 'No email was sent — this address may already have an account. Share this link with them directly:'}
             </p>
             <div className="flex items-center gap-2">
               <Input readOnly value={inviteLink} className="flex-1 text-xs" />

--- a/web/src/lib/actions/team.ts
+++ b/web/src/lib/actions/team.ts
@@ -202,14 +202,25 @@ export async function inviteMember(email: string, role: TeamRole) {
 
   const token = randomBytes(32).toString('hex');
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  // What we hand to Supabase as `redirectTo`. It becomes `{{ .RedirectTo }}`
-  // in the Invite User template, which we use as the *base* for the
-  // /auth/confirm URL — token_hash + type get appended in the template.
-  // The benefit: the prefix is whatever appUrl is for *this* environment
-  // (localhost when running `pnpm dev`, app.ansvisor.com in production),
-  // independent of Supabase's project-level Site URL. So a single template
-  // works for both dev and prod.
-  const inviteLink = `${appUrl}/auth/confirm?next=${encodeURIComponent(`/invite/${token}`)}`;
+
+  // The link we surface to the admin (dashboard "share this link directly" +
+  // clipboard) is the direct, self-contained accept page. It looks the
+  // invitation up by token and routes to sign-up/accept on its own, so it
+  // NEVER depends on Supabase's email OTP params.
+  //
+  // Previously this returned the /auth/confirm base below, which only works
+  // once the invite EMAIL template appends token_hash + type. Opened directly
+  // (which is exactly what the "share this link" affordance does) it has
+  // neither, so /auth/confirm bounced to /sign-in?error=auth_confirm_missing_params.
+  // resendInvitation already returned this direct form; inviteMember now matches.
+  const shareLink = `${appUrl}/invite/${token}`;
+
+  // What we hand to Supabase as `redirectTo` for the invite EMAIL only. It
+  // becomes `{{ .RedirectTo }}` in the Invite User template, which appends
+  // token_hash + type; /auth/confirm then verifies the OTP server-side and
+  // forwards to /invite/{token}. The prefix is this environment's appUrl, so
+  // one template works for both dev and prod.
+  const emailRedirectTo = `${appUrl}/auth/confirm?next=${encodeURIComponent(`/invite/${token}`)}`;
 
   const { data: invitation, error: insertError } = await supabaseAdmin
     .from('invitations')
@@ -232,16 +243,25 @@ export async function inviteMember(email: string, role: TeamRole) {
 
   try {
     await supabaseAdmin.auth.admin.inviteUserByEmail(normalizedEmail, {
-      redirectTo: inviteLink,
+      redirectTo: emailRedirectTo,
       data: { invitation_token: token },
     });
-  } catch {
-    // Supabase may fail if user already has an account; we still keep the
-    // invitation row so that the direct link works.
+  } catch (err) {
+    // inviteUserByEmail only emails BRAND-NEW addresses — it errors for an
+    // email that's already registered (Supabase can't "create" that user), so
+    // existing users never get the Supabase invite mail. That's acceptable:
+    // the invitation row is saved and the admin shares `shareLink` directly.
+    // Log the reason so genuine SMTP failures for new users stay diagnosable
+    // instead of vanishing into a silent catch.
+    console.warn(
+      `[invite] Supabase invite email not sent for ${normalizedEmail} (existing user or SMTP): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 
   revalidatePath('/dashboard/settings');
-  return { invitation, inviteLink };
+  return { invitation, inviteLink: shareLink };
 }
 
 export async function revokeInvitation(invitationId: string) {

--- a/web/src/lib/actions/team.ts
+++ b/web/src/lib/actions/team.ts
@@ -241,27 +241,30 @@ export async function inviteMember(email: string, role: TeamRole) {
     throw new Error(insertError.message);
   }
 
+  // inviteUserByEmail only emails BRAND-NEW addresses — it errors for an email
+  // that's already registered (Supabase can't "create" that user), so existing
+  // users never get the Supabase invite mail. Surface whether it actually sent
+  // so the UI can be honest ("share this link" vs. "email sent") instead of
+  // always claiming an email went out.
+  let emailSent = false;
   try {
     await supabaseAdmin.auth.admin.inviteUserByEmail(normalizedEmail, {
       redirectTo: emailRedirectTo,
       data: { invitation_token: token },
     });
+    emailSent = true;
   } catch (err) {
-    // inviteUserByEmail only emails BRAND-NEW addresses — it errors for an
-    // email that's already registered (Supabase can't "create" that user), so
-    // existing users never get the Supabase invite mail. That's acceptable:
-    // the invitation row is saved and the admin shares `shareLink` directly.
-    // Log the reason so genuine SMTP failures for new users stay diagnosable
-    // instead of vanishing into a silent catch.
+    // Existing-user or SMTP failure — the invitation row is saved and the admin
+    // shares `shareLink` directly. Log the invitation/org id (not the invitee's
+    // email — that's PII in persistent logs) plus the error for diagnostics.
     console.warn(
-      `[invite] Supabase invite email not sent for ${normalizedEmail} (existing user or SMTP): ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `[invite] Supabase invite email not sent (invitation=${invitation.id}, org=${profile.organization_id}) — existing user or SMTP`,
+      err,
     );
   }
 
   revalidatePath('/dashboard/settings');
-  return { invitation, inviteLink: shareLink };
+  return { invitation, inviteLink: shareLink, emailSent };
 }
 
 export async function revokeInvitation(invitationId: string) {


### PR DESCRIPTION
## Summary

Fixes a broken team-invite link. When an admin invited a member and used the dashboard's **"share this link directly"** affordance (copy button), the copied URL was `…/auth/confirm?next=/invite/{token}` — which redirected the invitee to `…/sign-in?error=auth_confirm_missing_params`.

**Root cause:** `/auth/confirm` only works when Supabase's invite **email template** appends `token_hash` + `type`. `inviteMember` was handing that same `/auth/confirm` base back to the dashboard as the shareable link, so opening it directly (no `token_hash`/`type`) hit the "missing params" guard. `resendInvitation` already returned the correct direct form; `inviteMember` now matches.

## Changes (`web/src/lib/actions/team.ts`)

- **Return the direct `/invite/{token}` accept link** for the admin to share. That page looks the invitation up by token and routes to sign-up/accept on its own — no Supabase OTP params — so it works for new users, signed-out users, and existing users being re-invited alike.
- **Keep `/auth/confirm?next=…` as the email `redirectTo` only** (renamed `emailRedirectTo` for clarity), where the invite email template decorates it with `token_hash` + `type`.
- **Replace the silent `catch {}`** around `inviteUserByEmail` with a `console.warn`. `inviteUserByEmail` only emails brand-new addresses and errors for already-registered emails (a Supabase limitation) — expected, since the share link is the delivery path, but genuine SMTP failures for new users are now diagnosable instead of vanishing.

## Re-inviting a removed member

This also unblocks the "removed then re-invited" case raised in review:
- `removeMember` detaches the profile (`organization_id = null`) but keeps the auth user + profile row.
- The partial unique index `invitations_org_email_pending_idx` only blocks duplicate **pending** invites, so a fresh invite for a previously-accepted/removed user inserts fine.
- `acceptInvitation` re-attaches the existing profile to the org, so opening the direct link and signing in re-joins them.

Note: auto-emailing *existing* users (vs. sharing the link) is intentionally out of scope — the app has no transactional email provider beyond Supabase Auth, and Supabase can't send an invite email to an already-registered address. Tracked as a possible follow-up (magic-link or Resend).

## Type of change

- [x] `fix` — Bug fix

## How to test

1. As an admin, invite a member (a brand-new email, and separately an email that already has an account).
2. In the post-invite dialog, copy the **"share this link directly"** link → it is now `…/invite/{token}` (not `/auth/confirm?…`).
3. Open it: signed-out → sign-up/sign-in then the accept card; signed-in with the invited email → accept card. No `auth_confirm_missing_params`.
4. Remove a member, then re-invite the same email → the new invite is created and the link accepts them back into the org.
5. `yarn typecheck`, `yarn lint`, `yarn format:check` pass from `web/`.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (from `web/`)
- [x] `yarn typecheck` passes (from `web/`)
- [x] `yarn format:check` passes (from `web/`)
- [x] Changes are focused — one concern per PR