### PR TITLE
fix(i18n): guard template name lookups with t.has() to prevent MISSING_MESSAGE crash

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/reports/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/reports/[id]/page.tsx
@@ -171,7 +171,7 @@ export default function ReportDetailPage() {
           </Link>
           <h1 className="text-2xl font-bold tracking-tight">{report.title}</h1>
           <p className="text-sm text-muted-foreground">
-            {KNOWN_TEMPLATE_IDS.has(report.template) && (
+            {KNOWN_TEMPLATE_IDS.has(report.template) && t.has(`templates.${report.template}.name`) && (
               <>{t(`templates.${report.template}.name`)} · </>
             )}
             {formatDate(report.dateFrom)} — {formatDate(report.dateTo)} · {t('generatedOn')}{' '}

--- a/web/src/app/[locale]/(dashboard)/dashboard/reports/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/reports/[id]/page.tsx
@@ -171,9 +171,10 @@ export default function ReportDetailPage() {
           </Link>
           <h1 className="text-2xl font-bold tracking-tight">{report.title}</h1>
           <p className="text-sm text-muted-foreground">
-            {KNOWN_TEMPLATE_IDS.has(report.template) && t.has(`templates.${report.template}.name`) && (
-              <>{t(`templates.${report.template}.name`)} · </>
-            )}
+            {KNOWN_TEMPLATE_IDS.has(report.template) &&
+              t.has(`templates.${report.template}.name`) && (
+                <>{t(`templates.${report.template}.name`)} · </>
+              )}
             {formatDate(report.dateFrom)} — {formatDate(report.dateTo)} · {t('generatedOn')}{' '}
             {formatDate(report.createdAt)}
           </p>

--- a/web/src/app/[locale]/(dashboard)/dashboard/reports/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/reports/page.tsx
@@ -230,7 +230,7 @@ export default function ReportsPage() {
                   <TableRow key={report.id}>
                     <TableCell>
                       <span className="font-medium">{report.title}</span>
-                      {KNOWN_TEMPLATE_IDS.has(report.template) && (
+                      {KNOWN_TEMPLATE_IDS.has(report.template) && t.has(`templates.${report.template}.name`) && (
                         <span className="mt-0.5 block text-xs text-muted-foreground">
                           {t(`templates.${report.template}.name`)}
                         </span>
@@ -299,7 +299,7 @@ export default function ReportsPage() {
                     )}
                   >
                     <div className="flex items-center justify-between gap-2">
-                      <span className="text-sm font-medium">{t(`templates.${tpl.id}.name`)}</span>
+                      <span className="text-sm font-medium">{t.has(`templates.${tpl.id}.name`) ? t(`templates.${tpl.id}.name`) : tpl.id}</span>
                       <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
                         {t(`presets.${tpl.defaultPreset}`)}
                       </span>

--- a/web/src/app/[locale]/(dashboard)/dashboard/reports/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/reports/page.tsx
@@ -230,11 +230,12 @@ export default function ReportsPage() {
                   <TableRow key={report.id}>
                     <TableCell>
                       <span className="font-medium">{report.title}</span>
-                      {KNOWN_TEMPLATE_IDS.has(report.template) && t.has(`templates.${report.template}.name`) && (
-                        <span className="mt-0.5 block text-xs text-muted-foreground">
-                          {t(`templates.${report.template}.name`)}
-                        </span>
-                      )}
+                      {KNOWN_TEMPLATE_IDS.has(report.template) &&
+                        t.has(`templates.${report.template}.name`) && (
+                          <span className="mt-0.5 block text-xs text-muted-foreground">
+                            {t(`templates.${report.template}.name`)}
+                          </span>
+                        )}
                     </TableCell>
                     <TableCell className="text-muted-foreground">
                       {formatDate(report.dateFrom)} — {formatDate(report.dateTo)}
@@ -299,7 +300,9 @@ export default function ReportsPage() {
                     )}
                   >
                     <div className="flex items-center justify-between gap-2">
-                      <span className="text-sm font-medium">{t.has(`templates.${tpl.id}.name`) ? t(`templates.${tpl.id}.name`) : tpl.id}</span>
+                      <span className="text-sm font-medium">
+                        {t.has(`templates.${tpl.id}.name`) ? t(`templates.${tpl.id}.name`) : tpl.id}
+                      </span>
                       <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
                         {t(`presets.${tpl.defaultPreset}`)}
                       </span>

--- a/web/src/app/[locale]/(dashboard)/dashboard/reports/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/reports/page.tsx
@@ -308,7 +308,8 @@ export default function ReportsPage() {
                       </span>
                     </div>
                     <p className="mt-1 text-xs text-muted-foreground">
-                      {t(`templates.${tpl.id}.description`)}
+                      {t.has(`templates.${tpl.id}.description`) &&
+                        t(`templates.${tpl.id}.description`)}
                     </p>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {tpl.sections.map((s) => (


### PR DESCRIPTION
Fixes #420

## Problem

Opening a report detail page crashed with: MISSING_MESSAGE: Could not resolve reports.templates.executive_summary.name in messages for locale en.

The key exists in `en.json` but was unresolvable at runtime due to a stale Turbopack module cache after switching branches without restarting the dev server.

## Fix

Added `t.has()` guards at all three template-name render sites so a missing key silently omits the label instead of throwing:

**`reports/[id]/page.tsx`** — detail page header (crash site):
```tsx
{KNOWN_TEMPLATE_IDS.has(report.template) && t.has(`templates.${report.template}.name`) && (
  <>{t(`templates.${report.template}.name`)} · </>
)}
```

**`reports/page.tsx`** — reports list table cell:
```tsx
{KNOWN_TEMPLATE_IDS.has(report.template) && t.has(`templates.${report.template}.name`) && (
  <span className="mt-0.5 block text-xs text-muted-foreground">
    {t(`templates.${report.template}.name`)}
  </span>
)}
```

**`reports/page.tsx`** — generate dialog template picker (falls back to `tpl.id`):
```tsx
{t.has(`templates.${tpl.id}.name`) ? t(`templates.${tpl.id}.name`) : tpl.id}
```

## Acceptance criteria

- [x] Report detail page renders even when a template-name message key cannot be resolved — label is simply omitted
- [x] Error does **not** reproduce on a clean dev-server start on the branch — confirmed this is a Turbopack HMR staleness artifact, not a real message-loading bug

## Notes

- Requires next-intl v4 `t.has()` API — already on `^4.8.3`
- TypeScript check: zero new errors introduced (248 pre-existing errors before and after)