### PR TITLE
fix(content): display user friendly error when sending with no webhoo…

### DIFF
--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -238,9 +238,7 @@ router.post('/bulk/send-webhook', async (req, res) => {
       .single();
 
     if (!webhookConfig) {
-      return res
-        .status(400)
-        .json({ error: 'No active webhook configured for this brand. Set up a webhook first.' });
+      return res.status(400).json({ error: 'No workflow connected' });
     }
 
     const { data: brand } = await supabaseAdmin
@@ -394,9 +392,7 @@ router.post('/:id/send-webhook', async (req, res) => {
       .single();
 
     if (!webhookConfig) {
-      return res
-        .status(400)
-        .json({ error: 'No active webhook configured for this brand. Set up a webhook first.' });
+      return res.status(400).json({ error: 'No workflow connected' });
     }
 
     const { data: brand } = await supabaseAdmin

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
@@ -117,13 +117,17 @@ export default function ContentDetailPage() {
   const handleSend = async () => {
     setSending(true);
     try {
-      await sendToWebhook(id);
-      toast.success('Sent to workflow!');
-      const updated = await getOpportunity(id);
-      setOpportunity(updated);
+      const result = await sendToWebhook(id);
+      if (result.success === false) {
+        toast.error(result.error);
+      } else {
+        toast.success('Sent to workflow!');
+        const updated = await getOpportunity(id);
+        setOpportunity(updated);
+      }
     } catch (err) {
       console.error('Send failed:', err);
-      toast.error(err instanceof Error ? err.message : 'Failed to send');
+      toast.error('Failed to send');
     } finally {
       setSending(false);
     }

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -267,12 +267,16 @@ export default function ContentPage() {
   const handleSendWebhook = async (id: string) => {
     setSendingId(id);
     try {
-      await sendToWebhook(id);
-      toast.success('Sent to workflow!');
-      await loadData(true);
+      const result = await sendToWebhook(id);
+      if (result.success === false) {
+        toast.error(result.error);
+      } else {
+        toast.success('Sent to workflow!');
+        await loadData(true);
+      }
     } catch (err) {
       console.error('Webhook send failed:', err);
-      toast.error(err instanceof Error ? err.message : 'Failed to send');
+      toast.error('Failed to send');
     } finally {
       setSendingId(null);
     }

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -297,12 +297,17 @@ export default function ContentPage() {
     setBulkSending(true);
     try {
       const result = await bulkSendToWebhook(Array.from(selectedIds));
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
       toast.success(`Sent ${result.sent} opportunities to workflow`);
       if (result.failed > 0) toast.error(`${result.failed} failed to send`);
       setSelectedIds(new Set());
       await loadData(true);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Bulk send failed');
+      console.error('Bulk webhook send failed:', err);
+      toast.error('Failed to send opportunities.');
     } finally {
       setBulkSending(false);
     }
@@ -630,9 +635,7 @@ export default function ContentPage() {
                         >
                           {t(
                             `impact.${opp.impact}` as
-                              | 'impact.high'
-                              | 'impact.medium'
-                              | 'impact.low',
+                              'impact.high' | 'impact.medium' | 'impact.low',
                           )}
                         </Badge>
                       </TableCell>

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -635,7 +635,9 @@ export default function ContentPage() {
                         >
                           {t(
                             `impact.${opp.impact}` as
-                              'impact.high' | 'impact.medium' | 'impact.low',
+                              | 'impact.high'
+                              | 'impact.medium'
+                              | 'impact.low',
                           )}
                         </Badge>
                       </TableCell>

--- a/web/src/lib/actions/content.ts
+++ b/web/src/lib/actions/content.ts
@@ -215,7 +215,7 @@ export async function sendToWebhook(id: string): Promise<SendToWebhookResult> {
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     let error = body.error || `Server error: ${res.status}`;
-    if (error.includes('No active webhook configured') || error.includes('No active webhook')) {
+    if (error.includes('No active webhook')) {
       error = 'No workflow connected';
     }
     return { success: false, error };
@@ -275,7 +275,18 @@ export async function bulkUpdateStatus(
   return res.json();
 }
 
-export async function bulkSendToWebhook(ids: string[]): Promise<{ sent: number; failed: number }> {
+export type BulkSendResult =
+  | {
+      success: true;
+      sent: number;
+      failed: number;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+export async function bulkSendToWebhook(ids: string[]): Promise<BulkSendResult> {
   const session = await getSession();
 
   const res = await fetch(`${AEO_SERVER_URL}/api/content/bulk/send-webhook`, {
@@ -289,10 +300,19 @@ export async function bulkSendToWebhook(ids: string[]): Promise<{ sent: number; 
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Server error: ${res.status}`);
+    let error = body.error || `Server error: ${res.status}`;
+    if (error.includes('No active webhook')) {
+      error = 'No workflow connected';
+    }
+    return { success: false, error };
   }
 
-  return res.json();
+  const data = await res.json();
+  return {
+    success: true,
+    sent: data.sent,
+    failed: data.failed,
+  };
 }
 
 export async function getWebhookConfig(brandId: string): Promise<WebhookConfig | null> {

--- a/web/src/lib/actions/content.ts
+++ b/web/src/lib/actions/content.ts
@@ -197,9 +197,11 @@ export async function updateOpportunityStatus(
   return res.json();
 }
 
-export async function sendToWebhook(
-  id: string,
-): Promise<{ success: boolean; webhookStatus: number; opportunityStatus: string }> {
+export type SendToWebhookResult =
+  | { success: true; webhookStatus: number; opportunityStatus: string }
+  | { success: false; error: string };
+
+export async function sendToWebhook(id: string): Promise<SendToWebhookResult> {
   const session = await getSession();
 
   const res = await fetch(`${AEO_SERVER_URL}/api/content/${id}/send-webhook`, {
@@ -212,10 +214,19 @@ export async function sendToWebhook(
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Server error: ${res.status}`);
+    let error = body.error || `Server error: ${res.status}`;
+    if (error.includes('No active webhook configured') || error.includes('No active webhook')) {
+      error = 'No workflow connected';
+    }
+    return { success: false, error };
   }
 
-  return res.json();
+  const data = await res.json();
+  return {
+    success: true,
+    webhookStatus: data.webhookStatus,
+    opportunityStatus: data.opportunityStatus,
+  };
 }
 
 export async function testWebhook(


### PR DESCRIPTION

## Summary

Fixes the production-only error handling for **"Send to Workflow"** when no workflow is connected.

### Changes

* Updated `sendToWebhook` to return a structured success/error result instead of throwing for expected failures.
* Updated both client call sites to handle the returned result and display a user-friendly toast.
* Preserved fallback error handling for unexpected failures.

### Result

Users now see a concise error message (e.g. **"No workflow connected"**) instead of the generic Next.js Server Components error in production.
