### PR TITLE
feat(plans): gate Claude tracking to Enterprise per-customer opt-in on cloud

### DIFF
--- a/server/src/config/plans.js
+++ b/server/src/config/plans.js
@@ -77,6 +77,9 @@ export const PLANS = {
       maxSiteAudits: 500,
       maxDailyOnDemand: 10,
       onDemandCooldownMinutes: 5,
+      // API-model tracking (Claude) is not part of Growth — scraper engines
+      // only. Enterprise can get it per customer via plan_overrides.
+      allowedModels: [],
       features: [
         'basic_insights',
         'prompt_suggestions',
@@ -107,6 +110,10 @@ export const PLANS = {
       maxSiteAudits: -1,
       maxDailyOnDemand: -1,
       onDemandCooldownMinutes: 0,
+      // API-model tracking (Claude) is a per-customer opt-in on Enterprise:
+      // default off; enable via
+      // organizations.plan_overrides = { "allowedModels": ["claude-sonnet-5"] }.
+      allowedModels: [],
       features: [
         'basic_insights',
         'prompt_suggestions',

--- a/server/src/lib/plan-guard.js
+++ b/server/src/lib/plan-guard.js
@@ -19,7 +19,7 @@ export class PlanLimitError extends Error {
  * Enterprise orgs can have per-customer limit overrides stored in
  * organizations.plan_overrides (jsonb) — mirrors web getOrgPlan().
  */
-function applyPlanOverrides(plan, org) {
+export function applyPlanOverrides(plan, org) {
   if (org?.plan === 'enterprise' && org.plan_overrides && typeof org.plan_overrides === 'object') {
     return { ...plan, limits: { ...plan.limits, ...org.plan_overrides } };
   }

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -7,7 +7,8 @@ import { runPrompt, analyzeSentimentAI } from '../lib/ai-tracker.js';
 import { submitScraperTask, pollScraperResult } from '../lib/cloro-scraper.js';
 import { parseResponse, countBrandMentions } from '../lib/response-parser.js';
 import supabaseAdmin from '../config/supabase.js';
-import { hasFeature, getPlan } from '../config/plans.js';
+import { hasFeature, getPlan, isCloud } from '../config/plans.js';
+import { applyPlanOverrides } from '../lib/plan-guard.js';
 import { generateContentOpportunities } from '../lib/opportunity-generator.js';
 import logger from '../lib/logger.js';
 
@@ -84,10 +85,33 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
     domain: c.domain || '',
   }));
 
+  // 3b. Cloud: API-model tracking is plan-gated (Growth has no Claude;
+  // Enterprise is per-customer via organizations.plan_overrides.allowedModels).
+  // Prompts can still carry disallowed model ids from an earlier plan, so
+  // filter at run time instead of trusting the stored arrays. `null` means
+  // every model is allowed (self-host, or a plan without the restriction).
+  let allowedModels = null;
+  if (isCloud()) {
+    const { data: org } = await supabaseAdmin
+      .from('organizations')
+      .select('plan, plan_overrides')
+      .eq('id', brand.organization_id)
+      .single();
+    const plan = applyPlanOverrides(getPlan(org?.plan), org);
+    allowedModels = plan.limits.allowedModels ?? null;
+    if (allowedModels) {
+      logger.info({ brandId, allowedModels }, 'api-model tracking plan-gated for this org');
+    }
+  }
+  const allowedModelsFor = (prompt) => {
+    const models = prompt.models && prompt.models.length > 0 ? prompt.models : [];
+    return allowedModels ? models.filter((m) => allowedModels.includes(m)) : models;
+  };
+
   // 4. Count total tasks: prompt × (models + scrapers) × regions
   let totalTasks = 0;
   for (const prompt of prompts) {
-    const mc = prompt.models && prompt.models.length > 0 ? prompt.models.length : 0;
+    const mc = allowedModelsFor(prompt).length;
     const sc = prompt.platforms && prompt.platforms.length > 0 ? prompt.platforms.length : 0;
     const rc = prompt.regions && prompt.regions.length > 0 ? prompt.regions.length : 1;
     totalTasks += (mc + sc) * rc;
@@ -337,7 +361,7 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
   // 7. Phase 2: Run AI model tasks concurrently
   const modelTasks = [];
   for (const prompt of prompts) {
-    const modelsToRun = prompt.models && prompt.models.length > 0 ? prompt.models : [];
+    const modelsToRun = allowedModelsFor(prompt);
     const regionsToRun = prompt.regions && prompt.regions.length > 0 ? prompt.regions : [null];
 
     for (const modelName of modelsToRun) {

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -74,16 +74,18 @@ export default function PromptsPage() {
   const [manualText, setManualText] = useState('');
   const [manualCategory, setManualCategory] = useState('');
   const [generateTopics, setGenerateTopics] = useState<string[] | null>(null);
-  const { planId } = usePlanContext();
+  const { planId, allowedModelIds: planAllowedModelIds } = usePlanContext();
   const { canManage } = useUserRole();
   const allowedScraperIds = useMemo(() => {
     const allowed = PLANS[planId].limits.allowedScrapers;
     return allowed ? [...allowed] : ALL_SCRAPERS.map((s) => s.id);
   }, [planId]);
-  const allowedModelIds = useMemo(() => {
-    const allowed = PLANS[planId].limits.allowedModels;
-    return allowed ? [...allowed] : ALL_MODELS.map((m) => m.id);
-  }, [planId]);
+  // From context, not PLANS[planId]: Enterprise orgs can have Claude switched
+  // on per customer via plan_overrides, which only the layout can see.
+  const allowedModelIds = useMemo(
+    () => planAllowedModelIds ?? ALL_MODELS.map((m) => m.id),
+    [planAllowedModelIds],
+  );
   const visibleScrapers = useMemo(
     () => ALL_SCRAPERS.filter((s) => allowedScraperIds.includes(s.id)),
     [allowedScraperIds],

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
@@ -8,6 +8,7 @@ import { createTopics } from '@/lib/actions/topic';
 import { savePromptSet } from '@/lib/actions/prompt';
 import { addCompetitor } from '@/lib/actions/competitor';
 import { triggerTrackingCheck } from '@/lib/actions/tracking';
+import { usePlanContext } from '@/components/providers/plan-provider';
 import { getFaviconUrl } from '@/lib/favicon';
 import { useBrandStore } from '@/stores/use-brand-store';
 import { REGIONS, LANGUAGES } from '@/config/prompt-options';
@@ -279,7 +280,9 @@ export default function NewBrandPage() {
   const activeScrapers = allowedScraperIds
     ? ALL_SCRAPERS.filter((s) => allowedScraperIds.includes(s.id))
     : ALL_SCRAPERS;
-  const allowedModelIds = currentPlan.limits.allowedModels;
+  // From context, not the static plan config: Enterprise orgs can have Claude
+  // switched on per customer via plan_overrides, which the layout merges in.
+  const { allowedModelIds } = usePlanContext();
   const activeModels = allowedModelIds
     ? ALL_MODELS.filter((m) => allowedModelIds.includes(m.id))
     : ALL_MODELS;

--- a/web/src/app/[locale]/(dashboard)/layout.tsx
+++ b/web/src/app/[locale]/(dashboard)/layout.tsx
@@ -9,7 +9,7 @@ import { RoleProvider, type TeamRole } from '@/components/providers/role-provide
 import { BrandLoader } from '@/components/providers/brand-loader';
 import { BrandGuard } from '@/components/providers/brand-guard';
 import { getBrands } from '@/lib/actions/brand';
-import { isCloud, type PlanId } from '@/config/plans';
+import { getPlan, isCloud, type PlanId } from '@/config/plans';
 import { evaluateSubscriptionAccess } from '@/lib/billing/subscription-access';
 import { SubscriptionExpiredNotice } from '@/components/billing/subscription-expired-notice';
 
@@ -38,7 +38,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
   const [{ data: org }, brands] = await Promise.all([
     supabase
       .from('organizations')
-      .select('plan, subscription_status')
+      .select('plan, subscription_status, plan_overrides')
       .eq('id', profile.organization_id)
       .single(),
     getBrands(profile.organization_id),
@@ -66,11 +66,24 @@ export default async function DashboardLayout({ children }: { children: React.Re
 
   const planId = (org?.plan ?? 'starter') as PlanId;
 
+  // Effective API-model allowlist for the client (null = all allowed).
+  // Enterprise orgs can be switched on per customer via
+  // organizations.plan_overrides — same merge getOrgPlan applies.
+  let allowedModelIds: string[] | null = null;
+  if (isCloud()) {
+    const overrides =
+      planId === 'enterprise' && org?.plan_overrides
+        ? (org.plan_overrides as { allowedModels?: string[] })
+        : null;
+    const effective = overrides?.allowedModels ?? getPlan(planId).limits.allowedModels;
+    allowedModelIds = effective ? [...effective] : null;
+  }
+
   return (
     <>
       <AuthProvider user={user} />
       <BrandLoader brands={brands} />
-      <PlanProvider planId={planId}>
+      <PlanProvider planId={planId} allowedModelIds={allowedModelIds}>
         <RoleProvider role={role}>
           <div className="flex h-screen overflow-hidden">
             {/* Desktop sidebar */}

--- a/web/src/components/providers/plan-provider.tsx
+++ b/web/src/components/providers/plan-provider.tsx
@@ -6,19 +6,43 @@ import type { PlanId } from '@/config/plans';
 interface PlanContextValue {
   planId: PlanId;
   isCloud: boolean;
+  /**
+   * Effective API-model allowlist for the org, with Enterprise
+   * `plan_overrides` already merged server-side (dashboard layout).
+   * `null` means every model is allowed (self-host, or a plan without an
+   * `allowedModels` restriction). Consumers must read this instead of the
+   * static `PLANS[planId].limits.allowedModels`, which can't see
+   * per-customer overrides.
+   */
+  allowedModelIds: string[] | null;
 }
 
 const PlanContext = createContext<PlanContextValue>({
   planId: 'self_hosted',
   isCloud: false,
+  allowedModelIds: null,
 });
 
-export function PlanProvider({ planId, children }: { planId: PlanId; children: React.ReactNode }) {
+export function PlanProvider({
+  planId,
+  allowedModelIds = null,
+  children,
+}: {
+  planId: PlanId;
+  allowedModelIds?: string[] | null;
+  children: React.ReactNode;
+}) {
   const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
   const effectivePlan: PlanId = isCloud ? planId : 'self_hosted';
 
   return (
-    <PlanContext.Provider value={{ planId: effectivePlan, isCloud }}>
+    <PlanContext.Provider
+      value={{
+        planId: effectivePlan,
+        isCloud,
+        allowedModelIds: isCloud ? allowedModelIds : null,
+      }}
+    >
       {children}
     </PlanContext.Provider>
   );

--- a/web/src/config/plans.ts
+++ b/web/src/config/plans.ts
@@ -153,6 +153,9 @@ export const PLANS: Record<PlanId, Plan> = {
       maxSiteAudits: 500,
       maxDailyOnDemand: 10,
       onDemandCooldownMinutes: 5,
+      // API-model tracking (Claude) is not part of Growth — scraper engines
+      // only. Enterprise can get it per customer via plan_overrides below.
+      allowedModels: [],
       features: [
         'basic_insights',
         'prompt_suggestions',
@@ -185,6 +188,12 @@ export const PLANS: Record<PlanId, Plan> = {
       maxSiteAudits: -1,
       maxDailyOnDemand: -1,
       onDemandCooldownMinutes: 0,
+      // API-model tracking (Claude) is a per-customer opt-in on Enterprise:
+      // default off; enable by setting
+      // organizations.plan_overrides = { "allowedModels": ["claude-sonnet-5"] }.
+      // getOrgPlan / the server's applyPlanOverrides merge that over these
+      // limits, so no code change is needed to switch a customer on.
+      allowedModels: [],
       features: [
         'basic_insights',
         'prompt_suggestions',

--- a/web/src/lib/plan-engines.ts
+++ b/web/src/lib/plan-engines.ts
@@ -59,7 +59,23 @@ export async function alignPromptsToPlanForOrg(
   models: string[];
   promptCount: number;
 }> {
-  const { platforms, models } = getActiveEngineIdsForPlan(planId);
+  const { platforms, models: baseModels } = getActiveEngineIdsForPlan(planId);
+
+  // Enterprise: API-model tracking (Claude) is a per-customer opt-in via
+  // organizations.plan_overrides.allowedModels — without this check, an
+  // alignment run would strip Claude from a customer we've enabled it for.
+  let models = baseModels;
+  if (planId === 'enterprise') {
+    const { data: org } = await supabaseAdmin
+      .from('organizations')
+      .select('plan_overrides')
+      .eq('id', orgId)
+      .maybeSingle();
+    const overrides = org?.plan_overrides as { allowedModels?: string[] } | null;
+    if (overrides?.allowedModels) {
+      models = ALL_MODELS.filter((m) => overrides.allowedModels!.includes(m.id)).map((m) => m.id);
+    }
+  }
 
   const { data: brands, error: brandsErr } = await supabaseAdmin
     .from('brands')


### PR DESCRIPTION
## Summary

On cloud, API-model (Claude) tracking is no longer part of **Growth** and becomes a **per-customer opt-in on Enterprise**. Self-host is untouched (`isCloud() === false` always resolves to the unrestricted `self_hosted` plan).

- **Plan config** (web `plans.ts` + server `plans.js`, kept in sync): Growth and Enterprise both set `allowedModels: []`. Enabling a specific Enterprise customer is a single DB write — `organizations.plan_overrides = { "allowedModels": ["claude-sonnet-5"] }` — because the existing override merge (web `getOrgPlan`, server `applyPlanOverrides`) already folds `plan_overrides` into the effective limits. No new mechanism.
- **UI reflects per-customer state**: the dashboard layout now computes the effective model allowlist (overrides included) and threads it through `PlanProvider` as `allowedModelIds`; the prompt pickers (brand prompts page, brands/new, suggestion card via prop) read it from context instead of the static `PLANS[planId]`, which can't see overrides.
- **Plan-change alignment**: `alignPromptsToPlanForOrg` now reads Enterprise `plan_overrides` so an alignment run doesn't strip Claude from a customer we've enabled.
- **Runtime guard in the tracking worker**: `prompt.models` is filtered against the org's effective allowlist at run time (`applyPlanOverrides` exported from the server plan-guard), so stored arrays that still carry Claude ids stop producing API calls immediately on deploy — no data migration required. Task counting uses the filtered list, keeping the progress bar denominator accurate.

Save-path enforcement needed no changes: `filterByPlan` already resolves through `getOrgPlan`.

### Notes

- Known edge: the onboarding wizard reads the static plan config, so an Enterprise org with the override set wouldn't see Claude during (re-)onboarding — models can be added from the prompts page afterwards. Left out deliberately to keep the change small.
- Existing prompts' `models` arrays have already been cleaned up separately; this PR is the standing rule that keeps things consistent going forward.

## Related Issue

N/A — packaging change requested directly.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Chore / refactor
- [ ] 📝 Documentation
- [ ] 🚨 Breaking change

## How to Test

1. Cloud env (`NEXT_PUBLIC_IS_CLOUD=true` / `IS_CLOUD=true`), Growth org → prompt create/edit dialogs show no Claude checkbox; saving a prompt with `models: ["claude-sonnet-5"]` via the action strips it.
2. Enterprise org without overrides → same as Growth (no Claude).
3. Set `plan_overrides = {"allowedModels": ["claude-sonnet-5"]}` on the Enterprise org → after reload, the Claude checkbox appears; saved prompts keep the model; a tracking run calls the Anthropic API.
4. Give a Growth org's prompt a stale `models: ["claude-sonnet-5"]` directly in the DB → the tracking worker logs `api-model tracking plan-gated for this org` and makes no Anthropic call; progress total excludes the skipped task.
5. Self-host (no cloud env vars) → Claude picker visible, tracking runs, nothing gated.

## Checklist

- [x] My code follows the project's style guidelines (Prettier clean)
- [x] I have performed a self-review of my code
- [x] `npx tsc --noEmit` passes
- [x] Web tests pass (45/45), server tests pass (113/113)
- [ ] Manually tested on cloud with a Growth + Enterprise org