### PR TITLE
fix(topics): hide zero KPI delta

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
@@ -93,7 +93,7 @@ function KpiCard({
               <span className="text-sm font-normal text-muted-foreground ml-0.5">{suffix}</span>
             )}
           </div>
-          {change !== null && change !== undefined && (
+          {change !== null && change !== undefined && change !== 0 && (
             <span
               className={cn(
                 'flex items-center text-xs font-medium',


### PR DESCRIPTION
## Summary

- Hide the KPI delta when `change === 0`.
- Preserve the existing behavior for positive and negative deltas by only rendering the delta for non-zero values.
- This removes the unnecessary `0pts` / `0` display on KPI cards.

## Related issue

Closes #360

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [ ] `yarn lint` passes (couldn't run locally)
- [ ] `yarn typecheck` passes (couldn't run locally)
- [ ] `yarn format:check` passes (couldn't run locally)
- [x] Changes are focused — one concern per PR

### Note

I wasn't able to run the project locally due to environment setup constraints. The change is limited to the conditional rendering logic described in the issue.
