### PR TITLE
chore(models): upgrade Claude to claude-sonnet-5

### DIFF
--- a/server/src/lib/anthropic-tracker.js
+++ b/server/src/lib/anthropic-tracker.js
@@ -20,7 +20,7 @@ function getClient() {
 /**
  * Run a single prompt through Anthropic Messages API with web_search enabled.
  * @param {string} promptText
- * @param {string} model - e.g. "claude-sonnet-4-6"
+ * @param {string} model - e.g. "claude-sonnet-5"
  * @param {string} [region] - ISO 2-letter country code for web_search user_location
  * @returns {Promise<{ text: string, citations: Array<{ url: string, title: string, startIndex: number, endIndex: number }>, model: string }>}
  */

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -142,6 +142,7 @@ const MODEL_DISPLAY_NAME: Record<string, string> = {
   'gpt-4.1-mini': 'GPT-4.1 Mini',
   'gpt-4.1-nano': 'GPT-4.1 Nano',
   'gpt-5-chat-latest': 'ChatGPT',
+  'claude-sonnet-5': 'Claude',
   'claude-sonnet-4-6': 'Claude',
   'claude-opus-4-6': 'Claude',
   'claude-haiku-4-5': 'Claude',

--- a/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
@@ -71,6 +71,7 @@ const MODEL_DISPLAY_NAME: Record<string, string> = {
   'gpt-4.1-mini': 'GPT-4.1 Mini',
   'gpt-4.1-nano': 'GPT-4.1 Nano',
   'gpt-5-chat-latest': 'ChatGPT',
+  'claude-sonnet-5': 'Claude Sonnet 5',
   'claude-sonnet-4-6': 'Claude Sonnet',
   'claude-opus-4-6': 'Claude Opus',
   'claude-haiku-4-5': 'Claude Haiku',

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
@@ -98,6 +98,7 @@ const PLATFORM_COLORS: Record<string, string> = {
   'google-aimode': '#4285f4',
   'gpt-5-chat-latest': '#8b5cf6',
   'gpt-5-mini': '#a78bfa',
+  'claude-sonnet-5': '#fb923c',
   'claude-sonnet-4-6': '#f97316',
   'claude-opus-4-6': '#ea580c',
   'gemini-2.5-pro': '#22c55e',

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -243,6 +243,7 @@ const MODEL_DISPLAY_NAME: Record<string, string> = {
   'gpt-4.1-mini': 'GPT-4.1 Mini',
   'gpt-4.1-nano': 'GPT-4.1 Nano',
   'gpt-5-chat-latest': 'ChatGPT',
+  'claude-sonnet-5': 'Claude',
   'claude-sonnet-4-6': 'Claude',
   'claude-opus-4-6': 'Claude',
   'claude-haiku-4-5': 'Claude',

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -43,6 +43,7 @@ const MODEL_DISPLAY_NAME: Record<string, string> = {
   'gpt-4.1-mini': 'GPT-4.1 Mini',
   'gpt-4.1-nano': 'GPT-4.1 Nano',
   'gpt-5-chat-latest': 'ChatGPT',
+  'claude-sonnet-5': 'Claude',
   'claude-sonnet-4-6': 'Claude',
   'claude-opus-4-6': 'Claude',
   'claude-haiku-4-5': 'Claude',

--- a/web/src/config/platform-labels.ts
+++ b/web/src/config/platform-labels.ts
@@ -33,6 +33,7 @@ export const PLATFORM_LABELS: Record<string, string> = {
   // Model slugs reused as a fallback label in a few chart/progress spots.
   'gpt-5-chat-latest': 'GPT-5',
   'gpt-5-mini': 'GPT-5 Mini',
+  'claude-sonnet-5': 'Claude Sonnet 5',
   'claude-sonnet-4-6': 'Claude Sonnet 4.6',
   'claude-opus-4-6': 'Claude Opus 4.6',
   'gemini-2.5-pro': 'Gemini 2.5 Pro',

--- a/web/src/config/prompt-options.ts
+++ b/web/src/config/prompt-options.ts
@@ -42,7 +42,7 @@ export type LanguageCode = (typeof LANGUAGES)[number]['code'];
 export const MODEL_GROUPS = [
   {
     provider: 'Claude',
-    models: [{ id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' }],
+    models: [{ id: 'claude-sonnet-5', label: 'Claude Sonnet 5' }],
   },
 ] as const;
 

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -1052,6 +1052,7 @@ const MODEL_TO_PROVIDER: Record<string, string> = {
   'gpt-5-chat-latest': 'ChatGPT',
   'gpt-5-mini': 'ChatGPT',
   'gpt-4o': 'ChatGPT',
+  'claude-sonnet-5': 'Claude',
   'claude-sonnet-4-6': 'Claude',
   'claude-opus-4-6': 'Claude',
   'gemini-2.5-pro': 'Gemini',

--- a/web/src/lib/agent/model.ts
+++ b/web/src/lib/agent/model.ts
@@ -8,11 +8,10 @@ import { createAnthropic, type AnthropicProvider } from '@ai-sdk/anthropic';
  * chat route resolves the key per turn via `resolveAnthropicKey(orgId)`
  * and hands it to this builder; self-host passes the operator's env key.
  *
- * Model choice (claude-sonnet-4-6) stays consistent with the
- * brief-generation flow on aeo-server so behavior + cost shape match
- * across the product.
+ * Model choice (claude-sonnet-5) matches the tracking flow's Claude
+ * option so behavior + cost shape stay consistent across the product.
  */
 export function buildAgentModel(apiKey: string): ReturnType<AnthropicProvider> {
   const anthropic = createAnthropic({ apiKey });
-  return anthropic('claude-sonnet-4-6');
+  return anthropic('claude-sonnet-5');
 }


### PR DESCRIPTION
## Summary

- Tracking's selectable Claude model moves from `claude-sonnet-4-6` to **`claude-sonnet-5`** (`web/src/config/prompt-options.ts`) — newly created prompts and prompt edits now track against Sonnet 5.
- The in-product agent (`web/src/lib/agent/model.ts`) moves to `claude-sonnet-5` as well; its stale docstring (which claimed consistency with the brief-generation flow — briefs actually run on `DEFAULT_SUGGESTION_MODEL`) is corrected to reference the tracking flow.
- All label/color maps (insights, citations, prompt detail, competitors, platform-labels, tracking provider map) gain the `claude-sonnet-5` entry while **keeping** the `claude-sonnet-4-6` / `claude-opus-4-6` / `claude-haiku-4-5` entries so historical `prompt_results` rows stay correctly labeled in charts and filters.

### Notes

- Existing prompts that carry `claude-sonnet-4-6` in their `models` array keep tracking against it — the id remains valid on the Anthropic API, so nothing breaks. They migrate to `claude-sonnet-5` when the user re-edits them (the picker only offers the new id) or when a plan change triggers `alignPromptsToPlanForOrg`.
- Plan gating is unaffected: only Starter sets `allowedModels`, and it's `[]` (no Claude either way).
- Optional follow-up: a one-off backfill to rewrite `claude-sonnet-4-6` → `claude-sonnet-5` in existing prompts' `models` arrays, if we want the fleet to migrate immediately instead of lazily.

## Related Issue

N/A — small model-version bump requested directly.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Chore / refactor
- [ ] 📝 Documentation
- [ ] 🚨 Breaking change

## How to Test

1. Create a new prompt → the Claude option shows "Claude Sonnet 5"; save and confirm `prompts.models` stores `claude-sonnet-5`.
2. Run tracking for a prompt with the Claude model → `prompt_results.model_used` is `claude-sonnet-5` and Insights/Citations label it "Claude".
3. Open a brand with pre-existing `claude-sonnet-4-6` results → charts/filters still label them correctly.
4. Use the agent chat → responses come from `claude-sonnet-5` (visible in Anthropic console usage).

## Checklist

- [x] My code follows the project's style guidelines (Prettier clean)
- [x] I have performed a self-review of my code
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (45/45)
- [ ] Manually tested in the dashboard