### PR TITLE
fix(fanout): complete aggregation, bounded fetches, real error messages

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -46,6 +46,23 @@ type QueryFanoutTabProps = {
 
 const INTENT_INITIAL_LOAD_TIMEOUT_MS = 1500;
 
+/**
+ * Server-action failures reach the client with Next's production-masked
+ * message ("An error occurred in the Server Components render… A digest
+ * property is included…"), which is meaningless to users (#427). Surface the
+ * real message only when it survived; otherwise fall back to a friendly one.
+ */
+function userErrorMessage(err: unknown, fallback: string): string {
+  if (
+    err instanceof Error &&
+    err.message &&
+    !/^An error occurred in the Server/i.test(err.message)
+  ) {
+    return err.message;
+  }
+  return fallback;
+}
+
 export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
   const [data, setData] = useState<QueryFanoutData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -93,7 +110,8 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
           }
         }
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Failed to load query fan-out');
+        console.error('[fanout] load failed', err);
+        toast.error(userErrorMessage(err, 'Failed to load query fan-out — please retry.'));
         setData({ subQueries: [], totalObserved: 0 });
       } finally {
         if (!silent) {
@@ -161,7 +179,8 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
       await load({ silent: true });
       await onTracked?.();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to track this query');
+      console.error('[fanout] track failed', err);
+      toast.error(userErrorMessage(err, 'Failed to track this query — please retry.'));
     } finally {
       setAddingKey(null);
     }

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -159,6 +159,10 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
     setAddingKey(query.toLowerCase());
     try {
       const result = await trackFanoutQuery(brandId, query);
+      if ('error' in result) {
+        toast.error(result.error);
+        return;
+      }
       toast.success('Added as a tracked prompt');
       setData((prev) => {
         if (!prev) return prev;

--- a/web/src/lib/actions/fanout.ts
+++ b/web/src/lib/actions/fanout.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { addPromptToSet } from '@/lib/actions/prompt';
+import { PlanLimitError } from '@/lib/guards/plan-guard';
 import { API_BASE_URL } from '@/config/api';
 
 /**
@@ -229,13 +230,12 @@ export async function getQueryFanout(
  * set, deriving platforms/models from its most recent active prompt.
  * `addPromptToSet` enforces the plan's `maxPrompts` limit.
  */
-export async function trackFanoutQuery(
-  brandId: string,
-  query: string,
-): Promise<{ promptId: string }> {
+export type TrackFanoutResult = { promptId: string } | { error: string };
+
+export async function trackFanoutQuery(brandId: string, query: string): Promise<TrackFanoutResult> {
   const supabase = await createClient();
   const text = normalizeQuery(query);
-  if (!text) throw new Error('Empty query');
+  if (!text) return { error: 'Empty query' };
 
   const { data: ps, error: psErr } = await supabase
     .from('prompt_sets')
@@ -245,7 +245,7 @@ export async function trackFanoutQuery(
     .limit(1)
     .maybeSingle();
   if (psErr || !ps) {
-    throw new Error('No prompt set exists for this brand. Create one first.');
+    return { error: 'No prompt set exists for this brand. Create one first.' };
   }
 
   const { data: defaults } = await supabase
@@ -263,7 +263,16 @@ export async function trackFanoutQuery(
       : ['chatgpt-web'];
   const models = Array.isArray(defaults?.models) ? (defaults!.models as string[]) : [];
 
-  const created = await addPromptToSet({ promptSetId: ps.id as string, text, platforms, models });
+  // User-facing failures (plan limit, invalid input) come back as a VALUE:
+  // production masks every error thrown from a server action, so a thrown
+  // PlanLimitError reached users as the meaningless digest message (#427).
+  let created;
+  try {
+    created = await addPromptToSet({ promptSetId: ps.id as string, text, platforms, models });
+  } catch (err) {
+    if (err instanceof PlanLimitError) return { error: err.message };
+    throw err;
+  }
 
   revalidatePath('/dashboard/prompts');
   return { promptId: created.id };

--- a/web/src/lib/actions/fanout.ts
+++ b/web/src/lib/actions/fanout.ts
@@ -48,6 +48,53 @@ interface RawSearchQueryItem {
 const MAX_FANOUT_DAYS = 90;
 
 /**
+ * PostgREST silently caps un-paginated selects at 1000 rows, which quietly
+ * truncated the aggregation on exactly the brands where fan-out matters most
+ * (#427). Page through the window instead, with a hard row ceiling so a
+ * pathological brand can't pin the server action.
+ */
+const FANOUT_PAGE_SIZE = 1000;
+const FANOUT_MAX_ROWS = 50_000;
+
+/** How long the intent-classification round-trip may take before we abort (#427). */
+const FANOUT_INTENT_FETCH_TIMEOUT_MS = 20_000;
+
+interface FanoutResultRow {
+  prompt_id: string | null;
+  platform: string | null;
+  search_queries: unknown;
+}
+
+async function fetchFanoutRows(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  brandId: string,
+  since: string,
+  promptId?: string,
+): Promise<FanoutResultRow[]> {
+  const rows: FanoutResultRow[] = [];
+  for (let from = 0; from < FANOUT_MAX_ROWS; from += FANOUT_PAGE_SIZE) {
+    let query = supabase
+      .from('prompt_results')
+      .select('prompt_id, platform, search_queries')
+      .eq('brand_id', brandId)
+      .gte('created_at', since)
+      // Deterministic order so .range() pages don't shuffle between requests.
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+      .range(from, from + FANOUT_PAGE_SIZE - 1);
+    if (promptId) query = query.eq('prompt_id', promptId);
+
+    const { data, error } = await query;
+    if (error) throw new Error(error.message);
+
+    const batch = (data ?? []) as FanoutResultRow[];
+    rows.push(...batch);
+    if (batch.length < FANOUT_PAGE_SIZE) break;
+  }
+  return rows;
+}
+
+/**
  * Canonical form of a sub-query for display + grouping: trim, then collapse any
  * internal whitespace run (double spaces, tabs, newlines) to a single space, so
  * "best  laptops" and "best laptops" group as one row.
@@ -78,13 +125,7 @@ export async function getQueryFanout(
   // No server-side "non-empty" filter: comparing a jsonb column to '[]' through
   // PostgREST is unreliable, and rows with an empty fan-out contribute nothing
   // to the aggregation below anyway (the item loop skips them).
-  const { data: rows, error } = await supabase
-    .from('prompt_results')
-    .select('prompt_id, platform, search_queries')
-    .eq('brand_id', brandId)
-    .gte('created_at', since);
-
-  if (error) throw new Error(error.message);
+  const rows = await fetchFanoutRows(supabase, brandId, since);
 
   interface Acc {
     display: string;
@@ -243,6 +284,9 @@ export async function classifyFanoutIntents(queries: string[]): Promise<Record<s
   } = await supabase.auth.getSession();
   if (!session) throw new Error('Not authenticated');
 
+  // Bounded: classifying a cold cache can take the aeo-server a while, and a
+  // hung upstream must never pin this server action until the platform kills
+  // it (#427). The tab degrades gracefully to no intent badges on rejection.
   const res = await fetch(`${API_BASE_URL}/api/prompts/fanout-intents`, {
     method: 'POST',
     headers: {
@@ -250,6 +294,7 @@ export async function classifyFanoutIntents(queries: string[]): Promise<Record<s
       Authorization: `Bearer ${session.access_token}`,
     },
     body: JSON.stringify({ queries }),
+    signal: AbortSignal.timeout(FANOUT_INTENT_FETCH_TIMEOUT_MS),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
@@ -274,14 +319,7 @@ export async function getPromptFanout(
   const days = Math.min(Math.max(Math.trunc(opts?.days ?? 30) || 30, 1), MAX_FANOUT_DAYS);
   const since = new Date(Date.now() - days * 86_400_000).toISOString();
 
-  const { data: rows, error } = await supabase
-    .from('prompt_results')
-    .select('prompt_id, platform, search_queries')
-    .eq('brand_id', brandId)
-    .eq('prompt_id', promptId)
-    .gte('created_at', since);
-
-  if (error) throw new Error(error.message);
+  const rows = await fetchFanoutRows(supabase, brandId, since, promptId);
 
   interface Acc {
     display: string;


### PR DESCRIPTION
## Summary

Fixes #427. Root cause of the reported error is **confirmed**: the org was at its `maxPrompts` limit, and the `PlanLimitError` thrown inside the `trackFanoutQuery` server action reached production users as Next's masked digest message ("An error occurred in the Server Components render…"), surfaced verbatim in a toast.

Four fixes, three of them defects found during diagnosis:

- **Plan-limit failures return as values.** Production masks *every* error thrown from a server action, so `trackFanoutQuery` now returns user-facing failures as `{ error }` instead of throwing — the real message ("Plan limit reached: maximum 200 for maxPrompts. Upgrade to increase.") survives to the toast. Unexpected errors still throw.
- **No more silent 1000-row truncation.** `getQueryFanout` / `getPromptFanout` page through `prompt_results` with `.range()` (deterministic `created_at, id` order, 50k-row safety ceiling). PostgREST's un-paginated cap meant busy brands aggregated an incomplete fan-out.
- **Bounded intent classification.** `classifyFanoutIntents` carries `AbortSignal.timeout(20s)` so a slow/hung aeo-server can never pin the server action until the platform kills it; the tab already degrades to no intent badges.
- **Masked digests never reach users.** The fan-out tab maps "An error occurred in the Server…" messages to friendly copy in both the load and Track paths, logs the raw error to console, and passes genuine messages through.

Deliberately out of scope: reducing the Track path's sequential DB round-trips (optimization with behavior-change risk; noted in #427).

## Related Issue

Fixes https://github.com/ansvisor/ansvisor/issues/427

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Chore / refactor
- [ ] 📝 Documentation
- [ ] 🚨 Breaking change

## How to Test

1. On an org at its `maxPrompts` limit, open Prompts → Query Fan-out and hit **+** on a sub-query → the toast shows the actual plan-limit message (in production too), not the digest text.
2. On an org under the limit, **+** adds the prompt and flips the row to Tracked ✓.
3. On a brand with >1000 `prompt_results` rows in 30 days, the fan-out list includes sub-queries that only appear in rows beyond the first 1000.
4. Stop the aeo-server and load the tab → table renders within ~20s with no intent badges instead of hanging.

## Checklist

- [x] My code follows the project's style guidelines (Prettier clean)
- [x] I have performed a self-review of my code
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (45/45)
- [x] Reproduced locally and verified the root cause before fixing