### PR TITLE
fix(citations): show competitor name in select trigger instead of id

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -1020,7 +1020,9 @@ function ByCompetitorView({
           }}
         >
           <SelectTrigger className="h-8 w-56 text-xs">
-            <SelectValue placeholder="Select competitor" />
+            <SelectValue placeholder="Select competitor">
+              {(value) => gaps.competitors.find((c) => c.id === value)?.name ?? 'Select competitor'}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {gaps.competitors.map((c) => (


### PR DESCRIPTION
## Summary

On the Citations page → Competitor Gaps → By competitor view, the competitor
dropdown trigger was displaying the competitor's UUID instead of its name after
selection. Added a render function to `SelectValue` that maps the selected id
to the competitor's name — the same pattern already used by the Platform and
Topic selects on the same page.

## Related issue

Closes #328 

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR