### PR TITLE
feat(web): render site audit results in agent chat

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, type UIMessage } from 'ai';
 import type { AgentChartSpec } from '@/components/agent/agent-chart';
+import { AuditResultCard } from '@/components/audit/audit-result-card';
+import type { AgentAuditSpec } from '@/components/agent/agent-chart';
 import dynamic from 'next/dynamic';
 import { Skeleton } from '@/components/ui/skeleton';
 const AgentChart = dynamic(
@@ -446,6 +448,9 @@ function MessageBubble({ message }: { message: UIMessage }) {
           if (part.type === 'tool-render_chart') {
             return <ChartToolPart key={i} part={part} />;
           }
+          if (part.type === 'tool-render_audit') {
+            return <AuditToolPart key={i} part={part} />;
+          }
           if (part.type.startsWith('tool-')) {
             return <ToolCallDisclosure key={i} part={part} />;
           }
@@ -604,6 +609,37 @@ function ChartToolPart({ part }: { part: UIMessage['parts'][number] }) {
   }
 
   return <AgentChart spec={spec} />;
+}
+function AuditToolPart({ part }: { part: UIMessage['parts'][number] }) {
+  const toolPart = part as unknown as {
+    type: string;
+    state?: 'input-streaming' | 'input-available' | 'output-available' | 'output-error';
+    input?: AgentAuditSpec;
+    output?: AgentAuditSpec;
+    errorText?: string;
+  };
+
+  if (toolPart.state === 'output-error') {
+    return (
+      <div className="my-2 rounded-md border bg-destructive/10 px-2 py-1 text-xs text-destructive">
+        <span className="font-mono">render_audit</span>
+        {toolPart.errorText && <span className="ml-2">{toolPart.errorText}</span>}
+      </div>
+    );
+  }
+
+  const audit = toolPart.output ?? toolPart.input;
+
+  if (!audit) {
+    return (
+      <div className="my-2 inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        <span className="font-mono">render_audit</span>
+      </div>
+    );
+  }
+
+  return <AuditResultCard audit={audit} />;
 }
 
 function EmptyState() {

--- a/web/src/components/agent/agent-chart.tsx
+++ b/web/src/components/agent/agent-chart.tsx
@@ -34,6 +34,15 @@ export interface AgentChartSpec {
   labelKey?: string;
 }
 
+export interface AgentAuditSpec {
+  url: string;
+  totalScore: number | null;
+  categoryScores: Record<string, unknown>;
+  recommendations: unknown[];
+  signalsEvaluated: number | null;
+  signalsTotal: number | null;
+}
+
 // Palette pulled from globals.css (`--chart-1` … `--chart-5`). Wraps
 // around for charts with more than 5 series — fine in practice because
 // the agent rarely emits beyond that, and even if it does the wrap is

--- a/web/src/components/audit/audit-report.tsx
+++ b/web/src/components/audit/audit-report.tsx
@@ -39,7 +39,7 @@ export function scoreColor(score: number | null): string {
   return 'text-destructive';
 }
 
-function barColor(score: number | null): string {
+export function barColor(score: number | null): string {
   if (score === null) return 'bg-muted';
   if (score >= 0.7) return 'bg-green-600';
   if (score >= 0.4) return 'bg-amber-500';
@@ -67,7 +67,7 @@ function gradeKey(score: number | null): 'good' | 'needsWork' | 'poor' | null {
   return 'poor';
 }
 
-function ScoreGauge({ score }: { score: number | null }) {
+export function ScoreGauge({ score }: { score: number | null }) {
   const p = pct(score) ?? 0;
   const radius = 52;
   const circ = 2 * Math.PI * radius;

--- a/web/src/components/audit/audit-result-card.tsx
+++ b/web/src/components/audit/audit-result-card.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { AgentAuditSpec } from '@/components/agent/agent-chart';
+import type { AuditRecommendation, CategoryScore } from '@/lib/actions/audits';
+import { CATEGORY_META, ScoreGauge, pct, barColor } from '@/components/audit/audit-report';
+import { cn } from '@/lib/utils';
+
+export function AuditResultCard({ audit }: { audit: AgentAuditSpec }) {
+  // The render_audit tool schema uses z.unknown(), so narrow the types here.
+  const categoryScores = audit.categoryScores as Record<string, CategoryScore>;
+  const recommendations = audit.recommendations as AuditRecommendation[];
+
+  return (
+    <div className="my-3 space-y-5 rounded-lg border bg-card p-4">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <ScoreGauge score={audit.totalScore} />
+
+        <div className="min-w-0 flex-1 space-y-2">
+          <h3 className="text-sm font-semibold">Site Audit</h3>
+
+          <p className="break-all text-xs text-muted-foreground">{audit.url}</p>
+
+          <p className="text-xs text-muted-foreground">
+            {audit.signalsEvaluated ?? '—'} / {audit.signalsTotal ?? '—'} signals evaluated
+          </p>
+        </div>
+      </div>
+
+      {/* Category breakdown */}
+      <div className="space-y-3">
+        <h4 className="text-sm font-medium">Category breakdown</h4>
+
+        {CATEGORY_META.map((category) => {
+          const score = categoryScores[category.key]?.score ?? null;
+          const percentage = pct(score);
+
+          return (
+            <div key={category.key}>
+              <div className="mb-1 flex items-center justify-between text-xs">
+                <span>{category.label}</span>
+
+                <span className="text-muted-foreground">
+                  {percentage === null ? 'n/a' : `${percentage}/100`}
+                </span>
+              </div>
+
+              <div className="h-2 overflow-hidden rounded-full bg-muted">
+                <div
+                  className={cn('h-full rounded-full transition-all', barColor(score))}
+                  style={{
+                    width: `${percentage ?? 0}%`,
+                  }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Recommendations */}
+      {recommendations.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium">Top recommendations</h4>
+
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            {recommendations.slice(0, 3).map((rec, index) => (
+              <li key={`${rec.signalKey}-${index}`} className="flex gap-2">
+                <span>•</span>
+                <span>{rec.recommendation}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/agent/system-prompt.ts
+++ b/web/src/lib/agent/system-prompt.ts
@@ -45,6 +45,7 @@ You have these tools, all scoped to the authenticated user's organization:
 - **get_site_audit** — read a Site Audit's result (status, total + per-category scores, signals, AI fix recommendations) by id. No credit consumed.
 - **list_site_audits** — list a brand's recent audits (id, url, status, score, date) to find a past one by url/date. No credit consumed.
 - **render_chart** — render a chart inline in the chat (line / bar / pie). Call this *after* a data tool when the answer is meaningfully easier to read as a chart than as a sentence. See "Visualization" below.
+- **render_audit** — render a completed Site Audit inline in the chat as an audit card. Call this after \`get_site_audit\` returns a completed audit so the user sees the score, category breakdown, and recommendations instead of raw JSON.
 
 ## Visualization (render_chart)
 
@@ -59,6 +60,17 @@ Hard rules:
 - Always call the data tool first, then \`render_chart\`. Never call \`render_chart\` without real data in hand.
 - Pass the values straight from the data tool's response. Do not reformat numbers, invent missing rows, or "round to make the chart cleaner".
 - After the chart renders, write 1–2 sentences interpreting it: the slope, the leader, the surprise. Don't summarize a 12-point series row-by-row.
+
+## Site Audit Rendering (render_audit)
+
+After \`get_site_audit\` returns a completed audit, call \`render_audit\` to display the audit result inline instead of exposing the raw tool output.
+
+Hard rules:
+
+- Always call \`get_site_audit\` first, then \`render_audit\`. Never call \`render_audit\` without a completed audit result.
+- Pass the values directly from \`get_site_audit\`.
+- Never invent or recalculate scores.
+- After the audit card renders, briefly summarize the key findings and top recommendations.
 
 ## Rules
 

--- a/web/src/lib/agent/tools.ts
+++ b/web/src/lib/agent/tools.ts
@@ -281,5 +281,23 @@ export function buildAgentTools(auth: McpAuthContext) {
       }),
       execute: async (args) => args,
     }),
+    render_audit: tool({
+      description:
+        'Render a Site Audit result inline in the chat. Call this AFTER you have the completed audit data from get_site_audit (typically after running run_site_audit and polling until completion). Pass the audit result directly from the previous tool result — never invent or recalculate scores. The tool only echoes the audit data back; the UI renders the audit card.',
+      inputSchema: z.object({
+        url: z.string().describe('The URL that was audited.'),
+
+        totalScore: z.number().nullable().describe('The overall Site Audit score.'),
+
+        categoryScores: z.record(z.string(), z.unknown()).describe('Per-category audit scores.'),
+
+        recommendations: z.array(z.unknown()).describe('AI-generated audit recommendations.'),
+
+        signalsEvaluated: z.number().nullable().describe('Number of audit signals evaluated.'),
+
+        signalsTotal: z.number().nullable().describe('Total number of audit signals.'),
+      }),
+      execute: async (args) => args,
+    }),
   };
 }


### PR DESCRIPTION
## Summary

Adds inline rendering support for completed Site Audit results in the in-product agent chat.

### Changes
- Added a new `render_audit` agent tool that renders completed Site Audit results inline.
- Added `AgentAuditSpec` for the audit rendering payload.
- Added an `AuditToolPart` renderer to handle `tool-render_audit` responses.
- Added an `AuditResultCard` component that reuses the existing Site Audit UI (score gauge, category breakdown, and recommendations).
- Updated the agent system prompt to instruct the model to call `render_audit` after a completed `get_site_audit` response.

## Related issue

Closes #272 

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore`/, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
