### PR TITLE
chore(web): rename sidebar nav labels to Content and Visibility

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -18,11 +18,11 @@
   "nav": {
     "overview": "Overview",
     "agent": "Agent",
-    "insights": "Answer Engine Insights",
+    "insights": "Visibility",
     "traffic": "AI Traffic Analytics",
     "prompts": "Prompts",
     "topics": "Topics",
-    "content": "Content Optimization",
+    "content": "Content",
     "audit": "Site Audit",
     "competitors": "Competitors",
     "citations": "Citations",


### PR DESCRIPTION
## Summary

Renames two sidebar navigation labels for a cleaner, shorter nav:

- **Answer Engine Insights** → **Visibility**
- **Content Optimization** → **Content**

Only the `nav.*` translation keys in `web/messages/en.json` are changed — routes, page titles, and internal identifiers are untouched. The desktop sidebar and mobile nav both read from these keys, so both pick up the new labels.

## Related issue

N/A

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Run the web app and open the dashboard.
2. Check the sidebar: the Analytics group should show **Visibility** (formerly Answer Engine Insights) and the Optimization group should show **Content** (formerly Content Optimization).
3. Verify the same labels on the mobile nav (narrow viewport).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

Made with [Cursor](https://cursor.com)