### PR TITLE
fix(content): show friendly workflow error toast

### DIFF
--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -240,7 +240,7 @@ router.post('/bulk/send-webhook', async (req, res) => {
     if (!webhookConfig) {
       return res
         .status(400)
-        .json({ error: 'No active webhook configured for this brand. Set up a webhook first.' });
+        .json({ error: 'No workflow connected' });
     }
 
     const { data: brand } = await supabaseAdmin
@@ -396,7 +396,7 @@ router.post('/:id/send-webhook', async (req, res) => {
     if (!webhookConfig) {
       return res
         .status(400)
-        .json({ error: 'No active webhook configured for this brand. Set up a webhook first.' });
+        .json({ error: 'No workflow connected' });
     }
 
     const { data: brand } = await supabaseAdmin

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
@@ -117,13 +117,17 @@ export default function ContentDetailPage() {
   const handleSend = async () => {
     setSending(true);
     try {
-      await sendToWebhook(id);
+      const result = await sendToWebhook(id);
+      if (!result.success) {
+        toast.error(result.error || 'Failed to send');
+        return;
+      }
       toast.success('Sent to workflow!');
       const updated = await getOpportunity(id);
       setOpportunity(updated);
     } catch (err) {
       console.error('Send failed:', err);
-      toast.error(err instanceof Error ? err.message : 'Failed to send');
+      toast.error('Failed to send');
     } finally {
       setSending(false);
     }

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -267,12 +267,16 @@ export default function ContentPage() {
   const handleSendWebhook = async (id: string) => {
     setSendingId(id);
     try {
-      await sendToWebhook(id);
+      const result = await sendToWebhook(id);
+      if (!result.success) {
+        toast.error(result.error || 'Failed to send');
+        return;
+      }
       toast.success('Sent to workflow!');
       await loadData(true);
     } catch (err) {
       console.error('Webhook send failed:', err);
-      toast.error(err instanceof Error ? err.message : 'Failed to send');
+      toast.error('Failed to send');
     } finally {
       setSendingId(null);
     }

--- a/web/src/lib/actions/content.ts
+++ b/web/src/lib/actions/content.ts
@@ -197,9 +197,12 @@ export async function updateOpportunityStatus(
   return res.json();
 }
 
-export async function sendToWebhook(
-  id: string,
-): Promise<{ success: boolean; webhookStatus: number; opportunityStatus: string }> {
+export async function sendToWebhook(id: string): Promise<{
+  success: boolean;
+  webhookStatus?: number;
+  opportunityStatus?: string;
+  error?: string;
+}> {
   const session = await getSession();
 
   const res = await fetch(`${AEO_SERVER_URL}/api/content/${id}/send-webhook`, {
@@ -212,10 +215,13 @@ export async function sendToWebhook(
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Server error: ${res.status}`);
+    return {
+      success: false,
+      error: body.error || `Server error: ${res.status}`,
+    };
   }
 
-  return res.json();
+  return await res.json();
 }
 
 export async function testWebhook(


### PR DESCRIPTION
Fixes #393

## Summary

- Return structured error results from `sendToWebhook` instead of throwing expected Server Action errors.
- Update content page handlers to display user-friendly toast messages.
- Shorten the backend validation message to "No workflow connected".
- Preserve fallback handling for unexpected failures.

## Testing

- Verified successful workflow sending.
- Verified a friendly error toast is shown when no workflow is connected.