### PR TITLE
fix(prompts): refresh all prompts after tracking fanout query

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -30,7 +30,12 @@ function platformLabel(slug: string): string {
   return PLATFORM_LABELS[slug] ?? slug;
 }
 
-export function QueryFanoutTab({ brandId }: { brandId: string }) {
+type QueryFanoutTabProps = {
+  brandId: string;
+  onTracked?: () => void | Promise<void>;
+};
+
+export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
   const [data, setData] = useState<QueryFanoutData | null>(null);
   const [loading, setLoading] = useState(true);
   const [addingKey, setAddingKey] = useState<string | null>(null);
@@ -59,7 +64,6 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
       setLoading(false);
     }
   }, [brandId]);
-
   useEffect(() => {
     load();
   }, [load]);
@@ -73,8 +77,9 @@ export function QueryFanoutTab({ brandId }: { brandId: string }) {
     try {
       await trackFanoutQuery(brandId, query);
       toast.success('Added as a tracked prompt');
-      setPage(1);
       await load();
+      setPage(1);
+      await onTracked?.();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to track this query');
     } finally {

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -619,7 +619,7 @@ export default function PromptsPage() {
 
         {/* ─── Query Fan-out tab ───────────────────────────────────────── */}
         <TabsContent value="fanout" className="mt-4">
-          {activeBrandId && <QueryFanoutTab brandId={activeBrandId} />}
+          {activeBrandId && <QueryFanoutTab brandId={activeBrandId} onTracked={loadData} />}
         </TabsContent>
 
         {/* ─── Insights tab ────────────────────────────────────────────── */}


### PR DESCRIPTION
## Summary

Refresh the parent Prompts page after successfully tracking a Query Fan-out sub-query.

This PR adds an optional `onTracked` callback to `QueryFanoutTab` and invokes it after a successful `trackFanoutQuery` operation. The parent `Prompts` page passes its existing `loadData` function as the callback, ensuring the **All Prompts** list and related metrics are refreshed immediately without requiring a manual page reload.

## Related issue

Closes #345

## Type of change

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`) *(warnings only, no errors)*
- [ ] `yarn typecheck` passes (requires project environment setup)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR