### PR TITLE
feat(tracking): capture & store observed query fan-out (Cloro searchQueries)

### DIFF
--- a/server/src/lib/cloro-result-handler.js
+++ b/server/src/lib/cloro-result-handler.js
@@ -65,7 +65,7 @@ export async function handleScraperResult({
       competitor_mentions: metrics.competitorMentions,
       shopping_cards: aiResponse.shopping_cards ?? [],
       inline_products: aiResponse.inline_products ?? [],
-      search_queries: aiResponse.search_queries ?? [],
+      search_queries: Array.isArray(aiResponse.search_queries) ? aiResponse.search_queries : [],
     })
     .select('id')
     .single();

--- a/server/src/lib/cloro-result-handler.js
+++ b/server/src/lib/cloro-result-handler.js
@@ -21,7 +21,7 @@ import { logger } from './logger.js';
 
 /**
  * @param {object} args
- * @param {{ text: string, citations: Array, model: string, shopping_cards: Array }} args.aiResponse
+ * @param {{ text: string, citations: Array, model: string, shopping_cards: Array, search_queries?: Array }} args.aiResponse
  *   Already parsed via parseScraperResponse (cloro-scraper.js)
  * @param {string} args.scraperId           Cloro scraper id (e.g. 'chatgpt-web')
  * @param {string} args.promptId
@@ -65,6 +65,7 @@ export async function handleScraperResult({
       competitor_mentions: metrics.competitorMentions,
       shopping_cards: aiResponse.shopping_cards ?? [],
       inline_products: aiResponse.inline_products ?? [],
+      search_queries: aiResponse.search_queries ?? [],
     })
     .select('id')
     .single();

--- a/server/src/lib/cloro-scraper.js
+++ b/server/src/lib/cloro-scraper.js
@@ -95,12 +95,17 @@ function buildRequestBody(promptText, scraperId, region) {
  * synthesize sub-queries.
  */
 function normalizeSearchQueries(result, scraperId) {
+  // Trim on write so the same sub-query never fragments into whitespace
+  // variants — the #333 aggregation groups by query string. `engine` is only
+  // kept when it's a non-empty string (never a stray non-string value).
   if (Array.isArray(result.search_model_queries)) {
     return result.search_model_queries
       .filter((q) => typeof q?.query === 'string' && q.query.trim() !== '')
       .map((q) => ({
-        query: q.query,
-        ...(q.engine ? { engine: q.engine } : {}),
+        query: q.query.trim(),
+        ...(typeof q.engine === 'string' && q.engine.trim() !== ''
+          ? { engine: q.engine.trim() }
+          : {}),
         source_platform: scraperId,
       }));
   }
@@ -108,7 +113,7 @@ function normalizeSearchQueries(result, scraperId) {
   if (Array.isArray(result.searchQueries)) {
     return result.searchQueries
       .filter((q) => typeof q === 'string' && q.trim() !== '')
-      .map((q) => ({ query: q, source_platform: scraperId }));
+      .map((q) => ({ query: q.trim(), source_platform: scraperId }));
   }
 
   return [];

--- a/server/src/lib/cloro-scraper.js
+++ b/server/src/lib/cloro-scraper.js
@@ -76,9 +76,42 @@ function buildRequestBody(promptText, scraperId, region) {
       html: false,
       markdown: true,
       rawResponse: false,
-      searchQueries: false,
+      // Opt in to the observed query fan-out (#332). Copilot/Perplexity
+      // populate it; ChatGPT surfaces the key but returns it empty in
+      // practice — enabling it is free and harmless.
+      searchQueries: true,
     },
   };
+}
+
+/**
+ * Normalize the observed query fan-out from a raw Cloro response into a rich,
+ * engine-labelled array: `[{ query, engine?, source_platform }]` (#332).
+ *
+ * Two provider shapes:
+ *  - Perplexity → `search_model_queries: [{ query, engine, limit }]` (keep `engine`)
+ *  - Copilot / ChatGPT / Grok / Gemini → `searchQueries: string[]`
+ * Anything else (or missing) → `[]`. This is OBSERVED data only — we never
+ * synthesize sub-queries.
+ */
+function normalizeSearchQueries(result, scraperId) {
+  if (Array.isArray(result.search_model_queries)) {
+    return result.search_model_queries
+      .filter((q) => typeof q?.query === 'string' && q.query.trim() !== '')
+      .map((q) => ({
+        query: q.query,
+        ...(q.engine ? { engine: q.engine } : {}),
+        source_platform: scraperId,
+      }));
+  }
+
+  if (Array.isArray(result.searchQueries)) {
+    return result.searchQueries
+      .filter((q) => typeof q === 'string' && q.trim() !== '')
+      .map((q) => ({ query: q, source_platform: scraperId }));
+  }
+
+  return [];
 }
 
 export function parseScraperResponse(result, scraperId) {
@@ -162,6 +195,8 @@ export function parseScraperResponse(result, scraperId) {
     // .shopping_cards column raw, in their own provider shape — downstream
     // branches on `platform` to interpret. Other providers have neither key.
     shopping_cards: result.shopping_cards ?? result.shoppingCards ?? [],
+    // Observed query fan-out (#332) — rich, engine-labelled; [] when absent.
+    search_queries: normalizeSearchQueries(result, scraperId),
   };
 }
 

