### PR TITLE
feat(content): show prompt's observed query fan-outs in Source Data (#392)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
@@ -34,6 +34,7 @@ import {
   type BriefQuota,
 } from '@/lib/actions/content';
 import type { ContentBrief, ContentOpportunity } from '@/types';
+import { getPromptFanout, type FanoutSubQuery } from '@/lib/actions/fanout';
 import { toast } from 'sonner';
 
 const IMPACT_COLORS: Record<string, string> = {
@@ -94,6 +95,7 @@ export default function ContentDetailPage() {
   const [generatingBrief, setGeneratingBrief] = useState(false);
   const [brief, setBrief] = useState<ContentBrief | null>(null);
   const [quota, setQuota] = useState<BriefQuota | null>(null);
+  const [fanoutQueries, setFanoutQueries] = useState<FanoutSubQuery[]>([]);
 
   useEffect(() => {
     setLoading(true);
@@ -101,6 +103,11 @@ export default function ContentDetailPage() {
       .then((opp) => {
         setOpportunity(opp);
         if (opp.brief) setBrief(opp.brief);
+        if (opp.brandId && opp.promptId) {
+          getPromptFanout(opp.brandId, opp.promptId)
+            .then((d) => setFanoutQueries(d.subQueries))
+            .catch(() => setFanoutQueries([]));
+        }
       })
       .catch((err) => {
         console.error('Failed to load opportunity:', err);
@@ -289,6 +296,26 @@ export default function ContentDetailPage() {
                   {sd.keywords.map((kw) => (
                     <Badge key={kw} variant="outline" className="text-xs">
                       {kw}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {fanoutQueries.length > 0 && (
+              <div>
+                <p className="text-xs text-muted-foreground mb-1.5">Observed fan-out queries</p>
+                <div className="flex flex-wrap gap-1">
+                  {fanoutQueries.map((sq) => (
+                    <Badge
+                      key={sq.query}
+                      variant="outline"
+                      className="text-xs border-violet-500/30 bg-violet-500/10 text-violet-600 dark:text-violet-400 gap-1"
+                      title={`Searched ${sq.timesSearched}× by answer engines`}
+                    >
+                      <Search className="h-2.5 w-2.5 shrink-0" />
+                      {sq.query}
+                      <span className="opacity-60 tabular-nums">×{sq.timesSearched}</span>
                     </Badge>
                   ))}
                 </div>

--- a/web/src/lib/actions/fanout.ts
+++ b/web/src/lib/actions/fanout.ts
@@ -258,3 +258,79 @@ export async function classifyFanoutIntents(queries: string[]): Promise<Record<s
   const data = await res.json();
   return (data.intents ?? {}) as Record<string, string>;
 }
+
+/**
+ * Observed query fan-out for a single prompt (#392).
+ * Filters prompt_results by both brand_id and prompt_id so only sub-queries
+ * from answers to THIS prompt are returned. Aggregation is identical to
+ * getQueryFanout (normalise → dedupe per answer → count distinct answers).
+ */
+export async function getPromptFanout(
+  brandId: string,
+  promptId: string,
+  opts?: { days?: number },
+): Promise<QueryFanoutData> {
+  const supabase = await createClient();
+  const days = Math.min(Math.max(Math.trunc(opts?.days ?? 30) || 30, 1), MAX_FANOUT_DAYS);
+  const since = new Date(Date.now() - days * 86_400_000).toISOString();
+
+  const { data: rows, error } = await supabase
+    .from('prompt_results')
+    .select('prompt_id, platform, search_queries')
+    .eq('brand_id', brandId)
+    .eq('prompt_id', promptId)
+    .gte('created_at', since);
+
+  if (error) throw new Error(error.message);
+
+  interface Acc {
+    display: string;
+    engines: Set<string>;
+    answerCount: number;
+  }
+  const byQuery = new Map<string, Acc>();
+
+  for (const row of rows ?? []) {
+    const items = Array.isArray(row.search_queries)
+      ? (row.search_queries as RawSearchQueryItem[])
+      : [];
+    const seenInRow = new Set<string>();
+    for (const item of items) {
+      const q = typeof item?.query === 'string' ? normalizeQuery(item.query) : '';
+      if (!q) continue;
+      const key = q.toLowerCase();
+
+      let acc = byQuery.get(key);
+      if (!acc) {
+        acc = { display: q, engines: new Set(), answerCount: 0 };
+        byQuery.set(key, acc);
+      }
+
+      const sp =
+        typeof item?.source_platform === 'string' && item.source_platform
+          ? item.source_platform
+          : (row.platform as string | null);
+      if (sp) acc.engines.add(sp);
+
+      if (!seenInRow.has(key)) {
+        acc.answerCount += 1;
+        seenInRow.add(key);
+      }
+    }
+  }
+
+  if (byQuery.size === 0) return { subQueries: [], totalObserved: 0 };
+
+  const subQueries: FanoutSubQuery[] = [...byQuery.entries()]
+    .map(([, acc]) => ({
+      query: acc.display,
+      engines: [...acc.engines].sort(),
+      timesSearched: acc.answerCount,
+      sourcedPrompts: [],
+      tracked: false,
+      trackedPromptId: null,
+    }))
+    .sort((a, b) => b.timesSearched - a.timesSearched || a.query.localeCompare(b.query));
+
+  return { subQueries, totalObserved: subQueries.length };
+}


### PR DESCRIPTION
## Summary

Closes #392

Adds an **Observed fan-out queries** block to the Source Data card on
`/dashboard/content/[id]`, showing the sub-queries answer engines
actually ran when answering this opportunity's prompt — first-hand
demand signal for content writers.

## Changes

### `web/src/lib/actions/fanout.ts`

Added `getPromptFanout(brandId, promptId, opts?)` — a new server action
that filters `prompt_results` by both `brand_id` and `prompt_id` (30-day
rolling window by default, clamped to `MAX_FANOUT_DAYS`). Aggregation is
identical to `getQueryFanout`: normalize whitespace/case, dedupe per
answer row so one answer counts once per sub-query, count distinct
answers. Returns `QueryFanoutData` — no `sourcedPrompts`/`tracked` fields
needed for this display-only context.

### `web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx`

- Import `getPromptFanout` and `FanoutSubQuery` from `fanout.ts`
- Add `fanoutQueries: FanoutSubQuery[]` state (default `[]`)
- Inside the existing `getOpportunity().then()` block, load fan-out when
  `opp.brandId` and `opp.promptId` are both present; errors caught
  silently so a missing fan-out never breaks the page load
- Render fan-out chips (violet, consistent with the Keywords style) below
  the Keywords block — each chip shows the sub-query text and a
  `×{timesSearched}` count
- Block is hidden entirely when `fanoutQueries` is empty

## Acceptance criteria

- [x] Source Data card shows observed fan-out sub-queries with
  times-searched count when data exists
- [x] Block is hidden when the prompt has no captured fan-outs
- [x] Aggregation matches Query Fan-out tab semantics
  (same normalizeQuery + per-answer dedup + distinct answer count)
- [x] No layout regression when block is absent — purely conditional,
  sits between existing Keywords and Competitors Cited blocks