### PR TITLE
feat(prompts): Query Fan-out — By prompt grouped view with expandable…

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -528,3 +528,86 @@ INSERT INTO public.prompt_result_shopping_cards (
 )
 ON CONFLICT (id) DO NOTHING;
 
+-- ─── Query Fan-out seed data ──────────────────────────────────────────────────
+-- Populates search_queries on copilot-web and perplexity-web prompt_results so
+-- the Query Fan-out tab has data to display locally. Each item mirrors the real
+-- shape: { query, engine?, source_platform }.
+
+-- Prompt 801: "What are the best coffee subscription services in 2026?"
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "best coffee subscription services 2026", "source_platform": "copilot-web"},
+  {"query": "coffee subscription box comparison", "source_platform": "copilot-web"},
+  {"query": "top rated coffee subscription 2026", "source_platform": "copilot-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888801' AND platform = 'copilot-web';
+
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "best coffee subscription services 2026", "engine": "web", "source_platform": "perplexity-web"},
+  {"query": "top rated monthly coffee boxes", "engine": "web", "source_platform": "perplexity-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888801' AND platform = 'perplexity-web';
+
+-- Prompt 802: "Which specialty coffee subscriptions ship internationally?"
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "international coffee subscription shipping", "source_platform": "copilot-web"},
+  {"query": "specialty coffee worldwide delivery", "source_platform": "copilot-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888802' AND platform = 'copilot-web';
+
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "international coffee subscription shipping", "engine": "web", "source_platform": "perplexity-web"},
+  {"query": "worldwide coffee delivery subscription", "engine": "web", "source_platform": "perplexity-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888802' AND platform = 'perplexity-web';
+
+-- Prompt 803: "Best monthly coffee bean subscription for offices"
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "office coffee subscription plans", "source_platform": "copilot-web"},
+  {"query": "bulk coffee beans subscription for teams", "source_platform": "copilot-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888803' AND platform = 'copilot-web';
+
+-- Prompt 804: "Best espresso machines under $500?"
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "best espresso machine under 500", "source_platform": "copilot-web"},
+  {"query": "home espresso machine reviews 2026", "source_platform": "copilot-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888804' AND platform = 'copilot-web';
+
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "best espresso machine under 500", "engine": "web", "source_platform": "perplexity-web"},
+  {"query": "affordable espresso machine comparison", "engine": "web", "source_platform": "perplexity-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888804' AND platform = 'perplexity-web';
+
+-- Prompt 805: "Compare home espresso machines for beginners"
+-- "best espresso machine under 500" is shared with prompt 804 — demonstrates
+-- the cross-prompt grouping the "By prompt" view is designed to show.
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "best espresso machine for beginners", "source_platform": "copilot-web"},
+  {"query": "best espresso machine under 500", "source_platform": "copilot-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888805' AND platform = 'copilot-web';
+
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "best espresso machine for beginners", "engine": "web", "source_platform": "perplexity-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888805' AND platform = 'perplexity-web';
+
+-- Prompt 806: "Manual vs automatic espresso machine for home use"
+UPDATE public.prompt_results
+SET search_queries = '[
+  {"query": "manual vs automatic espresso machine", "source_platform": "copilot-web"},
+  {"query": "home espresso machine comparison 2026", "source_platform": "copilot-web"}
+]'::jsonb
+WHERE prompt_id = '88888888-8888-8888-8888-888888888806' AND platform = 'copilot-web';
+

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { Link } from '@/i18n/navigation';
 import {
@@ -8,6 +8,7 @@ import {
   trackFanoutQuery,
   classifyFanoutIntents,
   type QueryFanoutData,
+  type FanoutSubQuery,
 } from '@/lib/actions/fanout';
 import { PLATFORM_LABELS } from '@/config/platform-labels';
 import { INTENT_LABELS, INTENT_COLORS } from '@/config/intent-labels';
@@ -24,10 +25,17 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Check, Plus, Loader2, Search } from 'lucide-react';
+import { Check, ChevronRight, Plus, Loader2, Search } from 'lucide-react';
 
 function platformLabel(slug: string): string {
   return PLATFORM_LABELS[slug] ?? slug;
+}
+
+type View = 'frequency' | 'by-prompt';
+
+interface PromptGroup {
+  prompt: { id: string; text: string };
+  subQueries: FanoutSubQuery[];
 }
 
 type QueryFanoutTabProps = {
@@ -42,6 +50,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
   // Intent is keyed by the lower-cased sub-query (matches the server cache key).
   const [intents, setIntents] = useState<Record<string, string>>({});
   const [page, setPage] = useState(1);
+  const [view, setView] = useState<View>('frequency');
   const PAGE_SIZE = 10;
 
   const load = useCallback(async () => {
@@ -72,6 +81,21 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
     setPage(1);
   }, [brandId]);
 
+  // Invert sub-query → prompts into prompt → sub-queries for the "By prompt" view.
+  const byPrompt = useMemo<PromptGroup[]>(() => {
+    if (!data) return [];
+    const map = new Map<string, PromptGroup>();
+    for (const sq of data.subQueries) {
+      for (const p of sq.sourcedPrompts) {
+        if (!map.has(p.id)) {
+          map.set(p.id, { prompt: p, subQueries: [] });
+        }
+        map.get(p.id)!.subQueries.push(sq);
+      }
+    }
+    return [...map.values()].sort((a, b) => b.subQueries.length - a.subQueries.length);
+  }, [data]);
+
   async function handleTrack(query: string) {
     setAddingKey(query.toLowerCase());
     try {
@@ -87,14 +111,44 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
     }
   }
 
+  const isEmpty = !data || data.subQueries.length === 0;
+
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-sm font-medium">High frequency</CardTitle>
+        <div className="flex items-center justify-between gap-4">
+          <CardTitle className="text-sm font-medium">Query Fan-out</CardTitle>
+          {!loading && !isEmpty && (
+            <div className="flex rounded-md border p-0.5">
+              <button
+                className={cn(
+                  'rounded px-3 py-1 text-xs font-medium transition-colors',
+                  view === 'frequency'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                onClick={() => setView('frequency')}
+              >
+                High frequency
+              </button>
+              <button
+                className={cn(
+                  'rounded px-3 py-1 text-xs font-medium transition-colors',
+                  view === 'by-prompt'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                onClick={() => setView('by-prompt')}
+              >
+                By prompt
+              </button>
+            </div>
+          )}
+        </div>
         <p className="text-xs text-muted-foreground">
-          The sub-queries answer engines actually ran while building your answers (last 30 days) —
-          observed, never predicted. Sorted by how often they were searched. Track any of them with
-          the <span className="font-medium">+</span> to measure its own visibility.
+          {view === 'by-prompt'
+            ? 'Your tracked prompts grouped by the sub-queries their answers actually triggered — expand a prompt to see its observed fan-out.'
+            : 'The sub-queries answer engines actually ran while building your answers (last 30 days) — observed, never predicted. Sorted by how often they were searched. Track any of them with the + to measure its own visibility.'}
         </p>
       </CardHeader>
       <CardContent>
@@ -104,120 +158,283 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
               <Skeleton key={i} className="h-11 w-full" />
             ))}
           </div>
-        ) : !data || data.subQueries.length === 0 ? (
-          <div className="flex flex-col items-center gap-2 py-12 text-center">
-            <Search className="h-8 w-8 text-muted-foreground/50" />
-            <p className="text-sm font-medium">No fan-out captured yet</p>
-            <p className="max-w-md text-xs text-muted-foreground">
-              Fan-out is emitted mostly by <span className="font-medium">Copilot</span> and{' '}
-              <span className="font-medium">Perplexity</span>, and only for some queries. Once those
-              platforms run for your prompts, the observed sub-queries will appear here.
-            </p>
-          </div>
+        ) : isEmpty ? (
+          <EmptyState />
+        ) : view === 'frequency' ? (
+          <HighFrequencyView
+            subQueries={data.subQueries}
+            intents={intents}
+            addingKey={addingKey}
+            page={page}
+            pageSize={PAGE_SIZE}
+            onPageChange={setPage}
+            onTrack={handleTrack}
+          />
         ) : (
-          <>
-            {(() => {
-              const totalPages = Math.ceil(data.subQueries.length / PAGE_SIZE);
-              const pageRows = data.subQueries.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
-              return (
-                <>
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Sub-query</TableHead>
-                        <TableHead className="w-[160px]">Engine</TableHead>
-                        <TableHead className="w-[120px] text-right">Times searched</TableHead>
-                        <TableHead className="w-[220px]">Sourced prompts</TableHead>
-                        <TableHead className="w-[130px]">Intent</TableHead>
-                        <TableHead className="w-[64px] text-right">Track</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {pageRows.map((sq) => {
-                        const key = sq.query.toLowerCase();
-                        const adding = addingKey === key;
-                        return (
-                          <TableRow key={key}>
-                            <TableCell className="font-medium">{sq.query}</TableCell>
-                            <TableCell>
-                              <div className="flex flex-wrap gap-1">
-                                {sq.engines.map((e) => (
-                                  <Badge key={e} variant="secondary" className="text-[10px]">
-                                    {platformLabel(e)}
-                                  </Badge>
-                                ))}
-                              </div>
-                            </TableCell>
-                            <TableCell className="text-right tabular-nums">
-                              {sq.timesSearched}
-                            </TableCell>
-                            <TableCell>
-                              <SourcedPrompts prompts={sq.sourcedPrompts} />
-                            </TableCell>
-                            <TableCell>
-                              <IntentBadge intent={intents[key]} />
-                            </TableCell>
-                            <TableCell className="text-right">
-                              {sq.tracked ? (
-                                <Badge
-                                  variant="outline"
-                                  className="gap-1 text-[10px] text-emerald-600 dark:text-emerald-400"
-                                  render={
-                                    sq.trackedPromptId ? (
-                                      <Link href={`/dashboard/prompts/${sq.trackedPromptId}`} />
-                                    ) : undefined
-                                  }
-                                >
-                                  <Check className="h-3 w-3" />
-                                  Tracked
-                                </Badge>
-                              ) : (
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-7 w-7"
-                                  disabled={adding}
-                                  onClick={() => handleTrack(sq.query)}
-                                  aria-label={`Track "${sq.query}" as a prompt`}
-                                >
-                                  {adding ? (
-                                    <Loader2 className="h-4 w-4 animate-spin" />
-                                  ) : (
-                                    <Plus className="h-4 w-4" />
-                                  )}
-                                </Button>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                  {totalPages > 1 && (
-                    <div className="flex items-center justify-center gap-1 pt-4">
-                      {Array.from({ length: totalPages }, (_, i) => {
-                        const p = i + 1;
-                        return (
-                          <Button
-                            key={p}
-                            variant={page === p ? 'default' : 'ghost'}
-                            size="sm"
-                            className="h-7 w-7 p-0 text-xs"
-                            onClick={() => setPage(p)}
-                          >
-                            {p}
-                          </Button>
-                        );
-                      })}
-                    </div>
-                  )}
-                </>
-              );
-            })()}
-          </>
+          <ByPromptView
+            groups={byPrompt}
+            intents={intents}
+            addingKey={addingKey}
+            onTrack={handleTrack}
+          />
         )}
       </CardContent>
     </Card>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-2 py-12 text-center">
+      <Search className="h-8 w-8 text-muted-foreground/50" />
+      <p className="text-sm font-medium">No fan-out captured yet</p>
+      <p className="max-w-md text-xs text-muted-foreground">
+        Fan-out is emitted mostly by <span className="font-medium">Copilot</span> and{' '}
+        <span className="font-medium">Perplexity</span>, and only for some queries. Once those
+        platforms run for your prompts, the observed sub-queries will appear here.
+      </p>
+    </div>
+  );
+}
+
+function HighFrequencyView({
+  subQueries,
+  intents,
+  addingKey,
+  page,
+  pageSize,
+  onPageChange,
+  onTrack,
+}: {
+  subQueries: FanoutSubQuery[];
+  intents: Record<string, string>;
+  addingKey: string | null;
+  page: number;
+  pageSize: number;
+  onPageChange: (p: number) => void;
+  onTrack: (query: string) => void;
+}) {
+  const totalPages = Math.ceil(subQueries.length / pageSize);
+  const pageRows = subQueries.slice((page - 1) * pageSize, page * pageSize);
+
+  return (
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Sub-query</TableHead>
+            <TableHead className="w-[160px]">Engine</TableHead>
+            <TableHead className="w-[120px] text-right">Times searched</TableHead>
+            <TableHead className="w-[220px]">Sourced prompts</TableHead>
+            <TableHead className="w-[130px]">Intent</TableHead>
+            <TableHead className="w-[64px] text-right">Track</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {pageRows.map((sq) => {
+            const key = sq.query.toLowerCase();
+            return (
+              <TableRow key={key}>
+                <TableCell className="font-medium">{sq.query}</TableCell>
+                <TableCell>
+                  <EngineBadges engines={sq.engines} />
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{sq.timesSearched}</TableCell>
+                <TableCell>
+                  <SourcedPrompts prompts={sq.sourcedPrompts} />
+                </TableCell>
+                <TableCell>
+                  <IntentBadge intent={intents[key]} />
+                </TableCell>
+                <TableCell className="text-right">
+                  <TrackCell sq={sq} adding={addingKey === key} onTrack={onTrack} />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-1 pt-4">
+          {Array.from({ length: totalPages }, (_, i) => {
+            const p = i + 1;
+            return (
+              <Button
+                key={p}
+                variant={page === p ? 'default' : 'ghost'}
+                size="sm"
+                className="h-7 w-7 p-0 text-xs"
+                onClick={() => onPageChange(p)}
+              >
+                {p}
+              </Button>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}
+
+function ByPromptView({
+  groups,
+  intents,
+  addingKey,
+  onTrack,
+}: {
+  groups: PromptGroup[];
+  intents: Record<string, string>;
+  addingKey: string | null;
+  onTrack: (query: string) => void;
+}) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  function toggle(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[28px]" />
+          <TableHead>Prompt</TableHead>
+          <TableHead className="w-[110px] text-right">Sub-queries</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {groups.map(({ prompt, subQueries }) => {
+          const isOpen = expanded.has(prompt.id);
+          return (
+            <>
+              <TableRow
+                key={prompt.id}
+                className="cursor-pointer select-none"
+                onClick={() => toggle(prompt.id)}
+              >
+                <TableCell className="pr-0">
+                  <ChevronRight
+                    className={cn(
+                      'h-4 w-4 text-muted-foreground transition-transform duration-150',
+                      isOpen && 'rotate-90',
+                    )}
+                  />
+                </TableCell>
+                <TableCell className="font-medium">{prompt.text}</TableCell>
+                <TableCell className="text-right">
+                  <Badge variant="secondary" className="tabular-nums text-[10px]">
+                    {subQueries.length}
+                  </Badge>
+                </TableCell>
+              </TableRow>
+              {isOpen && (
+                <TableRow key={`${prompt.id}-expanded`} className="hover:bg-transparent">
+                  <TableCell />
+                  <TableCell colSpan={2} className="pb-3 pt-0">
+                    <div className="rounded-md border">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Sub-query</TableHead>
+                            <TableHead className="w-[160px]">Engine</TableHead>
+                            <TableHead className="w-[120px] text-right">Times searched</TableHead>
+                            <TableHead className="w-[130px] pl-6">Intent</TableHead>
+                            <TableHead className="w-[64px] text-right">Track</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {subQueries.map((sq) => {
+                            const key = sq.query.toLowerCase();
+                            return (
+                              <TableRow key={key} className="align-middle">
+                                <TableCell className="align-middle font-medium">
+                                  {sq.query}
+                                </TableCell>
+                                <TableCell className="align-middle">
+                                  <EngineBadges engines={sq.engines} />
+                                </TableCell>
+                                <TableCell className="align-middle text-right tabular-nums">
+                                  {sq.timesSearched}
+                                </TableCell>
+                                <TableCell className="align-middle pl-6">
+                                  <IntentBadge intent={intents[key]} />
+                                </TableCell>
+                                <TableCell className="align-middle text-right">
+                                  <TrackCell sq={sq} adding={addingKey === key} onTrack={onTrack} />
+                                </TableCell>
+                              </TableRow>
+                            );
+                          })}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
+            </>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+function EngineBadges({ engines }: { engines: string[] }) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {engines.map((e) => (
+        <Badge key={e} variant="secondary" className="text-[10px]">
+          {platformLabel(e)}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function TrackCell({
+  sq,
+  adding,
+  onTrack,
+}: {
+  sq: FanoutSubQuery;
+  adding: boolean;
+  onTrack: (query: string) => void;
+}) {
+  if (sq.tracked) {
+    return (
+      <Badge
+        variant="outline"
+        className="gap-1 text-[10px] text-emerald-600 dark:text-emerald-400"
+        render={
+          sq.trackedPromptId ? (
+            <Link href={`/dashboard/prompts/${sq.trackedPromptId}`} />
+          ) : undefined
+        }
+      >
+        <Check className="h-3 w-3" />
+        Tracked
+      </Badge>
+    );
+  }
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-7 w-7"
+      disabled={adding}
+      onClick={(e) => {
+        e.stopPropagation();
+        onTrack(sq.query);
+      }}
+      aria-label={`Track "${sq.query}" as a prompt`}
+    >
+      {adding ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+    </Button>
   );
 }
 

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { Link } from '@/i18n/navigation';
 import {
@@ -311,12 +311,8 @@ function ByPromptView({
         {groups.map(({ prompt, subQueries }) => {
           const isOpen = expanded.has(prompt.id);
           return (
-            <>
-              <TableRow
-                key={prompt.id}
-                className="cursor-pointer select-none"
-                onClick={() => toggle(prompt.id)}
-              >
+            <Fragment key={prompt.id}>
+              <TableRow className="cursor-pointer select-none" onClick={() => toggle(prompt.id)}>
                 <TableCell className="pr-0">
                   <ChevronRight
                     className={cn(
@@ -376,7 +372,7 @@ function ByPromptView({
                   </TableCell>
                 </TableRow>
               )}
-            </>
+            </Fragment>
           );
         })}
       </TableBody>


### PR DESCRIPTION
## Summary

   On the Prompts page → Query Fan-out tab, the view showed a single flat list of sub-queries with no way to see which tracked prompts drove the most fan-out. Added a **By prompt** toggle that pivots the same data — one collapsible row per prompt, expanding to reveal the sub-queries that prompt's answers actually triggered. The "High frequency" flat list is unchanged; the two lenses share the tab via a segmented toggle.

   Data is derived client-side by inverting the existing `sourcedPrompts` array on each `FanoutSubQuery` — no new server action or DB columns required.

   Also adds fan-out seed data to `supabase/seed.sql` so the tab is populated on a local `db reset`.

   ## Related issue
   
   Closes #350 

   ## Type of change

   - [x] `feat` — New feature

   ## Checklist

   - [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
   - [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
   - [x] `yarn lint` passes (run from `web/`)
   - [x] `yarn format:check` passes (run from `web/`)
   - [x] Changes are focused — one concern per PR
