### PR TITLE
fix(prompts): remove Keywords and Multiplier columns from Prompt Volumes table

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -825,12 +825,7 @@ export default function PromptsPage() {
                     <TableHeader>
                       <TableRow>
                         <TableHead className="pl-6">Prompt</TableHead>
-                        <ColHead
-                          className="text-center"
-                          tooltip="Number of keywords extracted from this prompt by AI analysis."
-                        >
-                          Keywords
-                        </ColHead>
+
                         <ColHead
                           className="text-right"
                           tooltip="Total monthly Google search volume across all extracted keywords."
@@ -849,12 +844,6 @@ export default function PromptsPage() {
                         >
                           Intent
                         </ColHead>
-                        <ColHead
-                          className="text-right pr-6"
-                          tooltip="The AI adoption multiplier applied to Google volume."
-                        >
-                          Multiplier
-                        </ColHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -863,9 +852,7 @@ export default function PromptsPage() {
                           <TableCell className="pl-6 font-medium text-sm max-w-[280px]">
                             <span className="line-clamp-1">{row.promptText}</span>
                           </TableCell>
-                          <TableCell className="text-center text-xs text-muted-foreground tabular-nums">
-                            {row.keywords.length}
-                          </TableCell>
+
                           <TableCell className="text-right tabular-nums text-sm text-muted-foreground">
                             {row.totalGoogleVolume.toLocaleString()}
                           </TableCell>
@@ -882,9 +869,6 @@ export default function PromptsPage() {
                             >
                               {INTENT_LABELS[row.intent] || row.intent}
                             </Badge>
-                          </TableCell>
-                          <TableCell className="text-right pr-6 text-xs text-muted-foreground tabular-nums">
-                            ×{row.aiVolumeMultiplier}
                           </TableCell>
                         </TableRow>
                       ))}


### PR DESCRIPTION
## Summary

- Removed the `Keywords` column from the Prompt Volumes table.
- Removed the `Multiplier` column from the Prompt Volumes table.
- Left the underlying data and AI volume calculations unchanged.

## Testing

- Verified the table now displays:
  - Prompt
  - Google Vol.
  - Est. AI Vol.
  - Intent
- No changes to KPI cards or AI volume calculations.