--- a/server/src/lib/cloro-scraper.test.js
+++ b/server/src/lib/cloro-scraper.test.js
@@ -169,4 +169,57 @@ describe('cloro-scraper – parseScraperResponse', () => {
       expect(parsed.shopping_cards).toEqual([]);
     });
   });
+
+  describe('search_queries (observed query fan-out, #332)', () => {
+    it('maps Copilot string[] searchQueries to rich items tagged with the source platform', () => {
+      const result = {
+        markdown: 'text',
+        sources: [],
+        searchQueries: ['best running shoes 2026', 'running shoes flat feet'],
+      };
+      const parsed = parseScraperResponse(result, 'copilot-web');
+      expect(parsed.search_queries).toEqual([
+        { query: 'best running shoes 2026', source_platform: 'copilot-web' },
+        { query: 'running shoes flat feet', source_platform: 'copilot-web' },
+      ]);
+    });
+
+    it('preserves the per-item engine label from Perplexity search_model_queries', () => {
+      const result = {
+        markdown: 'text',
+        sources: [],
+        search_model_queries: [
+          { query: 'best laptops 2026', engine: 'web', limit: 10 },
+          { query: 'laptop reviews', engine: 'web' },
+        ],
+      };
+      const parsed = parseScraperResponse(result, 'perplexity-web');
+      expect(parsed.search_queries).toEqual([
+        { query: 'best laptops 2026', engine: 'web', source_platform: 'perplexity-web' },
+        { query: 'laptop reviews', engine: 'web', source_platform: 'perplexity-web' },
+      ]);
+    });
+
+    it('drops blank / non-string fan-out entries', () => {
+      const result = {
+        markdown: 'text',
+        sources: [],
+        searchQueries: ['ok query', '   ', '', 42, null],
+      };
+      const parsed = parseScraperResponse(result, 'copilot-web');
+      expect(parsed.search_queries).toEqual([
+        { query: 'ok query', source_platform: 'copilot-web' },
+      ]);
+    });
+
+    it('defaults to an empty array when the engine returns none (ChatGPT in practice)', () => {
+      expect(
+        parseScraperResponse({ markdown: 't', sources: [], searchQueries: [] }, 'chatgpt-web')
+          .search_queries,
+      ).toEqual([]);
+      expect(
+        parseScraperResponse({ markdown: 't', sources: [] }, 'gemini-web').search_queries,
+      ).toEqual([]);
+    });
+  });
 });

--- a/server/src/lib/cloro-scraper.test.js
+++ b/server/src/lib/cloro-scraper.test.js
@@ -212,6 +212,46 @@ describe('cloro-scraper – parseScraperResponse', () => {
       ]);
     });
 
