### PR TITLE
fix(opportunities): prevent prompt index leak in generated titles/descriptions (#424)

### DIFF
--- a/server/src/lib/opportunity-generator.js
+++ b/server/src/lib/opportunity-generator.js
@@ -13,8 +13,16 @@ const opportunitySchema = z.object({
   opportunities: z
     .array(
       z.object({
-        title: z.string(),
-        description: z.string(),
+        title: z
+          .string()
+          .describe(
+            'A specific, actionable content recommendation. Never reference prompts by their bracketed index like [0] or "Prompt 3" — name the topic or paraphrase the prompt text instead.',
+          ),
+        description: z
+          .string()
+          .describe(
+            'A 1-2 sentence explanation of why this action matters, referencing specific metrics. Never reference prompts by their bracketed index like [0] or "Prompt 3" — name the topic or paraphrase the prompt text instead.',
+          ),
         type: z.enum(['owned', 'earned']),
         impact: z.enum(['high', 'medium', 'low']),
         relatedPromptIndex: z.number(),
@@ -30,7 +38,8 @@ Rules:
 - Reference specific data points: volumes, visibility scores, competitor gaps.
 - Focus on content that will improve the brand's visibility in AI-generated answers.
 - Categorize as "owned" or "earned".
-- Generate between 5 and 15 opportunities.`;
+- Generate between 5 and 15 opportunities.
+- The bracketed [N] indexes in the prompt data exist ONLY for the relatedPromptIndex field. NEVER mention an index like "[0]" or "Prompt 3" in titles or descriptions — refer to the prompt by quoting or paraphrasing its actual text/topic instead.`;
 
 function computeScore(volume, visibility, competitorGap, intent) {
   const weights = {

--- a/server/src/workers/content-worker.js
+++ b/server/src/workers/content-worker.js
@@ -16,11 +16,13 @@ const opportunitySchema = z.object({
       z.object({
         title: z
           .string()
-          .describe('A specific, actionable content recommendation backed by the data provided'),
+          .describe(
+            'A specific, actionable content recommendation backed by the data provided. Never reference prompts by their bracketed index like [0] or "Prompt 3" — name the topic or paraphrase the prompt text instead.',
+          ),
         description: z
           .string()
           .describe(
-            'A 1-2 sentence explanation of why this action matters, referencing specific metrics',
+            'A 1-2 sentence explanation of why this action matters, referencing specific metrics. Never reference prompts by their bracketed index like [0] or "Prompt 3" — name the topic or paraphrase the prompt text instead.',
           ),
         type: z
           .enum(['owned', 'earned'])
@@ -48,7 +50,8 @@ Rules:
 - Categorize as "owned" (blog posts, landing pages, FAQ pages the brand controls) or "earned" (guest posts, PR, review sites).
 - Set impact based on: volume × (100 - current visibility) × competitor gap.
 - Generate between 5 and 15 opportunities depending on data richness.
-- Do NOT repeat the same recommendation in different wording.`;
+- Do NOT repeat the same recommendation in different wording.
+- The bracketed [N] indexes in the prompt data exist ONLY for the relatedPromptIndex field. NEVER mention an index like "[0]" or "Prompt 3" in titles or descriptions — refer to the prompt by quoting or paraphrasing its actual text/topic instead.`;
 
 function computeOpportunityScore(volume, visibility, competitorGap, intent) {
   const intentWeights = {


### PR DESCRIPTION
## Summary

Closes #424

Fixes a bug where the LLM occasionally used internal bracketed prompt
indexes like `[0]` or `"Prompt 3"` in user-facing opportunity titles and
descriptions (e.g. *"For Prompt [0] specifically, there is 32,880 monthly
AI volume..."*). Users reading the opportunity card have no idea what
`Prompt [0]` means — it's a pure internal artifact.

## Root Cause

Both generation paths label the prompt list with `[${i}]` so the model
can return a `relatedPromptIndex` to link each opportunity back to the
right `prompt_id`. Nothing told the model these indexes existed **only**
for that field, so it occasionally leaked them into the prose.

## Fix

Two-layer defense in **both** generation paths
(`content-worker.js` and `opportunity-generator.js`), as the issue
recommends — with `generateObject`, models weight per-field schema
descriptions heavily, and the system-prompt rule alone doesn't reliably
stop the leak:

**1. System prompt rule (new bullet in both files):**

The bracketed [N] indexes in the prompt data exist ONLY for the
relatedPromptIndex field. NEVER mention an index like "[0]" or
"Prompt 3" in titles or descriptions — refer to the prompt by
quoting or paraphrasing its actual text/topic instead.

**2. Hardened Zod schema `.describe()` on both `title` and `description`
fields (both files):**

Never reference prompts by their bracketed index like [0] or "Prompt 3"
— name the topic or paraphrase the prompt text instead.

Note: `opportunity-generator.js` had no `.describe()` on `title` or
`description` at all before this PR — both fields were bare `z.string()`
with no guidance, which made the leak more likely in that path.

## What was NOT changed

- `relatedPromptIndex` field and its resolution logic are untouched in
  both files — opportunities still link to the correct `prompt_id`
- No regex post-processing was added (rejected per issue: descriptions
  are generated in the brand's language, so index-mention patterns vary
  too much to strip safely)
- Existing bad rows self-heal on the next worker run (the worker deletes
  `status='new'` opportunities and regenerates)

## Acceptance criteria

- ✅ Both generation paths carry the new rules
- ✅ `relatedPromptIndex` resolution is untouched
- ✅ Prettier, ESLint, and all 115 tests pass

