### PR TITLE
feat(prompts): add search filter to the By Prompt view

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -25,7 +25,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Check, ChevronRight, Plus, Loader2, Search } from 'lucide-react';
+import { Check, ChevronRight, Plus, Loader2, Search, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
 
 function platformLabel(slug: string): string {
   return PLATFORM_LABELS[slug] ?? slug;
@@ -331,6 +332,7 @@ function ByPromptView({
   onTrack: (query: string) => void;
 }) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = useState('');
 
   function toggle(id: string) {
     setExpanded((prev) => {
@@ -341,8 +343,50 @@ function ByPromptView({
     });
   }
 
+  const filteredGroups = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return groups;
+    return groups.filter((g) => g.prompt.text.toLowerCase().includes(q));
+  }, [groups, searchQuery]);
+
   return (
-    <Table>
+    <div className="space-y-3">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search prompts…"
+          className="h-8 pl-8 pr-8 text-sm"
+        />
+        {searchQuery && (
+          <button
+            onClick={() => setSearchQuery('')}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {filteredGroups.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-10 text-center">
+          <Search className="h-6 w-6 text-muted-foreground/50" />
+          <p className="text-sm font-medium">No prompts match your search</p>
+          <p className="text-xs text-muted-foreground">
+            Try a different search term or{' '}
+            <button
+              onClick={() => setSearchQuery('')}
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              clear the filter
+            </button>
+            .
+          </p>
+        </div>
+      ) : (
+      <Table>
       <TableHeader>
         <TableRow>
           <TableHead className="w-[28px]" />
@@ -351,7 +395,7 @@ function ByPromptView({
         </TableRow>
       </TableHeader>
       <TableBody>
-        {groups.map(({ prompt, subQueries }) => {
+        {filteredGroups.map(({ prompt, subQueries }) => {
           const isOpen = expanded.has(prompt.id);
           return (
             <Fragment key={prompt.id}>
@@ -420,6 +464,8 @@ function ByPromptView({
         })}
       </TableBody>
     </Table>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #413.
 
## Problem
 
On `/dashboard/prompts?tab=fanout`, the **By Prompt** view lists every
prompt that produced fan-out sub-queries with no way to search or filter
them. For a brand tracking dozens of prompts, finding a specific one
meant scrolling and expanding rows manually.
 
## What changed
 
**`web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx`**
 
All changes are contained inside `ByPromptView` — no other component,
no data-fetching path, and no other view is touched.
 
- Added `searchQuery` state and a `filteredGroups` `useMemo` that
  filters the existing `PromptGroup[]` by `prompt.text`
  (case-insensitive substring match). The `byPrompt` memo and all
  server calls are completely unchanged — this is a pure client-side
  filter with no debounce needed.
- Added a search `Input` (standard `@/components/ui/input`) with a
  `Search` icon on the left, placed above the By Prompt table.
- An `X` clear button appears inside the input whenever there is an
  active query; clicking it resets the filter.
- When no prompt matches, an empty state is shown:
  *"No prompts match your search"* with a "clear the filter" link.
- Expanded/collapsed row state is keyed by `prompt.id` (unchanged), so
  a row that was open before filtering stays open when it reappears in
  the filtered list.
## Acceptance criteria
 
- [x] Typing in the search box filters the By Prompt groups by prompt
      text, case-insensitively
- [x] Empty state shown when no prompt matches
- [x] Clearing the search restores the full list
- [x] No change to data fetching (pure client-side filter)
## Testing
 
```
yarn typecheck   → 0 errors
yarn lint        → 0 errors (9 pre-existing warnings in unrelated files)
yarn vitest run  → 45/45 passed
```
 
