### PR TITLE
fix(shopping): round and format product prices

### DIFF
--- a/server/src/lib/shopping-cards.js
+++ b/server/src/lib/shopping-cards.js
@@ -87,14 +87,14 @@ function parsePrice(value) {
       currency = CURRENCY_SYMBOLS[value.currencySymbol.trim()] ?? null;
     }
     return {
-      amount: Number.isFinite(amount) ? amount : null,
+      amount: Number.isFinite(amount) ? Math.round(amount * 100) / 100 : null,
       currency: currency && CURRENCY_CODES.has(currency) ? currency : currency || null,
     };
   }
 
   // Numeric form (rare, but tolerate)
   if (typeof value === 'number' && Number.isFinite(value)) {
-    return { amount: value, currency: null };
+    return { amount: Math.round(value * 100) / 100, currency: null };
   }
 
   // String form — the common case. Examples we see in the wild:
@@ -148,7 +148,7 @@ function parsePrice(value) {
         }
       }
       const parsed = Number.parseFloat(s);
-      amount = Number.isFinite(parsed) ? parsed : null;
+      amount = Number.isFinite(parsed) ? Math.round(parsed * 100) / 100 : null;
     }
 
     return {

--- a/server/src/lib/shopping-cards.test.js
+++ b/server/src/lib/shopping-cards.test.js
@@ -123,6 +123,14 @@ describe('shopping-cards – parsePerplexityCard', () => {
     expect(result.product_title).toBe('Gadget');
     expect(result.product_brand).toBe('Acme Inc');
   });
+
+  it('should round prices with float-precision garbage to exactly two decimals', () => {
+    const card1 = { price: 2999.989990234375 };
+    const card2 = { price: { amount: 2999.989990234375 } };
+
+    expect(parsePerplexityCard(card1, 0).price_amount).toBe(2999.99);
+    expect(parsePerplexityCard(card2, 0).price_amount).toBe(2999.99);
+  });
 });
 
 describe('shopping-cards – parseAiModeCard', () => {

--- a/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
@@ -313,7 +313,8 @@ export default function ShoppingPage() {
                           impressions: p.impressions,
                           platforms: p.platforms.join('; '),
                           regions: p.regions.join('; '),
-                          last_price: p.last_price !== null ? p.last_price : '',
+                          last_price:
+                            p.last_price !== null ? Math.round(p.last_price * 100) / 100 : '',
                           price_currency: p.price_currency || '',
                           top_merchant: p.top_merchant || '',
                           last_seen: p.last_seen,
@@ -379,7 +380,8 @@ export default function ShoppingPage() {
                           impressions: p.impressions,
                           platforms: p.platforms.join('; '),
                           regions: p.regions.join('; '),
-                          last_price: p.last_price !== null ? p.last_price : '',
+                          last_price:
+                            p.last_price !== null ? Math.round(p.last_price * 100) / 100 : '',
                           price_currency: p.price_currency || '',
                           top_merchant: p.top_merchant || '',
                           last_seen: p.last_seen,
@@ -1142,8 +1144,15 @@ function ProductTable({
         </TableHeader>
         <TableBody>
           {sortedProducts.map((p, idx) => {
+            const formattedPrice =
+              p.last_price !== null
+                ? new Intl.NumberFormat(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  }).format(p.last_price)
+                : '';
             const lastPriceStr =
-              p.last_price !== null ? `${p.last_price} ${p.price_currency || ''}` : '—';
+              p.last_price !== null ? `${formattedPrice} ${p.price_currency || ''}` : '—';
             const formattedDate = p.last_seen
               ? new Date(p.last_seen).toLocaleDateString(undefined, {
                   month: 'short',

--- a/web/src/lib/actions/shopping.ts
+++ b/web/src/lib/actions/shopping.ts
@@ -696,9 +696,13 @@ export interface CardEligiblePromptsResponse {
 
 function formatPrice(amount: number | null, currency: string | null): string {
   if (amount == null) return '—';
+  const formattedAmount = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
   const symbol = currency === 'USD' ? '$' : currency === 'EUR' ? '€' : currency || '';
   const isSymbolWord = symbol.length > 1;
-  return isSymbolWord ? `${amount} ${symbol}` : `${symbol}${amount}`;
+  return isSymbolWord ? `${formattedAmount} ${symbol}` : `${symbol}${formattedAmount}`;
 }
 
 export async function getCardEligiblePrompts(


### PR DESCRIPTION
## Summary

Fixes float precision artifacts shown in Shopping prices.

### Backend

- Round parsed prices to two decimals in parsePrice()
- Added test covering float32 precision noise

### Frontend

- Format displayed prices using Intl.NumberFormat
- Display two decimal places with thousands separators

### CSV

- Export prices with at most two decimal places

### Notes

- Existing historical rows can be re-normalized using the existing backfill script.
- No migration required.

Closes #417