### PR TITLE
feat(citations): paginate Domains/URLs tables to 100 rows per page

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -92,6 +92,7 @@ import {
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const DATE_PRESETS: CitationsDatePreset[] = ['24h', '7d', '30d', '90d', 'all', 'custom'];
+const PAGE_SIZE = 100;
 
 const CATEGORY_COLORS: Record<SourceCategory, string> = {
   you: '#6366f1',
@@ -766,10 +767,12 @@ const DomainsTable = memo(function DomainsTable({
   rows,
   brandId,
   onAdded,
+  startRank,
 }: {
   rows: CitationDomainRow[];
   brandId: string;
   onAdded: () => void;
+  startRank: number;
 }) {
   if (rows.length === 0) return <EmptyRows />;
 
@@ -790,7 +793,9 @@ const DomainsTable = memo(function DomainsTable({
       <TableBody>
         {rows.map((row, i) => (
           <TableRow key={row.domain}>
-            <TableCell className="text-xs text-muted-foreground tabular-nums">{i + 1}</TableCell>
+            <TableCell className="text-xs text-muted-foreground tabular-nums">
+              {startRank + i}
+            </TableCell>
             <TableCell>
               <div className="flex items-center gap-2 min-w-0">
                 <DomainFavicon domain={row.domain} />
@@ -834,7 +839,13 @@ const DomainsTable = memo(function DomainsTable({
   );
 });
 
-const UrlsTable = memo(function UrlsTable({ rows }: { rows: CitationUrlRow[] }) {
+const UrlsTable = memo(function UrlsTable({
+  rows,
+  startRank,
+}: {
+  rows: CitationUrlRow[];
+  startRank: number;
+}) {
   if (rows.length === 0) return <EmptyRows />;
 
   return (
@@ -851,7 +862,9 @@ const UrlsTable = memo(function UrlsTable({ rows }: { rows: CitationUrlRow[] }) 
       <TableBody>
         {rows.map((row, i) => (
           <TableRow key={row.url}>
-            <TableCell className="text-xs text-muted-foreground tabular-nums">{i + 1}</TableCell>
+            <TableCell className="text-xs text-muted-foreground tabular-nums">
+              {startRank + i}
+            </TableCell>
             <TableCell>
               <div className="flex items-start gap-2 min-w-0">
                 <DomainFavicon domain={row.domain} />
@@ -894,6 +907,53 @@ function EmptyRows() {
       <p className="mt-1 text-xs text-muted-foreground">
         Try widening your date range or removing filters.
       </p>
+    </div>
+  );
+}
+
+function Pager({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+}) {
+  if (total <= pageSize) return null; // nothing to page through
+
+  const start = page * pageSize + 1;
+  const end = Math.min(total, (page + 1) * pageSize);
+  const canPrev = page > 0;
+  const canNext = end < total;
+
+  return (
+    <div className="flex items-center justify-between pt-3">
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {start}–{end} of {total}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          disabled={!canPrev}
+          onClick={() => onPageChange(page - 1)}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          disabled={!canNext}
+          onClick={() => onPageChange(page + 1)}
+        >
+          Next
+        </Button>
+      </div>
     </div>
   );
 }
@@ -1195,6 +1255,8 @@ export default function CitationsPage() {
   const activeBrandId = brand?.id ?? null;
 
   const [sourceTab, setSourceTab] = useState<'domains' | 'urls' | 'gaps'>('domains');
+  const [domainsPage, setDomainsPage] = useState(0);
+  const [urlsPage, setUrlsPage] = useState(0);
   const [gaps, setGaps] = useState<CitationGaps | null>(null);
   const [gapsLoading, setGapsLoading] = useState(false);
 
@@ -1234,6 +1296,11 @@ export default function CitationsPage() {
     }),
     [gapFilters, filters.excludeOwnDomain, filters.competitorOnly, filters.ownOnly],
   );
+
+  useEffect(() => {
+    setDomainsPage(0);
+    setUrlsPage(0);
+  }, [apiFilters]);
 
   useEffect(() => {
     if (!activeBrandId) return;
@@ -1331,6 +1398,15 @@ export default function CitationsPage() {
     ],
     [totals, t],
   );
+  const pagedDomainRows = useMemo(() => {
+    const rows = data?.rows ?? [];
+    return rows.slice(domainsPage * PAGE_SIZE, domainsPage * PAGE_SIZE + PAGE_SIZE);
+  }, [data?.rows, domainsPage]);
+
+  const pagedUrlRows = useMemo(() => {
+    const rows = data?.urlRows ?? [];
+    return rows.slice(urlsPage * PAGE_SIZE, urlsPage * PAGE_SIZE + PAGE_SIZE);
+  }, [data?.urlRows, urlsPage]);
 
   if (!brand) {
     return (
@@ -1393,13 +1469,26 @@ export default function CitationsPage() {
                       once and make switching a pure CSS visibility toggle (#299). */}
                   <TabsContent value="domains" keepMounted className="mt-4">
                     <DomainsTable
-                      rows={data?.rows ?? []}
+                      rows={pagedDomainRows}
                       brandId={activeBrandId ?? ''}
                       onAdded={loadData}
+                      startRank={domainsPage * PAGE_SIZE + 1}
+                    />
+                    <Pager
+                      page={domainsPage}
+                      pageSize={PAGE_SIZE}
+                      total={data?.totals.domains ?? 0}
+                      onPageChange={setDomainsPage}
                     />
                   </TabsContent>
                   <TabsContent value="urls" keepMounted className="mt-4">
-                    <UrlsTable rows={data?.urlRows ?? []} />
+                    <UrlsTable rows={pagedUrlRows} startRank={urlsPage * PAGE_SIZE + 1} />
+                    <Pager
+                      page={urlsPage}
+                      pageSize={PAGE_SIZE}
+                      total={data?.totals.urls ?? 0}
+                      onPageChange={setUrlsPage}
+                    />
                   </TabsContent>
                   <TabsContent value="gaps" className="mt-4">
                     <CompetitorGapsTab loading={gapsLoading} gaps={gaps} />


### PR DESCRIPTION
## Summary
The Top Sources card on /dashboard/citations rendered every row in the Domains and URLs tables at once, with no limit. DomainsTable and UrlsTable just looped over the full data returned by getCitationsOverview and rendered a row for each one.

This PR adds client-side pagination, 100 rows per page, independently for the Domains and URLs tabs:
- New `Pager` component (Previous/Next + "start–end of total")
<img width="452" height="77" alt="image" src="https://github.com/user-attachments/assets/ac48e061-e5dc-4215-90eb-b9392cd86db2" />

- Rank stays global across pages via `startRank = page * PAGE_SIZE + 1` (page 2 starts at 101, not 1)
- Independent `domainsPage`/`urlsPage` state, so paging one tab doesn't affect the other
- Resets to page 1 whenever a scoping filter changes (date preset, platform, topic, prompt, region, own-domain toggles), keyed off the existing `apiFilters` memo
- `keepMounted` is untouched — tab switching stays instant, and is now cheaper since each mounted panel holds at most 100 rows instead of the full set
- No changes to `getCitationsOverview` or server behavior — pagination is a pure client-side slice of data that's already fully loaded

## Related issue
Closes #395 

## Type of change
- [x] `feat` —  paginate Domains/URLs tables to 100 rows per page


## Checklist
- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes
- [x] Changes are focused — one concern per PR

## Manual Testing

- Inserted 157 domains and tested the pagination (uploaded a video) 
- Pagination resets to page 0 on any filter change.

https://github.com/user-attachments/assets/6f494134-3644-42ab-b1fe-c0db2c04516f

- Independent per-tab page state: navigated Domains to page 2 (rows 101+), 
      switched to the URLs tab (stayed on its own page 1), then switched back 
      to Domains — page 2 was preserved, confirming tab switches don't reset 
      or cross-contaminate each tab's pagination state.


https://github.com/user-attachments/assets/ac1567c7-a41c-4239-bcdc-83b6333514b0