+    it('trims surrounding whitespace so a sub-query has one canonical form', () => {
+      const copilot = parseScraperResponse(
+        { markdown: 't', sources: [], searchQueries: ['  spaced query  '] },
+        'copilot-web',
+      );
+      expect(copilot.search_queries).toEqual([
+        { query: 'spaced query', source_platform: 'copilot-web' },
+      ]);
+
+      const perplexity = parseScraperResponse(
+        {
+          markdown: 't',
+          sources: [],
+          search_model_queries: [{ query: '  spaced  ', engine: '  web  ' }],
+        },
+        'perplexity-web',
+      );
+      expect(perplexity.search_queries).toEqual([
+        { query: 'spaced', engine: 'web', source_platform: 'perplexity-web' },
+      ]);
+    });
+
+    it('omits a non-string / empty Perplexity engine label', () => {
+      const parsed = parseScraperResponse(
+        {
+          markdown: 't',
+          sources: [],
+          search_model_queries: [
+            { query: 'no engine', engine: 42 },
+            { query: 'blank engine', engine: '   ' },
+          ],
+        },
+        'perplexity-web',
+      );
+      expect(parsed.search_queries).toEqual([
+        { query: 'no engine', source_platform: 'perplexity-web' },
+        { query: 'blank engine', source_platform: 'perplexity-web' },
+      ]);
+    });
+
     it('defaults to an empty array when the engine returns none (ChatGPT in practice)', () => {
       expect(
         parseScraperResponse({ markdown: 't', sources: [], searchQueries: [] }, 'chatgpt-web')

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -305,7 +305,9 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
               model_used: aiResponse.model,
               region: meta.region,
               competitor_mentions: metrics.competitorMentions,
-              search_queries: aiResponse.search_queries ?? [],
+              search_queries: Array.isArray(aiResponse.search_queries)
+                ? aiResponse.search_queries
+                : [],
             });
 
             console.log(`[tracking] Task=${taskId} scraper=${scraperId} result saved.`);

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -305,6 +305,7 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
               model_used: aiResponse.model,
               region: meta.region,
               competitor_mentions: metrics.competitorMentions,
+              search_queries: aiResponse.search_queries ?? [],
             });
 
             console.log(`[tracking] Task=${taskId} scraper=${scraperId} result saved.`);

--- a/supabase/migrations/00021_prompt_results_search_queries.sql
+++ b/supabase/migrations/00021_prompt_results_search_queries.sql
@@ -1,0 +1,21 @@
+-- 00021_prompt_results_search_queries.sql
+-- Capture the observed query fan-out on each tracked answer.
+--
+-- Answer engines (Copilot, Perplexity, and — in principle — ChatGPT) run their
+-- own sub-queries to build an answer. Cloro already returns these in the poll /
+-- webhook response; we simply had nowhere to store them. This column holds that
+-- OBSERVED fan-out (straight from the engine, not an LLM prediction) as a rich,
+-- normalized array so the UI can keep the per-item engine label:
+--
+--   [{ "query": "best running shoes 2026", "engine": "web", "source_platform": "perplexity-web" }]
+--
+-- (`engine` is present only where the provider labels it — Perplexity today.)
+--
+-- Existing rows default to an empty array, so nothing changes for historical
+-- data; new Copilot/Perplexity results populate it as they land.
+
+ALTER TABLE prompt_results
+  ADD COLUMN IF NOT EXISTS search_queries jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN prompt_results.search_queries IS
+  'Observed query fan-out from the answer engine: [{ query, engine?, source_platform }]. Copilot is the primary source; Perplexity secondary (web queries, carries engine); ChatGPT usually empty. Defaults to [].';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2932,3 +2932,28 @@ ALTER TABLE brands
 COMMENT ON COLUMN brands.is_active IS
   'When false, the brand is paused: the daily tracking cron and on-demand tracking skip it. Historical data stays viewable. Defaults to true.';
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00021_prompt_results_search_queries.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- 00021_prompt_results_search_queries.sql
+-- Capture the observed query fan-out on each tracked answer.
+--
+-- Answer engines (Copilot, Perplexity, and — in principle — ChatGPT) run their
+-- own sub-queries to build an answer. Cloro already returns these in the poll /
+-- webhook response; we simply had nowhere to store them. This column holds that
+-- OBSERVED fan-out (straight from the engine, not an LLM prediction) as a rich,
+-- normalized array so the UI can keep the per-item engine label:
+--
+--   [{ "query": "best running shoes 2026", "engine": "web", "source_platform": "perplexity-web" }]
+--
+-- (`engine` is present only where the provider labels it — Perplexity today.)
+--
+-- Existing rows default to an empty array, so nothing changes for historical
+-- data; new Copilot/Perplexity results populate it as they land.
+
+ALTER TABLE prompt_results
+  ADD COLUMN IF NOT EXISTS search_queries jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN prompt_results.search_queries IS
+  'Observed query fan-out from the answer engine: [{ query, engine?, source_platform }]. Copilot is the primary source; Perplexity secondary (web queries, carries engine); ChatGPT usually empty. Defaults to [].';
+


