### PR TITLE
feat(prompts): paginate High frequency table 10/page with numbered controls (#349)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -120,72 +120,74 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
                     <TableHeader>
                       <TableRow>
                         <TableHead>Sub-query</TableHead>
-                <TableHead className="w-[160px]">Engine</TableHead>
-                <TableHead className="w-[120px] text-right">Times searched</TableHead>
-                <TableHead className="w-[220px]">Sourced prompts</TableHead>
-                <TableHead className="w-[130px]">Intent</TableHead>
-                <TableHead className="w-[64px] text-right">Track</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {pageRows.map((sq) => {
-                const key = sq.query.toLowerCase();
-                const adding = addingKey === key;
-                return (
-                  <TableRow key={key}>
-                    <TableCell className="font-medium">{sq.query}</TableCell>
-                    <TableCell>
-                      <div className="flex flex-wrap gap-1">
-                        {sq.engines.map((e) => (
-                          <Badge key={e} variant="secondary" className="text-[10px]">
-                            {platformLabel(e)}
-                          </Badge>
-                        ))}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">{sq.timesSearched}</TableCell>
-                    <TableCell>
-                      <SourcedPrompts prompts={sq.sourcedPrompts} />
-                    </TableCell>
-                    <TableCell>
-                      <IntentBadge intent={intents[key]} />
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {sq.tracked ? (
-                        <Badge
-                          variant="outline"
-                          className="gap-1 text-[10px] text-emerald-600 dark:text-emerald-400"
-                          render={
-                            sq.trackedPromptId ? (
-                              <Link href={`/dashboard/prompts/${sq.trackedPromptId}`} />
-                            ) : undefined
-                          }
-                        >
-                          <Check className="h-3 w-3" />
-                          Tracked
-                        </Badge>
-                      ) : (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7"
-                          disabled={adding}
-                          onClick={() => handleTrack(sq.query)}
-                          aria-label={`Track "${sq.query}" as a prompt`}
-                        >
-                          {adding ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <Plus className="h-4 w-4" />
-                          )}
-                        </Button>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
+                        <TableHead className="w-[160px]">Engine</TableHead>
+                        <TableHead className="w-[120px] text-right">Times searched</TableHead>
+                        <TableHead className="w-[220px]">Sourced prompts</TableHead>
+                        <TableHead className="w-[130px]">Intent</TableHead>
+                        <TableHead className="w-[64px] text-right">Track</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {pageRows.map((sq) => {
+                        const key = sq.query.toLowerCase();
+                        const adding = addingKey === key;
+                        return (
+                          <TableRow key={key}>
+                            <TableCell className="font-medium">{sq.query}</TableCell>
+                            <TableCell>
+                              <div className="flex flex-wrap gap-1">
+                                {sq.engines.map((e) => (
+                                  <Badge key={e} variant="secondary" className="text-[10px]">
+                                    {platformLabel(e)}
+                                  </Badge>
+                                ))}
+                              </div>
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {sq.timesSearched}
+                            </TableCell>
+                            <TableCell>
+                              <SourcedPrompts prompts={sq.sourcedPrompts} />
+                            </TableCell>
+                            <TableCell>
+                              <IntentBadge intent={intents[key]} />
+                            </TableCell>
+                            <TableCell className="text-right">
+                              {sq.tracked ? (
+                                <Badge
+                                  variant="outline"
+                                  className="gap-1 text-[10px] text-emerald-600 dark:text-emerald-400"
+                                  render={
+                                    sq.trackedPromptId ? (
+                                      <Link href={`/dashboard/prompts/${sq.trackedPromptId}`} />
+                                    ) : undefined
+                                  }
+                                >
+                                  <Check className="h-3 w-3" />
+                                  Tracked
+                                </Badge>
+                              ) : (
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7"
+                                  disabled={adding}
+                                  onClick={() => handleTrack(sq.query)}
+                                  aria-label={`Track "${sq.query}" as a prompt`}
+                                >
+                                  {adding ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <Plus className="h-4 w-4" />
+                                  )}
+                                </Button>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
                   {totalPages > 1 && (
                     <div className="flex items-center justify-center gap-1 pt-4">
                       {Array.from({ length: totalPages }, (_, i) => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -36,6 +36,8 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
   const [addingKey, setAddingKey] = useState<string | null>(null);
   // Intent is keyed by the lower-cased sub-query (matches the server cache key).
   const [intents, setIntents] = useState<Record<string, string>>({});
+  const [page, setPage] = useState(1);
+  const PAGE_SIZE = 10;
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -62,11 +64,16 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
     load();
   }, [load]);
 
+  useEffect(() => {
+    setPage(1);
+  }, [brandId]);
+
   async function handleTrack(query: string) {
     setAddingKey(query.toLowerCase());
     try {
       await trackFanoutQuery(brandId, query);
       toast.success('Added as a tracked prompt');
+      setPage(1);
       await load();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to track this query');
@@ -78,7 +85,7 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-sm font-medium">Query fan-out</CardTitle>
+        <CardTitle className="text-sm font-medium">High frequency</CardTitle>
         <p className="text-xs text-muted-foreground">
           The sub-queries answer engines actually ran while building your answers (last 30 days) —
           observed, never predicted. Sorted by how often they were searched. Track any of them with
@@ -103,10 +110,16 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
             </p>
           </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Sub-query</TableHead>
+          <>
+            {(() => {
+              const totalPages = Math.ceil(data.subQueries.length / PAGE_SIZE);
+              const pageRows = data.subQueries.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+              return (
+                <>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Sub-query</TableHead>
                 <TableHead className="w-[160px]">Engine</TableHead>
                 <TableHead className="w-[120px] text-right">Times searched</TableHead>
                 <TableHead className="w-[220px]">Sourced prompts</TableHead>
@@ -115,7 +128,7 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.subQueries.map((sq) => {
+              {pageRows.map((sq) => {
                 const key = sq.query.toLowerCase();
                 const adding = addingKey === key;
                 return (
@@ -173,6 +186,28 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
               })}
             </TableBody>
           </Table>
+                  {totalPages > 1 && (
+                    <div className="flex items-center justify-center gap-1 pt-4">
+                      {Array.from({ length: totalPages }, (_, i) => {
+                        const p = i + 1;
+                        return (
+                          <Button
+                            key={p}
+                            variant={page === p ? 'default' : 'ghost'}
+                            size="sm"
+                            className="h-7 w-7 p-0 text-xs"
+                            onClick={() => setPage(p)}
+                          >
+                            {p}
+                          </Button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </>
+              );
+            })()}
+          </>
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
Closes #349

## What changed
All changes are contained in a single file: `_fanout-tab.tsx`.

### 1. Renamed heading
- `CardTitle` text changed from `"Query fan-out"` → `"High frequency"` as specified in the issue.

### 2. Client-side pagination (10/page)
- Added `page` state (`useState(1)`) and a `PAGE_SIZE = 10` constant.
- `data.subQueries` is sliced into `pageRows` using `(page - 1) * PAGE_SIZE` offset before being passed to the table — no server changes needed.

### 3. Numbered page controls
- Rendered below the table when `totalPages > 1`.
- Each page number is a `Button` from the existing shadcn/ui component.
- Active page uses `variant="default"`, others use `variant="ghost"` for clear visual distinction.

### 4. Page reset on brand change
- Added a `useEffect` watching `brandId` that calls `setPage(1)` — ensures switching brands always starts at page 1.

### 5. Page reset after successful track
- `setPage(1)` called inside `handleTrack` immediately after `toast.success` — ensures the user lands back on page 1 after tracking a query.

## What was NOT changed
- No server actions touched (`fanout.ts` unchanged).
- No other files modified.
- Zero new TypeScript errors introduced (verified via `tsc --noEmit` diff before/after).

## Testing
- Load the prompts page with a brand that has >10 fan-out sub-queries → numbered controls appear below the table.
- Click a page number → table updates to show the correct slice.
- Switch brand → page resets to 1.
- Track a query → page resets to 1 after success toast.