### PR TITLE
feat(insights): show query fan-out on result detail

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/[id]/page.tsx
@@ -9,27 +9,18 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, ExternalLink, MessageSquareText, Quote, Eye, Clock } from 'lucide-react';
+import {
+  ArrowLeft,
+  ExternalLink,
+  MessageSquareText,
+  Quote,
+  Eye,
+  Clock,
+  Search,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
-
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI Overview',
-  'google-ai-mode': 'Google AI Mode',
-  'chatgpt-web': 'ChatGPT',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'perplexity-web': 'Perplexity',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
-};
+import { PLATFORM_LABELS } from '@/config/platform-labels';
+import { formatSearchQuerySource, visibleSearchQueries } from './query-fanout';
 
 function SentimentBadge({ sentiment }: { sentiment: 'positive' | 'neutral' | 'negative' }) {
   return (
@@ -103,6 +94,8 @@ export default function ResultDetailPage() {
       </div>
     );
   }
+
+  const searchQueries = visibleSearchQueries(result.searchQueries);
 
   return (
     <div className="space-y-6 p-2 sm:p-6 max-w-5xl mx-auto">
@@ -199,6 +192,30 @@ export default function ResultDetailPage() {
                     <p className="text-muted-foreground text-xs truncate">{cite.url}</p>
                   </div>
                 </a>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Query fan-out */}
+      {searchQueries.length > 0 && (
+        <Card>
+          <CardContent className="p-6">
+            <h2 className="text-sm font-medium mb-4">Query fan-out ({searchQueries.length})</h2>
+            <div className="space-y-2">
+              {searchQueries.map((item, i) => (
+                <div key={`${item.query}-${i}`} className="rounded-lg border px-4 py-3 text-sm">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 items-start gap-3">
+                      <Search className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+                      <p className="min-w-0 break-words font-medium">{item.query.trim()}</p>
+                    </div>
+                    <Badge variant="secondary" className="w-fit shrink-0 text-xs">
+                      {formatSearchQuerySource(item, result.platform)}
+                    </Badge>
+                  </div>
+                </div>
               ))}
             </div>
           </CardContent>

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/[id]/query-fanout.test.ts
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/[id]/query-fanout.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatSearchQuerySource, visibleSearchQueries } from './query-fanout';
+
+describe('visibleSearchQueries', () => {
+  it('keeps only entries with visible query text', () => {
+    expect(
+      visibleSearchQueries([
+        { query: 'best answer engine monitoring tools' },
+        { query: '   ' },
+      ]).map((item) => item.query),
+    ).toEqual(['best answer engine monitoring tools']);
+  });
+});
+
+describe('formatSearchQuerySource', () => {
+  it('uses platform labels and keeps the Perplexity engine label when present', () => {
+    expect(
+      formatSearchQuerySource(
+        {
+          query: 'best answer engine monitoring tools',
+          engine: 'sonar-pro',
+          source_platform: 'perplexity-web',
+        },
+        'chatgpt-web',
+      ),
+    ).toBe('Perplexity - sonar-pro');
+  });
+
+  it('falls back to the result platform when an item has no source platform', () => {
+    expect(formatSearchQuerySource({ query: 'monitoring tools' }, 'chatgpt-web')).toBe('ChatGPT');
+  });
+});

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/[id]/query-fanout.ts
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/[id]/query-fanout.ts
@@ -1,0 +1,15 @@
+import { PLATFORM_LABELS } from '@/config/platform-labels';
+import type { AIPlatform, ObservedSearchQuery } from '@/types';
+
+export function visibleSearchQueries(items: ObservedSearchQuery[] | undefined) {
+  return (items ?? []).filter((item) => typeof item.query === 'string' && item.query.trim());
+}
+
+export function formatSearchQuerySource(item: ObservedSearchQuery, fallbackPlatform: AIPlatform) {
+  const sourcePlatform = item.source_platform || fallbackPlatform;
+  const platformLabel = PLATFORM_LABELS[sourcePlatform] ?? sourcePlatform;
+  const engine = typeof item.engine === 'string' ? item.engine.trim() : '';
+  const isPerplexity = sourcePlatform.includes('perplexity');
+
+  return isPerplexity && engine ? `${platformLabel} - ${engine}` : platformLabel;
+}

--- a/web/src/lib/actions/tracking.test.ts
+++ b/web/src/lib/actions/tracking.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const promptResultRow = {
+  id: 'result-id',
+  prompt_id: 'prompt-id',
+  brand_id: 'brand-id',
+  platform: 'perplexity-web',
+  response: 'AI response',
+  citations: [],
+  mention_count: 0,
+  citation_count: 0,
+  sentiment: 'neutral',
+  visibility_score: 0,
+  model_used: null,
+  region: null,
+  competitor_mentions: null,
+  search_queries: [
+    {
+      query: 'best answer engine monitoring tools',
+      engine: 'sonar-pro',
+      source_platform: 'perplexity-web',
+    },
+  ],
+  created_at: '2026-07-07T00:00:00.000Z',
+};
+
+function fakeQueryBuilder(table: string) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    neq: () => builder,
+    single: async () => {
+      if (table === 'prompt_results') return { data: promptResultRow, error: null };
+      if (table === 'prompts') {
+        return {
+          data: {
+            text: 'Which answer engine monitor should I use?',
+            category: null,
+            topic_id: null,
+          },
+          error: null,
+        };
+      }
+      return { data: null, error: null };
+    },
+  };
+
+  return builder;
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    from: (table: string) => fakeQueryBuilder(table),
+  }),
+}));
+
+vi.mock('@/lib/actions/topic', () => ({
+  getTopicById: vi.fn(),
+}));
+
+describe('getPromptResultById', () => {
+  it('carries observed search queries through to prompt result details', async () => {
+    const { getPromptResultById } = await import('./tracking');
+
+    await expect(getPromptResultById('result-id')).resolves.toMatchObject({
+      id: 'result-id',
+      searchQueries: promptResultRow.search_queries,
+    });
+  });
+});

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -9,6 +9,7 @@ import type {
   Citation,
   CompetitorMention,
   Topic,
+  ObservedSearchQuery,
 } from '@/types';
 import { API_BASE_URL } from '@/config/api';
 import { getTopicById } from '@/lib/actions/topic';
