### PR TITLE
fix(citations): exclude chatgpt-shopping rows to match the insights KPIs

### DIFF
--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -168,7 +168,14 @@ async function scanFilteredResults<T>(
 
   let total = 0;
   for (let offset = 0; offset < CITATIONS_SCAN_MAX_ROWS; offset += CITATIONS_SCAN_PAGE_SIZE) {
-    let query = supabase.from('prompt_results').select(select).eq('brand_id', brandId);
+    let query = supabase
+      .from('prompt_results')
+      .select(select)
+      .eq('brand_id', brandId)
+      // #155 — chatgpt-shopping rows are isolated from analytical aggregates.
+      // The insights KPIs already exclude them; without this, the Citations
+      // page counted a superset of what the KPI counts.
+      .neq('platform', 'chatgpt-shopping');
     if (from) query = query.gte('created_at', from);
     if (expandedTo) query = query.lte('created_at', expandedTo);
     if (filters.platforms && filters.platforms.length > 0) {


### PR DESCRIPTION
## Summary

Recovers a commit orphaned by timing: #430 was merged just before this landed on its branch, so the squash didn't include it (GitHub's "recent pushes" banner on `fix/citations-pagination` was pointing at exactly this).

The insights aggregates exclude `chatgpt-shopping` (#155) but the citations scans did not, so the Citations page counted a superset of what the KPI counts — verified as the remaining source of the own-domain citation mismatch (e.g. 43 vs 25 on a 7-day window, where 18 of the 43 came from shopping rows). One-line filter in the shared `scanFilteredResults` scanner from #430, so the overview, gaps view, and report citations section all align with the KPIs.

## Related Issue

Completes the mismatch fix started in #430; verified locally end-to-end (Citations own-domain = Insights KPI on both a shopping-off and a shopping-on brand).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Chore / refactor
- [ ] 📝 Documentation
- [ ] 🚨 Breaking change

## How to Test

1. On a brand with chatgpt-shopping results in the window, Citations totals (and the own-domain filter) match the Insights KPIs for the same range.
2. Shopping data remains fully visible in the Shopping module — only analytical aggregates exclude it.

## Checklist

- [x] My code follows the project's style guidelines (Prettier clean)
- [x] I have performed a self-review of my code
- [x] `npx tsc --noEmit` passes
- [x] Web tests pass (45/45)
- [x] Manually verified locally (the mismatch closes with this commit applied)