### PR TITLE
docs(readme): add official website link under the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 # Ansvisor - Open-source AI Visibility Platform for AI Search
 
-**Ansvisor is an open-source AI Visibility platform for AI Search.** Official website: **[https://www.ansvisor.com](https://www.ansvisor.com)**
+Official website: **[https://www.ansvisor.com](https://www.ansvisor.com)**
 
 The search landscape is transforming fast. Buyers are moving from traditional search engines to AI platforms like ChatGPT, Claude, Gemini, Google AI Mode, etc.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 # Ansvisor - Open-source AI Visibility Platform for AI Search
 
+**Ansvisor is an open-source AI Visibility platform for AI Search.** Official website: **[https://www.ansvisor.com](https://www.ansvisor.com)**
+
 The search landscape is transforming fast. Buyers are moving from traditional search engines to AI platforms like ChatGPT, Claude, Gemini, Google AI Mode, etc.
 
 At Ansvisor, we are building the open future of AI Visibility and AI Search Optimization (AEO/GEO) to help brands claim their spot in AI-generated answers.


### PR DESCRIPTION
## Summary

Adds a prominent one-line **Official website** link right below the README's H1:

> **Ansvisor is an open-source AI Visibility platform for AI Search.** Official website: **[https://www.ansvisor.com](https://www.ansvisor.com)**

## Why

The GitHub repo currently ranks at the top of Google for the project name, above the official site. Placing an explicit, keyword-rich, crawlable link to https://www.ansvisor.com in the README's most authoritative spot (directly under the H1) helps surface the official website alongside the repo in search results.

## Type of change

- [x] `docs` — Documentation only

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Changes are focused — one concern per PR