### PR TITLE
Query Fan-out: open on the 'By prompt' view by default

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -70,7 +70,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
   // Intent is keyed by the lower-cased sub-query (matches the server cache key).
   const [intents, setIntents] = useState<Record<string, string>>({});
   const [page, setPage] = useState(1);
-  const [view, setView] = useState<View>('frequency');
+  const [view, setView] = useState<View>('by-prompt');
   const [searchText, setSearchText] = useState('');
   const PAGE_SIZE = 10;
 
@@ -202,17 +202,6 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
               <button
                 className={cn(
                   'rounded px-3 py-1 text-xs font-medium transition-colors',
-                  view === 'frequency'
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground',
-                )}
-                onClick={() => setView('frequency')}
-              >
-                High frequency
-              </button>
-              <button
-                className={cn(
-                  'rounded px-3 py-1 text-xs font-medium transition-colors',
                   view === 'by-prompt'
                     ? 'bg-background text-foreground shadow-sm'
                     : 'text-muted-foreground hover:text-foreground',
@@ -220,6 +209,17 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
                 onClick={() => setView('by-prompt')}
               >
                 By prompt
+              </button>
+              <button
+                className={cn(
+                  'rounded px-3 py-1 text-xs font-medium transition-colors',
+                  view === 'frequency'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                onClick={() => setView('frequency')}
+              >
+                High frequency
               </button>
             </div>
           )}


### PR DESCRIPTION
# Query Fan-out: open on the 'By prompt' view by default

## Summary

The fan-out tab in the dashboard was opening on the "High frequency" view by default, but the issue requested it to open on the "By prompt" view. Additionally, the toggle button order had "High frequency" first, but the desired order is "By prompt" then "High frequency".

This PR changes the default view state from 'frequency' to 'by-prompt' and swaps the order of the two toggle buttons so that "By prompt" appears first.

Fixes #445

## Changes

- Changed initial state of `view` in `useState` from 'frequency' to 'by-prompt' in `web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx`.
- Swapped the order of the toggle buttons in the card header so that the "By prompt" button is first, updating the conditional class names accordingly.

## Testing

- Ran `yarn lint` in the `web/` directory: produced 9 warnings (all pre-existing, no new errors introduced).
- Ran `yarn typecheck` in the `web/` directory: succeeded with no errors.
- Ran `yarn format:check` in the `web/` directory: succeeded with all files formatted correctly.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
