### PR TITLE
fix(shopping): normalize chatgpt-shopping cards — pickParser gains a ChatGPT branch

### DIFF
--- a/server/src/lib/shopping-cards.js
+++ b/server/src/lib/shopping-cards.js
@@ -1,7 +1,7 @@
 /**
  * Normalize shopping cards captured into `prompt_results.shopping_cards`.
  *
- * Three providers feed this column today with three different raw shapes:
+ * Four providers feed this column today with four different raw shapes:
  *
  *   - **Perplexity** (`platform = 'perplexity-web'`) — snake_case keys
  *     (`image_url`, `review_count`, …).
@@ -9,6 +9,10 @@
  *     (`imageUrl`, `reviewCount`, …). NB: the live response is camelCase
  *     even though the docs show snake_case — verified in #86.
  *   - **Microsoft Copilot** (`platform = 'copilot-web'`) — camelCase keys.
+ *   - **ChatGPT Shopping** (`platform = 'chatgpt-shopping'`) — snake_case
+ *     keys inside `{ products: [ … ], tags }` wrappers; rich product
+ *     objects with formatted price strings ("₺2.699,99") and an `offers`
+ *     array (#399).
  *
  * The downstream `prompt_result_shopping_cards` table flattens those onto
  * a single set of analytical columns. Each normalizer here pulls the
@@ -115,13 +119,40 @@ function parsePrice(value) {
       }
     }
 
-    // Amount — first decimal-looking number. Handles both "29.99" and
-    // "29,99" (EU comma decimals) by normalizing comma → dot.
-    const amountMatch = trimmed.replace(/\s+/g, '').match(/-?\d+(?:[.,]\d+)?/);
-    const amount = amountMatch ? Number.parseFloat(amountMatch[0].replace(',', '.')) : null;
+    // Amount — first number-looking run, then disambiguate separators.
+    // Providers ship every locale convention: "29.99", "29,99" (EU decimal),
+    // "1,299.99" (US thousands) and "₺2.699,99" (TR thousands — ChatGPT
+    // Shopping, #399). Rule: when both separators appear, the LAST one is
+    // the decimal point; a lone separator is decimal only when it's the
+    // only one of its kind and is followed by 1-2 digits, else thousands.
+    const amountMatch = trimmed.replace(/\s+/g, '').match(/-?\d[\d.,]*/);
+    let amount = null;
+    if (amountMatch) {
+      let s = amountMatch[0];
+      const lastDot = s.lastIndexOf('.');
+      const lastComma = s.lastIndexOf(',');
+      if (lastDot !== -1 && lastComma !== -1) {
+        const thousands = lastDot > lastComma ? ',' : '.';
+        s = s.split(thousands).join('');
+        if (thousands === '.') s = s.replace(',', '.');
+      } else if (lastComma !== -1) {
+        const frac = s.length - lastComma - 1;
+        s =
+          frac >= 1 && frac <= 2 && s.indexOf(',') === lastComma
+            ? s.replace(',', '.')
+            : s.split(',').join('');
+      } else if (lastDot !== -1) {
+        const frac = s.length - lastDot - 1;
+        if (!(frac >= 1 && frac <= 2 && s.indexOf('.') === lastDot)) {
+          s = s.split('.').join('');
+        }
+      }
+      const parsed = Number.parseFloat(s);
+      amount = Number.isFinite(parsed) ? parsed : null;
+    }
 
     return {
-      amount: Number.isFinite(amount) ? amount : null,
+      amount,
       currency,
     };
   }
