### PR TITLE
fix(shopping): keep chatgpt-shopping off brands that have Shopping disabled

### DIFF
--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -26,7 +26,7 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
   // 1. Fetch brand info with domains
   const { data: brand, error: brandErr } = await supabaseAdmin
     .from('brands')
-    .select('id, name, organization_id')
+    .select('id, name, organization_id, shopping_mode_enabled')
     .eq('id', brandId)
     .single();
   if (brandErr || !brand) throw new Error(`Brand not found: ${brandId}`);
@@ -108,11 +108,23 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
     return allowedModels ? models.filter((m) => allowedModels.includes(m)) : models;
   };
 
+  // Shopping tracking is opt-in per brand: prompts can still carry the
+  // chatgpt-shopping platform from before the brand turned Shopping off (or
+  // from a picker that offered it regardless of the pref), so filter at run
+  // time instead of trusting the stored arrays — each skipped task is a paid
+  // Cloro scrape for data the brand can't even see.
+  const allowedPlatformsFor = (prompt) => {
+    const platforms = prompt.platforms && prompt.platforms.length > 0 ? prompt.platforms : [];
+    return brand.shopping_mode_enabled
+      ? platforms
+      : platforms.filter((p) => p !== 'chatgpt-shopping');
+  };
+
   // 4. Count total tasks: prompt × (models + scrapers) × regions
   let totalTasks = 0;
   for (const prompt of prompts) {
     const mc = allowedModelsFor(prompt).length;
-    const sc = prompt.platforms && prompt.platforms.length > 0 ? prompt.platforms.length : 0;
+    const sc = allowedPlatformsFor(prompt).length;
     const rc = prompt.regions && prompt.regions.length > 0 ? prompt.regions.length : 1;
     totalTasks += (mc + sc) * rc;
   }
@@ -133,7 +145,7 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
   // 6. Phase 1: Collect & run all scraper (platform) tasks first
   const scraperTasks = [];
   for (const prompt of prompts) {
-    const scrapersToRun = prompt.platforms && prompt.platforms.length > 0 ? prompt.platforms : [];
+    const scrapersToRun = allowedPlatformsFor(prompt);
     const regionsToRun = prompt.regions && prompt.regions.length > 0 ? prompt.regions : [null];
 
     for (const scraperId of scrapersToRun) {

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -78,8 +78,11 @@ export default function PromptsPage() {
   const { canManage } = useUserRole();
   const allowedScraperIds = useMemo(() => {
     const allowed = PLANS[planId].limits.allowedScrapers;
-    return allowed ? [...allowed] : ALL_SCRAPERS.map((s) => s.id);
-  }, [planId]);
+    const ids = allowed ? [...allowed] : ALL_SCRAPERS.map((s) => s.id);
+    // Shopping tracking is opt-in per brand (#155): hide the engine entirely
+    // when the pref is off. The write actions strip it server-side too.
+    return brand?.shoppingModeEnabled ? ids : ids.filter((id) => id !== 'chatgpt-shopping');
+  }, [planId, brand?.shoppingModeEnabled]);
   // From context, not PLANS[planId]: Enterprise orgs can have Claude switched
   // on per customer via plan_overrides, which only the layout can see.
   const allowedModelIds = useMemo(

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -20,6 +20,21 @@ function filterByPlan(plan: Plan, platforms: string[], models: string[]) {
   };
 }
 
+/**
+ * Shopping tracking is opt-in per brand (#155). Every prompt write must pass
+ * through this: with the pref OFF, `chatgpt-shopping` is stripped no matter
+ * where it came from — the pickers offer the full engine list, and inherited
+ * defaults (fan-out Track copies the latest prompt's platforms) would
+ * otherwise keep leaking paid shopping scrapes onto brands that can't even
+ * see the data.
+ */
+function stripShoppingWhenDisabled(
+  platforms: string[],
+  shoppingEnabled: boolean | null | undefined,
+): string[] {
+  return shoppingEnabled ? platforms : platforms.filter((p) => p !== 'chatgpt-shopping');
+}
+
 // ─── Row Mappers ──────────────────────────────────────────────────────────────
 
 function mapPromptRow(row: Record<string, unknown>): Prompt {
@@ -180,6 +195,13 @@ export async function savePromptSet(input: SavePromptSetInput): Promise<PromptSe
   let insertedPrompts: Record<string, unknown>[] = [];
 
   if (input.prompts.length > 0) {
+    const { data: brandRow } = await supabase
+      .from('brands')
+      .select('shopping_mode_enabled')
+      .eq('id', input.brandId)
+      .single();
+    const shoppingEnabled = !!brandRow?.shopping_mode_enabled;
+
     const categories = [
       ...new Set(input.prompts.map((p) => p.category).filter(Boolean)),
     ] as string[];
@@ -196,7 +218,8 @@ export async function savePromptSet(input: SavePromptSetInput): Promise<PromptSe
       .insert(
         input.prompts.map((p) => {
           const filtered = filterByPlan(plan, p.platforms, p.models ?? []);
-          if (filtered.platforms.length === 0 && filtered.models.length === 0) {
+          const platforms = stripShoppingWhenDisabled(filtered.platforms, shoppingEnabled);
+          if (platforms.length === 0 && filtered.models.length === 0) {
             throw new Error('At least one platform or model must be selected for each prompt.');
           }
           return {
@@ -204,7 +227,7 @@ export async function savePromptSet(input: SavePromptSetInput): Promise<PromptSe
             text: p.text,
             category: p.category || null,
             topic_id: (p.category && topicIdMap.get(p.category)) || null,
-            platforms: filtered.platforms,
+            platforms,
             regions: [brandRegion],
             models: filtered.models,
             is_active: p.isActive ?? true,
@@ -254,19 +277,23 @@ export async function updatePrompt(
   if (updates.platforms !== undefined || updates.models !== undefined) {
     const { data: promptRow } = await supabase
       .from('prompts')
-      .select('prompt_sets!inner(brands!inner(organization_id))')
+      .select('prompt_sets!inner(brands!inner(organization_id, shopping_mode_enabled))')
       .eq('id', id)
       .single();
-    const orgId = (promptRow?.prompt_sets as { brands: { organization_id: string } })?.brands
-      ?.organization_id;
-    if (!orgId) throw new Error('Prompt not found');
+    const brandRow = (
+      promptRow?.prompt_sets as {
+        brands: { organization_id: string; shopping_mode_enabled: boolean | null };
+      }
+    )?.brands;
+    if (!brandRow?.organization_id) throw new Error('Prompt not found');
 
-    const plan = await getOrgPlan(orgId);
+    const plan = await getOrgPlan(brandRow.organization_id);
     const filtered = filterByPlan(plan, updates.platforms ?? [], updates.models ?? []);
-    if (filtered.platforms.length === 0 && filtered.models.length === 0) {
+    const platforms = stripShoppingWhenDisabled(filtered.platforms, brandRow.shopping_mode_enabled);
+    if (platforms.length === 0 && filtered.models.length === 0) {
       throw new Error('At least one platform or model must be selected.');
     }
-    if (updates.platforms !== undefined) payload.platforms = filtered.platforms;
+    if (updates.platforms !== undefined) payload.platforms = platforms;
     if (updates.models !== undefined) payload.models = filtered.models;
   }
 
@@ -318,10 +345,10 @@ export async function addPromptToSet(input: AddPromptInput): Promise<Prompt> {
 
   const topicId = await resolveTopicId(supabase, ps.brand_id as string, input.category);
 
-  // #155 — if the brand has Shopping mode on, every new prompt gets the
-  // chatgpt-shopping platform appended automatically so the user doesn't
-  // have to remember to flip it for each prompt. The caller's filtered
-  // platforms still take precedence; we just ensure inclusion.
+  // #155 — the brand's Shopping pref drives chatgpt-shopping BOTH ways: on
+  // means every new prompt gets it appended automatically (the user doesn't
+  // flip it per prompt), off means it's stripped even when inherited from a
+  // picker default or a copied platform list.
   const { data: brandRow } = await supabase
     .from('brands')
     .select('shopping_mode_enabled')
@@ -329,7 +356,10 @@ export async function addPromptToSet(input: AddPromptInput): Promise<Prompt> {
     .single();
   const platforms = brandRow?.shopping_mode_enabled
     ? Array.from(new Set([...filtered.platforms, 'chatgpt-shopping']))
-    : filtered.platforms;
+    : stripShoppingWhenDisabled(filtered.platforms, false);
+  if (platforms.length === 0 && filtered.models.length === 0) {
+    throw new Error('At least one platform or model must be selected.');
+  }
 
   const { data, error } = await supabase
     .from('prompts')


### PR DESCRIPTION
## Summary

Shopping tracking is opt-in per brand (#155), but nothing enforced the OFF side. Two shopping-disabled brands had accumulated `chatgpt-shopping` on 111 active prompts — roughly 700 paid Cloro scrapes a week for data those brands can't even see, with the rows leaking into analytics surfaces. How it spread: the engine pickers offered (and default-checked) ChatGPT Shopping regardless of the brand pref, fan-out Track copies the latest prompt's platforms verbatim, and the tracking worker runs whatever the stored arrays say.

Three enforcement layers, so this can't regrow:

- **Prompt write actions** (`addPromptToSet`, `savePromptSet`, `updatePrompt`) strip `chatgpt-shopping` when the brand's pref is off — one server-side choke point covers manual adds, suggestion accepts and fan-out Track. The pref-ON behavior is unchanged: `addPromptToSet` still auto-appends the platform, so fan-out Track on a Shopping-enabled brand keeps getting it.
- **Tracking worker** filters `prompt.platforms` by the brand pref at run time (same pattern as the plan-gated model filter), so already-contaminated arrays stop producing paid scrapes immediately on deploy.
- **Brand prompts page** hides the ChatGPT Shopping engine checkbox when the pref is off.

The existing 111 contaminated prompt rows were cleaned up separately (verified: 0 remaining on shopping-disabled brands; Shopping-enabled brands untouched).

## Related Issue

Found while investigating the citations mismatch behind #429/#430.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Chore / refactor
- [ ] 📝 Documentation
- [ ] 🚨 Breaking change

## How to Test

1. On a brand with Shopping **off**: the prompts page engine picker shows no ChatGPT Shopping option; adding a prompt (manual, suggestion, or fan-out Track) never persists `chatgpt-shopping` in `prompts.platforms`.
2. On a brand with Shopping **on**: new prompts (including fan-out Track) still get `chatgpt-shopping` appended automatically.
3. Give a Shopping-off brand's prompt a stale `platforms: [..., "chatgpt-shopping"]` directly in the DB → a tracking run submits no shopping scrape and the progress total excludes it.
4. Editing a prompt on a Shopping-off brand strips the platform on save; on a Shopping-on brand the user's selection is preserved.

## Checklist

- [x] My code follows the project's style guidelines (Prettier clean)
- [x] I have performed a self-review of my code
- [x] `npx tsc --noEmit` passes
- [x] Web tests pass (45/45), server tests pass (113/113)
- [x] Data cleanup executed and verified against production