### PR DESCRIPTION
## Summary

Capture and store the **observed query fan-out** — the sub-queries an AI answer engine actually ran to build its answer — which Cloro already returns in the poll/webhook response but we discarded at every layer. This is the storage/capture foundation; the product surface (a "Query Fan-out" tab) is #333.

**No extra AI/scraper spend** — the data is already in the response we poll.

## Changes

- **Migration `00021`** — `prompt_results.search_queries jsonb NOT NULL DEFAULT '[]'::jsonb`. Applied to the hosted DB; all 40,607 existing rows defaulted to `[]` (verified). `supabase/schema.sql` regenerated.
- **`cloro-scraper.js`**
  - `buildRequestBody`: opt in with `include.searchQueries: true` for the ChatGPT-family task (free; ChatGPT usually returns it empty, harmless).
  - new `normalizeSearchQueries(result, scraperId)` → rich, engine-labelled array `[{ query, engine?, source_platform }]`:
    - Perplexity `search_model_queries` → keeps its `engine` label
    - Copilot / ChatGPT / Grok / Gemini `searchQueries` (`string[]`) → mapped
    - blank / non-string entries dropped; anything else → `[]`
  - `parseScraperResponse` returns `search_queries` on the default (web-engine) branch.
- **Persist** `search_queries` in **both** insert sites: `cloro-result-handler.js` (webhook path) and `tracking-worker.js` (polling path).
- **+4 parser tests** (Copilot string[], Perplexity engine preserved, blanks dropped, empty/absent → `[]`).

## Verified end to end (live Cloro, real module)

Ran the actual `cloro-scraper.js` module against live Cloro:
- **Copilot** → `[{ query: "…", source_platform: "copilot-web" }]`
- **Perplexity** → `[{ query: "…", engine: "web", source_platform: "perplexity-web" }]`

Matches the per-platform shape/reliability established in #332 (Copilot primary; Perplexity secondary/web; ChatGPT usually empty).

## Related issue

Closes #332. UI surface is #333 (depends on this).

## Type of change

- [x] `feat` — New feature (data capture)

## How to test

1. From `server/`: `npm run lint`, `npm run format:check`, `npm run test` (97 tests) pass.
2. Run tracking for a brand with a **Copilot** or **Perplexity** prompt (needs this branch's code to process the *result insert* — in webhook mode that's whichever server owns `/cloro/callback`).
3. `SELECT platform, search_queries FROM prompt_results WHERE search_queries <> '[]' ORDER BY created_at DESC LIMIT 5;` → Copilot rows carry `[{query, source_platform}]`, Perplexity `[{query, engine, source_platform}]`; ChatGPT may stay empty (expected).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes (from `server/`)
- [x] `npm run format:check` passes (from `server/`)
- [x] Migration applied + `schema.sql` regenerated
- [x] Changes are focused — one concern per PR