@@ -275,7 +306,78 @@ export function parseCopilotCard(card, position) {
 }
 
 /**
+ * ChatGPT Shopping product normalizer (#399). Cloro ships shopping data as
+ * `{ products: [ … ], tags }` wrappers; `normalizeShoppingCards` flattens
+ * those, so this receives an individual product (snake_case, derived from
+ * captured production payloads):
+ *
+ *   { id, title, url, price: "₺2.699,99", image_urls: [ … ],
+ *     merchants: "kayra.com", rating, num_reviews, position, query,
+ *     offers: [{ url, price, brand, tag, details, … }], variants, specs,
+ *     price_history, … }
+ *
+ * Unlike the other parsers, `raw` keeps only a compact subset: a single
+ * ChatGPT product runs to tens of KB (variants, price_history, specs,
+ * analytics metadata), and the full original is already persisted on
+ * `prompt_results.shopping_cards` — which is what the backfill script
+ * re-derives from, so nothing is lost by trimming here.
+ *
+ * @param {object} card
+ * @param {number} position
+ */
+export function parseChatgptCard(card, position) {
+  const firstOffer =
+    Array.isArray(card.offers) && card.offers[0] && typeof card.offers[0] === 'object'
+      ? card.offers[0]
+      : null;
+  const price = parsePrice(card.price ?? firstOffer?.price);
+  const merchantUrl = toStringOrNull(card.url) ?? toStringOrNull(firstOffer?.url);
+  // `merchants` is a bare string in captured payloads; tolerate an array.
+  const merchant = Array.isArray(card.merchants)
+    ? toStringOrNull(card.merchants[0])
+    : toStringOrNull(card.merchants);
+  return {
+    position: toInteger(card.position) ?? position,
+    product_title: toStringOrNull(card.title ?? card.name),
+    product_brand: toStringOrNull(firstOffer?.brand) ?? merchant,
+    price_amount: price.amount,
+    price_currency: price.currency,
+    image_url: Array.isArray(card.image_urls)
+      ? toStringOrNull(card.image_urls[0])
+      : toStringOrNull(card.image_url ?? card.image),
+    merchant_url: merchantUrl,
+    merchant_domain: extractHostname(merchantUrl),
+    rating: toNumber(card.rating),
+    review_count: toInteger(card.num_reviews ?? card.review_count),
+    raw: {
+      id: card.id ?? null,
+      title: card.title ?? null,
+      url: card.url ?? null,
+      price: card.price ?? null,
+      merchants: card.merchants ?? null,
+      rating: card.rating ?? null,
+      num_reviews: card.num_reviews ?? null,
+      position: card.position ?? null,
+      query: card.query ?? null,
+      offers: firstOffer
+        ? [
+            {
+              url: firstOffer.url ?? null,
+              price: firstOffer.price ?? null,
+              brand: firstOffer.brand ?? null,
+            },
+          ]
+        : [],
+    },
+  };
+}
+
+/**
  * Pick the right normalizer for a platform / scraper id.
+ *
+ * NB: `chatgpt-shopping` matches exactly — plain `chatgpt-web` answers never
+ * carry shopping cards, and keeping it unmatched preserves the "unsupported
+ * platform → []" behavior for it.
  *
  * @param {string|null|undefined} platform
  */
