### PR TITLE
feat: Citations page: CSV export for Top Domains / Top URLs

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -20,6 +20,7 @@ import {
   Loader2,
   Info,
   Plus,
+  Download,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useBrandStore } from '@/stores/use-brand-store';
@@ -48,6 +49,7 @@ import {
   ComboboxTrigger,
   ComboboxValue,
 } from '@/components/ui/combobox';
+import { toCsv } from '@/lib/csv';
 import type { Topic } from '@/types';
 import { SOURCE_CATEGORY_LABELS, type SourceCategory } from '@/lib/citations/classify';
 import { getFaviconUrl } from '@/lib/favicon';
@@ -1311,6 +1313,22 @@ function getDateRange(
   return { dateFrom: from.toISOString() };
 }
 
+function triggerDownload(csv: string, filename: string) {
+  const blob = new Blob([csv], {
+    type: 'text/csv;charset=utf-8;',
+  });
+
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = filename;
+  link.click();
+
+  URL.revokeObjectURL(url);
+}
+
 export default function CitationsPage() {
   const t = useTranslations('citations');
   const { getActiveBrand } = useBrandStore();
@@ -1324,6 +1342,7 @@ export default function CitationsPage() {
   const domainPager = usePagination(data?.rows?.length ?? 0, filterKey);
   const urlPager = usePagination(data?.urlRows?.length ?? 0, filterKey);
   const [isLoading, setIsLoading] = useState(true);
+  const [isExporting, setIsExporting] = useState(false);
   const [topics, setTopics] = useState<Topic[]>([]);
   const [prompts, setPrompts] = useState<PromptOption[]>([]);
   const [availablePlatforms, setAvailablePlatforms] = useState<PlatformOption[]>([]);
@@ -1469,6 +1488,69 @@ export default function CitationsPage() {
     [totals, t],
   );
 
+  const handleExportCsv = useCallback(() => {
+    if (!brand || !data) return;
+
+    setIsExporting(true);
+
+    try {
+      const date = new Date().toISOString().slice(0, 10);
+      const slug = brand.slug ?? 'brand';
+
+      if (sourceTab === 'domains') {
+        const DOMAIN_HEADERS = [
+          'domain',
+          'category',
+          'total_citations',
+          'results_citing',
+          'usage_pct',
+          'models',
+        ];
+
+        const rows = (data.rows ?? []).map((r) => ({
+          domain: r.domain,
+          category: r.category,
+          total_citations: r.totalCitations,
+          results_citing: r.resultsCiting,
+          usage_pct: r.usagePct,
+          models: r.models.join(', '),
+        }));
+
+        const csv = toCsv(rows, DOMAIN_HEADERS);
+
+        triggerDownload(csv, `ansvisor_${slug}_citations_domains_${date}.csv`);
+      } else if (sourceTab === 'urls') {
+        const URL_HEADERS = [
+          'url',
+          'domain',
+          'category',
+          'title',
+          'total_citations',
+          'results_citing',
+          'usage_pct',
+        ];
+
+        const rows = (data.urlRows ?? []).map((r) => ({
+          url: r.url,
+          domain: r.domain,
+          category: r.category,
+          title: r.title ?? '',
+          total_citations: r.totalCitations,
+          results_citing: r.resultsCiting,
+          usage_pct: r.usagePct,
+        }));
+
+        const csv = toCsv(rows, URL_HEADERS);
+
+        triggerDownload(csv, `ansvisor_${slug}_citations_urls_${date}.csv`);
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to export CSV');
+    } finally {
+      setIsExporting(false);
+    }
+  }, [brand, data, sourceTab]);
+
   if (!brand) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
@@ -1486,6 +1568,20 @@ export default function CitationsPage() {
           <h1 className="text-2xl font-bold">{t('title')}</h1>
           <p className="mt-1 text-sm text-muted-foreground">{t('description')}</p>
         </div>
+        <Button
+          variant="outline"
+          className="gap-2"
+          onClick={handleExportCsv}
+          disabled={isExporting || sourceTab === 'gaps' || isLoading}
+        >
+          {isExporting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4" />
+          )}
+
+          {isExporting ? 'Exporting...' : 'Export CSV'}
+        </Button>
       </div>
 
       <FilterBar


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

Wires the CSV export functionality to Citations dashboard.

This change introduces an "Export CSV" action that allows users to download citation data directly from the dashboard. The export supports:
- Domains tab: exports domain-level citation data including category, citation count, results, usage percentage, and models.
- URLs tab: exports URL-level citation data including URL, domain, title, citation count, results, and usage percentage.

The export is handled client-side using the existing CSV utility and generates downloadable CSV files with appropriate filenames. The export button includes loading/disabled states and is disabled for unsupported tabs (such as Competitor Gaps).

Users can now export citation data from the Domains and URLs tabs as CSV files. The export respects the currently loaded citation data and generates downloadable CSV files with relevant fields such as domain, URL, category, citations, results, usage percentage, and models.

## Related issue
closes #436 
<!-- e.g. Closes #123 -->

## Type of change

<!-- Check all that apply -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
<img width="955" height="523" alt="Screenshot 2026-07-16 190602" src="https://github.com/user-attachments/assets/2bfc6cd7-a2de-499b-8afa-d72dc478c844" />
