### PR TITLE
perf(insights): drop the full-table scan on load + use SQL limit/count (closes #313)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -39,9 +39,7 @@ import { groupResultsByTopic, type PlatformGroup, type PromptGroup } from './gro
 import { useBrandStore } from '@/stores/use-brand-store';
 import {
   getPromptResults,
-  getInsightsSummary,
-  getCompetitorComparison,
-  getShareOfVoiceData,
+  getInsightsData,
   triggerTrackingCheck,
   getJobStatus,
   cancelTrackingJob,
@@ -1285,50 +1283,33 @@ export default function InsightsPage() {
           dateTo,
         };
 
-        const hasFilters = f.datePreset !== 'all' || f.model || f.region || f.topic;
+        const hasFilters = Boolean(f.datePreset !== 'all' || f.model || f.region || f.topic);
 
-        const promises: [
-          Promise<InsightsSummary>,
-          Promise<{ results: PromptResultWithText[]; total: number }>,
-          Promise<CompetitorComparisonData>,
-          Promise<ShareOfVoiceData>,
-          Promise<{ total: number } | null>,
-        ] = [
-          getInsightsSummary(brand.id, filterOpts),
-          getPromptResults(brand.id, {
-            limit: PROMPT_RESULTS_ROW_LIMIT,
-            ...filterOpts,
-          }),
-          getCompetitorComparison(brand.id, filterOpts),
-          getShareOfVoiceData(brand.id, filterOpts),
-          hasFilters
-            ? getPromptResults(brand.id, { limit: 1 }).then(({ total }) => ({ total }))
-            : Promise.resolve(null),
-        ];
-
-        const [summaryData, resultsData, compData, sovResult, unfilteredCheck] =
-          await Promise.all(promises);
-        setSummary(summaryData);
-        setResults(resultsData.results);
-        setTotalResults(resultsData.total);
-        setCompetitorData(compData.brands.length > 1 ? compData : null);
-        setSovData(sovResult.byPlatform.length > 0 ? sovResult : null);
-
-        if (unfilteredCheck !== null) {
-          setHasAnyData(unfilteredCheck.total > 0);
-        } else {
-          setHasAnyData(resultsData.total > 0);
-        }
+        // One consolidated server action (#313): summary + results + competitor
+        // + SoV run in a real server-side Promise.all (one round trip instead
+        // of five serialized POSTs), and "has any data" comes from a cheap
+        // count instead of an unbounded full-table scan.
+        const insights = await getInsightsData(brand.id, {
+          ...filterOpts,
+          rowLimit: PROMPT_RESULTS_ROW_LIMIT,
+          checkUnfiltered: hasFilters,
+        });
+        setSummary(insights.summary);
+        setResults(insights.results);
+        setTotalResults(insights.total);
+        setCompetitorData(insights.competitors.brands.length > 1 ? insights.competitors : null);
+        setSovData(insights.sov.byPlatform.length > 0 ? insights.sov : null);
+        setHasAnyData(insights.hasAnyData);
 
         const regions = [
-          ...new Set(resultsData.results.map((r) => r.region).filter(Boolean) as string[]),
+          ...new Set(insights.results.map((r) => r.region).filter(Boolean) as string[]),
         ].sort();
         // Group raw model slugs by their resolved display name so different
         // ChatGPT versions ("gpt-5-3-mini" + "gpt-5-5") collapse into one
         // "ChatGPT" filter option. Stored as `slugA,slugB` so the server can
         // filter the whole family with .in() via applyModelFilter().
         const slugToLabel = new Map<string, string>();
-        for (const r of resultsData.results) {
+        for (const r of insights.results) {
           const slug = r.modelUsed;
           if (!slug || slugToLabel.has(slug)) continue;
           const label =

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -192,15 +192,20 @@ async function buildResultsQuery(
     promptId?: string;
     topicId?: string;
   },
+  selectOpts?: { count?: 'exact' },
 ) {
   const supabase = await createClient();
   // #155 — Insights aggregates exclude `chatgpt-shopping`. That model's
   // visibility numbers aren't comparable to a normal ChatGPT answer and
   // would skew brand-level visibility/mentions/citations. Shopping data
   // is consumed by /dashboard/shopping only.
-  let query = supabase
-    .from('prompt_results')
-    .select('*')
+  //
+  // `count: 'exact'` (opt-in) makes the query return the full match count
+  // alongside a `.range()` page, so getPromptResults gets an accurate total
+  // without materializing every row. Export leaves it off (it paginates and
+  // doesn't need a per-page count).
+  const base = supabase.from('prompt_results');
+  let query = (selectOpts?.count ? base.select('*', { count: selectOpts.count }) : base.select('*'))
     .eq('brand_id', brandId)
     .neq('platform', 'chatgpt-shopping');
 
@@ -245,14 +250,23 @@ export async function getPromptResults(
     topicId?: string;
   },
 ): Promise<{ results: PromptResultWithText[]; total: number }> {
-  const { supabase, query } = await buildResultsQuery(brandId, opts);
+  const limit = opts?.limit ?? 50;
+  const offset = opts?.offset ?? 0;
 
-  const { data: allRows, error } = await query.order('created_at', {
-    ascending: false,
-  });
+  const { supabase, query } = await buildResultsQuery(brandId, opts, { count: 'exact' });
+
+  // One round trip: fetch only the requested page via SQL `.range()` and read
+  // the full match count from the same query, instead of materializing every
+  // matching row (all heavy columns) into Node and slicing/counting in JS.
+  const {
+    data: pageRows,
+    count,
+    error,
+  } = await query.order('created_at', { ascending: false }).range(offset, offset + limit - 1);
   if (error) throw new Error(error.message);
 
-  const rows = (allRows ?? []) as Record<string, unknown>[];
+  const rows = (pageRows ?? []) as Record<string, unknown>[];
+  const total = count ?? rows.length;
 
   const promptIds = [...new Set(rows.map((r) => r.prompt_id as string))];
   const { data: promptRows } =
@@ -284,11 +298,9 @@ export async function getPromptResults(
     ]),
   );
 
-  const limit = opts?.limit ?? 50;
-  const offset = opts?.offset ?? 0;
-  const paged = rows.slice(offset, offset + limit);
-
-  const results = paged.map((r) => {
+  // `rows` is already the requested page (SQL `.range()` above), so map it
+  // directly — no JS slicing.
+  const results = rows.map((r) => {
     const pm = promptMap.get(r.prompt_id as string);
     return {
       ...mapResultRow(r),
@@ -301,7 +313,78 @@ export async function getPromptResults(
     };
   });
 
-  return { results, total: rows.length };
+  return { results, total };
+}
+
+/** Cheap existence check for a brand's (non-shopping) prompt_results — counts, no rows. */
+async function getBrandResultsTotal(brandId: string): Promise<number> {
+  const supabase = await createClient();
+  const { count } = await supabase
+    .from('prompt_results')
+    .select('*', { count: 'exact', head: true })
+    .eq('brand_id', brandId)
+    .neq('platform', 'chatgpt-shopping');
+  return count ?? 0;
+}
+
+export interface InsightsData {
+  summary: InsightsSummary;
+  results: PromptResultWithText[];
+  total: number;
+  competitors: CompetitorComparisonData;
+  sov: ShareOfVoiceData;
+  hasAnyData: boolean;
+}
+
+/**
+ * One consolidated server action for the Insights page's first load (#313).
+ *
+ * Next.js runs server actions sequentially (each is its own queued POST), so
+ * firing the summary / results / competitor / SoV reads separately from the
+ * client cost roughly their sum, not the slowest. This runs them in a real
+ * server-side `Promise.all` (genuinely parallel, one round trip), and derives
+ * "has any data" from a cheap count instead of the old unbounded full-table
+ * scan. Output is identical to the previous per-call flow.
+ */
+export async function getInsightsData(
+  brandId: string,
+  opts: {
+    model?: string;
+    region?: string;
+    topicId?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    rowLimit?: number;
+    /** When the current view is filtered, check unfiltered data existence too. */
+    checkUnfiltered?: boolean;
+  },
+): Promise<InsightsData> {
+  const filterOpts = {
+    model: opts.model,
+    region: opts.region,
+    topicId: opts.topicId,
+    dateFrom: opts.dateFrom,
+    dateTo: opts.dateTo,
+  };
+
+  const [summary, resultsData, competitors, sov, unfilteredTotal] = await Promise.all([
+    getInsightsSummary(brandId, filterOpts),
+    getPromptResults(brandId, { limit: opts.rowLimit ?? 50, ...filterOpts }),
+    getCompetitorComparison(brandId, filterOpts),
+    getShareOfVoiceData(brandId, filterOpts),
+    opts.checkUnfiltered ? getBrandResultsTotal(brandId) : Promise.resolve(null),
+  ]);
+
+  const hasAnyData = unfilteredTotal !== null ? unfilteredTotal > 0 : resultsData.total > 0;
+
+  return {
+    summary,
+    results: resultsData.results,
+    total: resultsData.total,
+    competitors,
+    sov,
+    hasAnyData,
+  };
 }
 
 /**

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -319,11 +319,14 @@ export async function getPromptResults(
 /** Cheap existence check for a brand's (non-shopping) prompt_results — counts, no rows. */
 async function getBrandResultsTotal(brandId: string): Promise<number> {
   const supabase = await createClient();
-  const { count } = await supabase
+  const { count, error } = await supabase
     .from('prompt_results')
-    .select('*', { count: 'exact', head: true })
+    .select('id', { count: 'exact', head: true })
     .eq('brand_id', brandId)
     .neq('platform', 'chatgpt-shopping');
+  // Throw rather than swallow: a failed count must not masquerade as "no data"
+  // and silently flip the page to its empty state.
+  if (error) throw new Error(error.message);
   return count ?? 0;
 }
 


### PR DESCRIPTION
## Summary

Speeds up the first load of `/dashboard/insights`. The page fired **five server actions** through one client-side `Promise.all`; Next.js runs server actions **sequentially** (each is its own queued POST), so latency was ~their **sum**. One of them scanned the brand's **entire** `prompt_results` history, and `getPromptResults` over-fetched every matching row's heavy columns (full response text + JSON) just to slice/count in JS. (#313)

## Changes

- **`getPromptResults`** (`web/src/lib/actions/tracking.ts`) — now issues **one** query: SQL `.range(offset, offset + limit - 1)` for the page **plus** `count: 'exact'` for an accurate total, instead of materializing every matching row and slicing/counting in Node.
  - This also fixes a **latent cap**: the old fetch-all was bounded by Supabase's default (~1000 rows), so both the returned list *and* `total` were silently capped at ~1000. The range + count now return the true page (up to `limit`) and the true `N` — which is exactly what "Showing 1500 of N" should show.
- **`getInsightsData(brandId, opts)`** (new) — runs summary + results + competitor + SoV in a **real server-side `Promise.all`** (genuinely parallel, one round trip) and derives "has any data" from a cheap `count: 'exact', head: true` instead of the old unbounded `getPromptResults(..., { limit: 1 })` scan.
- **Insights page** — the five-promise block is replaced by a single `getInsightsData` call.

## Behavior-preserving

This is a performance refactor — the displayed rows, grouped table, and every number stay identical:
- Same rows (newest first, same `PROMPT_RESULTS_ROW_LIMIT` cap), same KPI/competitor/SoV/trend numbers, same filters + empty states.
- `buildResultsQuery`'s count is **opt-in**, so `exportPromptResults` (which paginates and doesn't need a per-page count) is untouched.
- Also speeds up the **topic detail** page (#312), which calls the same `getPromptResults`.

## Related issue

Closes #313. (The optional "narrower select" from the issue — dropping heavy columns not shown in the row list — is intentionally left as a safe follow-up so this PR stays strictly behavior-preserving; the count + `.range()` already remove the unbounded scan and the over-fetch of *all* rows.)

## Type of change

- [x] `refactor` — performance

## How to test

1. Open `/dashboard/insights` on a brand with a large history → first paint is noticeably faster; there is no `select('*')` over the whole history in the load path (the has-data check is a `count … head: true`).
2. Every number matches the previous page (KPI strip, competitor, SoV, trend, and the expandable table's per-topic/prompt rollups) for the same filters.
3. "Showing N of TOTAL" shows the correct TOTAL (now accurate past ~1000).
4. Filters (date / model / region / topic) and empty states behave exactly as before.
5. `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn test` pass from `web/`.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (from `web/`)
- [x] `yarn typecheck` passes (from `web/`)
- [x] `yarn format:check` passes (from `web/`)
- [x] Changes are focused — one concern per PR