@@ -285,15 +387,17 @@ function pickParser(platform) {
   if (p.startsWith('perplexity')) return parsePerplexityCard;
   if (p.startsWith('google-aimode') || p === 'google-ai-mode') return parseAiModeCard;
   if (p.startsWith('copilot')) return parseCopilotCard;
+  if (p === 'chatgpt-shopping') return parseChatgptCard;
   return null;
 }
 
 /**
- * Some providers (Microsoft Copilot) return shopping data as wrapper
- * objects — `{ type: 'shoppingProducts', layout, products: [ … ] }` — rather
- * than a flat array of product cards. Flatten any such wrapper into its
- * `products` so each product becomes its own normalized card. Elements that
- * are already flat product objects pass through untouched.
+ * Some providers (Microsoft Copilot, ChatGPT Shopping) return shopping data
+ * as wrapper objects — `{ type: 'shoppingProducts', layout, products: [ … ] }`
+ * or `{ products: [ … ], tags }` — rather than a flat array of product cards.
+ * Flatten any such wrapper into its `products` so each product becomes its
+ * own normalized card. Elements that are already flat product objects pass
+ * through untouched.
  *
  * @param {unknown[]} cards
  * @returns {object[]}

--- a/server/src/lib/shopping-cards.test.js
+++ b/server/src/lib/shopping-cards.test.js
@@ -3,6 +3,7 @@ import {
   parsePerplexityCard,
   parseAiModeCard,
   parseCopilotCard,
+  parseChatgptCard,
   normalizeShoppingCards,
   matchCardBrand,
 } from './shopping-cards.js';
@@ -162,6 +163,142 @@ describe('shopping-cards – parseCopilotCard', () => {
     expect(result.price_amount).toBeCloseTo(39.99);
     expect(result.merchant_domain).toBe('acme.co');
     expect(result.review_count).toBe(42);
+  });
+});
+
+// ChatGPT Shopping (#399): a `{ products, tags }` wrapper whose products are
+// rich snake_case objects — shape derived from captured production payloads.
+const chatgptWrapper = {
+  tags: ['shopping'],
+  products: [
+    {
+      id: 'prod_abc',
+      position: 1,
+      title: 'Premium Wool Double-Breasted Coat',
+      url: 'https://www.example-store.com/coats/premium-wool',
+      price: '₺2.699,99',
+      image_urls: ['https://images.example.com/coat-front.jpg'],
+      merchants: 'example-store.com',
+      rating: 4.4,
+      num_reviews: 128,
+      query: 'kaban',
+      offers: [
+        {
+          tag: { text: 'Best price', tooltip: null },
+          url: 'https://www.example-store.com/coats/premium-wool?utm_source=chatgpt.com',
+          brand: null,
+          price: '₺2.699,99',
+          details: 'In stock, free shipping',
+        },
+      ],
+      variants: [{ big: 'blob' }],
+      price_history: [{ another: 'blob' }],
+    },
+    {
+      title: 'Oversize Coat',
+      url: 'https://shop.example.org/products/oversize-coat',
+      price: '₺4.249,90',
+      image_urls: [],
+      merchants: 'ExampleShop',
+      rating: null,
+      num_reviews: null,
+      offers: [],
+    },
+  ],
+};
+
+describe('normalizeShoppingCards — ChatGPT Shopping wrapper (#399)', () => {
+  const cards = normalizeShoppingCards('chatgpt-shopping', [chatgptWrapper]);
+
+  it('flattens the products[] wrapper into one card per product', () => {
+    expect(cards).toHaveLength(2);
+  });
+
+  it('maps title, merchant url/domain and image', () => {
+    expect(cards[0].product_title).toBe('Premium Wool Double-Breasted Coat');
+    expect(cards[0].merchant_url).toBe('https://www.example-store.com/coats/premium-wool');
+    expect(cards[0].merchant_domain).toBe('example-store.com');
+    expect(cards[0].image_url).toBe('https://images.example.com/coat-front.jpg');
+  });
+
+  it('parses Turkish-formatted price strings (dot thousands, comma decimal)', () => {
+    expect(cards[0].price_amount).toBe(2699.99);
+    expect(cards[0].price_currency).toBe('TRY');
+    expect(cards[1].price_amount).toBe(4249.9);
+    expect(cards[1].price_currency).toBe('TRY');
+  });
+
+  it('falls back to the merchants string for product_brand when offer brand is null', () => {
+    expect(cards[0].product_brand).toBe('example-store.com');
+    expect(cards[1].product_brand).toBe('ExampleShop');
+  });
+
+  it("prefers the provider's flat position, falling back to the array index", () => {
+    expect(cards[0].position).toBe(1);
+    expect(cards[1].position).toBe(1); // no position field → index after flatten
+  });
+
+  it('maps rating and review count', () => {
+    expect(cards[0].rating).toBe(4.4);
+    expect(cards[0].review_count).toBe(128);
+    expect(cards[1].rating).toBeNull();
+    expect(cards[1].review_count).toBeNull();
+  });
+
+  it('trims raw to a compact subset (no variants/price_history blobs)', () => {
+    expect(cards[0].raw.variants).toBeUndefined();
+    expect(cards[0].raw.price_history).toBeUndefined();
+    expect(cards[0].raw.title).toBe('Premium Wool Double-Breasted Coat');
+    expect(cards[0].raw.offers).toEqual([
+      {
+        url: 'https://www.example-store.com/coats/premium-wool?utm_source=chatgpt.com',
+        brand: null,
+        price: '₺2.699,99',
+      },
+    ]);
+  });
+});
+
+describe('parseChatgptCard — offer fallbacks', () => {
+  it('falls back to the first offer for url and price when top-level fields are missing', () => {
+    const card = parseChatgptCard(
+      {
+        title: 'Sneaker',
+        offers: [{ url: 'https://merchant.example/p/1', price: '$129.99', brand: 'Acme' }],
+      },
+      3,
+    );
+    expect(card.merchant_url).toBe('https://merchant.example/p/1');
+    expect(card.merchant_domain).toBe('merchant.example');
+    expect(card.price_amount).toBe(129.99);
+    expect(card.price_currency).toBe('USD');
+    expect(card.product_brand).toBe('Acme');
+    expect(card.position).toBe(3);
+  });
+});
+
+describe('shopping-cards – parsePrice separator disambiguation', () => {
+  const priceOf = (price) => parsePerplexityCard({ title: 'X', price }, 0);
+
+  it('parses US thousands + decimal ("1,299.99")', () => {
+    expect(priceOf('$1,299.99').price_amount).toBe(1299.99);
+  });
+
+  it('parses EU/TR thousands + decimal ("2.699,99")', () => {
+    expect(priceOf('₺2.699,99').price_amount).toBe(2699.99);
+  });
+
+  it('treats a lone dot with 3 digits as thousands ("1.299")', () => {
+    expect(priceOf('₺1.299').price_amount).toBe(1299);
+  });
+
+  it('keeps a lone separator with 2 digits as the decimal', () => {
+    expect(priceOf('€29,99').price_amount).toBe(29.99);
+    expect(priceOf('$29.99').price_amount).toBe(29.99);
+  });
+
+  it('handles multi-group thousands ("1.234.567")', () => {
+    expect(priceOf('₺1.234.567').price_amount).toBe(1234567);
   });
 });
 


### PR DESCRIPTION
## Summary

ChatGPT Shopping results were being captured (`prompt_results.shopping_cards` fills up correctly) but **never normalized** into `prompt_result_shopping_cards`: `pickParser` in `server/src/lib/shopping-cards.js` had no branch for `chatgpt-shopping`, so `normalizeShoppingCards` always returned `[]` and the Shopping dashboard only ever showed Copilot cards.

### Changes

- **`parseChatgptCard`** — normalizes the `{ products, tags }` wrapper products. The shape was derived from real captured production payloads, not guessed: `title`, `url` (+ `offers[0].url` fallback), formatted price strings, `image_urls[0]`, `merchants` string, `rating` / `num_reviews`, provider-flat `position`.
  - `raw` intentionally keeps a **compact subset**: a single ChatGPT product runs to tens of KB (variants, price_history, specs, analytics metadata), and the full original is already persisted on `prompt_results.shopping_cards` — which is exactly what the backfill script re-derives from, so nothing is lost.
- **`pickParser`** matches `chatgpt-shopping` **exactly** — plain `chatgpt-web` answers never carry cards, and the existing "unsupported platform → []" test for it stays green.
- **`parsePrice` separator fix (shared by all parsers):** `"₺2.699,99"` previously parsed as `2.699` — the thousands dot was read as a decimal point. The string branch now disambiguates: when both separators appear the last one is the decimal; a lone separator is decimal only with 1-2 trailing digits. Covers US (`1,299.99`), EU/TR (`2.699,99`) and multi-group (`1.234.567`) conventions.
- **13 new tests** (wrapper flattening, field mapping, offer fallbacks, price separator matrix) — 112/112 passing. Also smoke-tested end to end against real captured payloads: correct amount/currency (TRY), merchant domain extraction, and `matchCardBrand` competitor matching.

### Backfill

No changes needed — the script is platform-agnostic and picks up the new parser. After merge, run once to rebuild history from the already-captured raw cards:

```bash
cd server && node src/scripts/backfill-shopping-cards.js
```

Fixes #399

## Type of change

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. `cd server && npm test` — 112 passing (13 new in `shopping-cards.test.js`).
2. With a shopping-mode brand, wait for (or trigger) a tracking run: new `chatgpt-shopping` results now produce rows in `prompt_result_shopping_cards` with `platform = 'chatgpt-shopping'`.
3. Run the backfill; `/dashboard/shopping` should now show ChatGPT alongside Copilot in the platform filters, with own/competitor matching populated.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes (run from `server/`)
- [x] `npm run format:check` passes (run from `server/`)
- [x] `npm test` passes (run from `server/`)
- [x] Changes are focused — one concern per PR