@@ -52,6 +53,9 @@ function mapResultRow(row: Record<string, unknown>): PromptResult {
     modelUsed: (row.model_used as string | null) ?? undefined,
     region: (row.region as string | null) ?? undefined,
     competitorMentions: (row.competitor_mentions as CompetitorMention[] | null) ?? undefined,
+    searchQueries: Array.isArray(row.search_queries)
+      ? (row.search_queries as ObservedSearchQuery[])
+      : [],
     createdAt: row.created_at as string,
   };
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -108,6 +108,12 @@ export interface Citation {
   endIndex: number;
 }
 
+export interface ObservedSearchQuery {
+  query: string;
+  engine?: string | null;
+  source_platform?: string | null;
+}
+
 export interface PromptResult {
   id: string;
   promptId: string;
@@ -122,6 +128,7 @@ export interface PromptResult {
   modelUsed?: string;
   region?: string;
   competitorMentions?: CompetitorMention[];
+  searchQueries?: ObservedSearchQuery[];
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

- carry `prompt_results.search_queries` through to `PromptResult.searchQueries`
- render a `Query fan-out` section below Citations on the result detail page
- add helper coverage for visible queries, platform labels, and Perplexity engine labels

## Validation

- `npx --yes vitest@3.0.0 run src/lib/actions/tracking.test.ts 'src/app/[locale]/(dashboard)/dashboard/insights/[id]/query-fanout.test.ts' --config vitest.local.config.mjs`
- `npx --yes prettier@3.8.3 --check src/types/index.ts src/lib/actions/tracking.ts src/lib/actions/tracking.test.ts 'src/app/[locale]/(dashboard)/dashboard/insights/[id]/page.tsx' 'src/app/[locale]/(dashboard)/dashboard/insights/[id]/query-fanout.ts' 'src/app/[locale]/(dashboard)/dashboard/insights/[id]/query-fanout.test.ts'`

Note: the Vitest command used a temporary local config for alias resolution because this checkout did not have dependencies installed. `yarn install --frozen-lockfile` repeatedly stalled while fetching packages in my local environment, so I could not run the full project test/typecheck commands locally.

Closes #361
