### PR TITLE
Feature: Add pagination and filtering for AI referral visits on traffic page

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -45,9 +45,22 @@ import {
   Code,
   Copy,
   Check,
+  Search,
+  X,
+  Loader2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const PAGE_SIZE = 10;
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
@@ -177,6 +190,160 @@ function timeAgo(dateStr: string): string {
   return `${days}d ago`;
 }
 
+// ─── Filter Bar ───────────────────────────────────────────────────────────────
+
+interface TrafficFilters {
+  platform: string;
+  search: string;
+}
+
+function TrafficFilterBar({
+  searchInput,
+  onSearchInputChange,
+  filters,
+  onChange,
+  platforms,
+  isLoading,
+}: {
+  searchInput: string;
+  onSearchInputChange: (value: string) => void;
+  filters: TrafficFilters;
+  onChange: (patch: Partial<TrafficFilters>) => void;
+  platforms: string[];
+  isLoading: boolean;
+}) {
+  const hasActiveFilters = filters.platform || filters.search;
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <div className="relative flex-1 min-w-[240px]">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          type="text"
+          placeholder="Search by URL or path..."
+          value={searchInput}
+          onChange={(e) => onSearchInputChange(e.target.value)}
+          className="pl-9 h-9 text-sm"
+          disabled={isLoading}
+        />
+      </div>
+
+      <Select
+        value={filters.platform || ''}
+        onValueChange={(v) => onChange({ platform: v || '' })}
+        disabled={isLoading}
+      >
+        <SelectTrigger className="w-40 h-9 text-sm">
+          <SelectValue placeholder="All platforms" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="">All platforms</SelectItem>
+          {platforms.map((p) => (
+            <SelectItem key={p} value={p}>
+              {getPlatformName(p)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {hasActiveFilters && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-9 gap-2"
+          onClick={() => {
+            onSearchInputChange('');
+            onChange({ platform: '', search: '' });
+          }}
+          disabled={isLoading}
+        >
+          <X className="h-3.5 w-3.5" />
+          Clear filters
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+function TablePager({
+  page,
+  totalPages,
+  total,
+  start,
+  end,
+  onPage,
+  isLoading,
+}: {
+  page: number;
+  totalPages: number;
+  total: number;
+  start: number;
+  end: number;
+  onPage: (p: number) => void;
+  isLoading: boolean;
+}) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-between border-t px-4 py-3">
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {start + 1}–{end} of {total}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 px-3 text-xs"
+          disabled={page === 0 || isLoading}
+          onClick={() => onPage(page - 1)}
+        >
+          Previous
+        </Button>
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {page + 1} / {totalPages}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 px-3 text-xs"
+          disabled={page >= totalPages - 1 || isLoading}
+          onClick={() => onPage(page + 1)}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Empty State ──────────────────────────────────────────────────────────────
+
+function EmptyLogsState({ hasFilters }: { hasFilters: boolean }) {
+  if (hasFilters) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <Search className="h-10 w-10 text-muted-foreground/40 mb-3" />
+        <h3 className="text-sm font-medium">No matching visits</h3>
+        <p className="text-xs text-muted-foreground mt-1 max-w-md">
+          Try adjusting your filters or search terms.
+        </p>
+      </div>
+    );
+  } else {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <LayoutList className="h-10 w-10 text-muted-foreground/40 mb-3" />
+        <h3 className="text-sm font-medium">No visits yet</h3>
+        <p className="text-xs text-muted-foreground mt-1 max-w-md">
+          Once visitors arrive from AI platforms, their visits will appear here.
+        </p>
+      </div>
+    );
+  }
+}
+
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function TrafficPage() {
@@ -187,31 +354,71 @@ export default function TrafficPage() {
   const [trend, setTrend] = useState<TrafficTrendPoint[]>([]);
   const [logs, setLogs] = useState<TrafficLog[]>([]);
   const [logsTotal, setLogsTotal] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingSummary, setIsLoadingSummary] = useState(true);
+  const [isLoadingLogs, setIsLoadingLogs] = useState(false);
 
-  const load = useCallback(async () => {
+  const [filters, setFilters] = useState<TrafficFilters>({ platform: '', search: '' });
+  const [searchInput, setSearchInput] = useState(filters.search);
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    setPage(0);
+  }, [filters.platform, filters.search]);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      setFilters((prevFilters) =>
+        prevFilters.search === searchInput ? prevFilters : { ...prevFilters, search: searchInput },
+      );
+    }, 300);
+
+    return () => window.clearTimeout(id);
+  }, [searchInput]);
+
+  const loadSummary = useCallback(async () => {
     if (!brand) return;
-    setIsLoading(true);
+    setIsLoadingSummary(true);
     try {
-      const [s, t, l] = await Promise.all([
-        getTrafficSummary(brand.id),
-        getTrafficTrend(brand.id),
-        getTrafficLogs(brand.id, { limit: 10 }),
-      ]);
+      const [s, t] = await Promise.all([getTrafficSummary(brand.id), getTrafficTrend(brand.id)]);
       setSummary(s);
       setTrend(t);
-      setLogs(l.logs);
-      setLogsTotal(l.total);
     } catch (err) {
-      console.error('Failed to load traffic data:', err);
+      console.error('Failed to load traffic summary:', err);
     } finally {
-      setIsLoading(false);
+      setIsLoadingSummary(false);
     }
   }, [brand]);
 
+  const loadLogs = useCallback(async () => {
+    if (!brand) return;
+    setIsLoadingLogs(true);
+    try {
+      const result = await getTrafficLogs(brand.id, {
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
+        platform: filters.platform || undefined,
+        search: filters.search || undefined,
+      });
+      setLogs(result.logs);
+      setLogsTotal(result.total);
+    } catch (err) {
+      console.error('Failed to load traffic logs:', err);
+    } finally {
+      setIsLoadingLogs(false);
+    }
+  }, [brand, page, filters.platform, filters.search]);
+
+  const handleFiltersChange = useCallback((patch: Partial<TrafficFilters>) => {
+    setFilters((f) => ({ ...f, ...patch }));
+  }, []);
+
   useEffect(() => {
-    load();
-  }, [load]);
+    loadSummary();
+  }, [loadSummary]);
+
+  useEffect(() => {
+    loadLogs();
+  }, [loadLogs]);
 
   if (!brand) {
     return (
@@ -226,7 +433,7 @@ export default function TrafficPage() {
 
   const primaryDomain = brand.domains.find((d) => d.isPrimary)?.domain ?? brand.domains[0]?.domain;
 
-  if (isLoading) {
+  if (isLoadingSummary) {
     return (
       <div className="space-y-6">
         <div>
@@ -418,60 +625,101 @@ export default function TrafficPage() {
             </Card>
           </div>
 
-          {/* Recent Visit Log */}
+          {/* Recent Visit Log with filtering and pagination*/}
           <Card>
-            <CardHeader className="pb-2">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <LayoutList className="h-4 w-4 text-muted-foreground" />
-                  <CardTitle className="text-sm font-medium">Recent AI Referral Visits</CardTitle>
+            <CardHeader className="pb-3">
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <LayoutList className="h-4 w-4 text-muted-foreground" />
+                    <CardTitle className="text-sm font-medium">Recent AI Referral Visits</CardTitle>
+                  </div>
+                  {logsTotal > 0 && (
+                    <Badge variant="secondary" className="text-xs">
+                      {logsTotal} total
+                    </Badge>
+                  )}
                 </div>
-                {logsTotal > 10 && (
-                  <Badge variant="secondary" className="text-xs">
-                    {logsTotal} total
-                  </Badge>
-                )}
+                <TrafficFilterBar
+                  filters={filters}
+                  searchInput={searchInput}
+                  onSearchInputChange={setSearchInput}
+                  onChange={handleFiltersChange}
+                  platforms={summary?.platformBreakdown.map((p) => p.platform) ?? []}
+                  isLoading={isLoadingLogs}
+                />
               </div>
             </CardHeader>
             <CardContent className="p-0">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="pl-6 w-[100px]">Time</TableHead>
-                    <TableHead>Platform</TableHead>
-                    <TableHead>Page</TableHead>
-                    <TableHead className="text-right pr-6">Country</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {logs.map((row) => (
-                    <TableRow key={row.id} className="hover:bg-muted/50">
-                      <TableCell className="pl-6 text-xs text-muted-foreground whitespace-nowrap">
-                        {timeAgo(row.createdAt)}
-                      </TableCell>
-                      <TableCell>
-                        <span className="text-sm">
-                          {getPlatformName(row.sourcePlatform ?? 'unknown')}
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        <span className="font-mono text-xs text-muted-foreground line-clamp-1">
-                          {(() => {
-                            try {
-                              return new URL(row.url).pathname;
-                            } catch {
-                              return row.url;
-                            }
-                          })()}
-                        </span>
-                      </TableCell>
-                      <TableCell className="text-right pr-6">
-                        <span className="text-xs text-muted-foreground">{row.country ?? '—'}</span>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              {isLoadingLogs ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : (filters.platform || filters.search) && logs.length === 0 ? (
+                <EmptyLogsState hasFilters={true} />
+              ) : logs.length === 0 ? (
+                <EmptyLogsState hasFilters={false} />
+              ) : (
+                <>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="pl-6 w-[100px]">Time</TableHead>
+                        <TableHead>Platform</TableHead>
+                        <TableHead>Page</TableHead>
+                        <TableHead className="text-right pr-6">Country</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {logs.map((row) => (
+                        <TableRow key={row.id} className="hover:bg-muted/50">
+                          <TableCell className="pl-6 text-xs text-muted-foreground whitespace-nowrap">
+                            {timeAgo(row.createdAt)}
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm">
+                              {getPlatformName(row.sourcePlatform ?? 'unknown')}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="font-mono text-xs text-muted-foreground line-clamp-1">
+                              {(() => {
+                                try {
+                                  return new URL(row.url).pathname;
+                                } catch {
+                                  return row.url;
+                                }
+                              })()}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-right pr-6">
+                            <span className="text-xs text-muted-foreground">
+                              {row.country ?? '—'}
+                            </span>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                  {(() => {
+                    const totalPages = Math.max(1, Math.ceil(logsTotal / PAGE_SIZE));
+                    const clampedPage = Math.min(page, totalPages - 1);
+                    const start = clampedPage * PAGE_SIZE;
+                    const end = Math.min(start + PAGE_SIZE, logsTotal);
+                    return (
+                      <TablePager
+                        page={clampedPage}
+                        totalPages={totalPages}
+                        total={logsTotal}
+                        start={start}
+                        end={end}
+                        onPage={setPage}
+                        isLoading={isLoadingLogs}
+                      />
+                    );
+                  })()}
+                </>
+              )}
             </CardContent>
           </Card>
         </>

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -224,15 +224,10 @@ function TrafficFilterBar({
           value={searchInput}
           onChange={(e) => onSearchInputChange(e.target.value)}
           className="pl-9 h-9 text-sm"
-          disabled={isLoading}
         />
       </div>
 
-      <Select
-        value={filters.platform || ''}
-        onValueChange={(v) => onChange({ platform: v || '' })}
-        disabled={isLoading}
-      >
+      <Select value={filters.platform || ''} onValueChange={(v) => onChange({ platform: v || '' })}>
         <SelectTrigger className="w-40 h-9 text-sm">
           <SelectValue placeholder="All platforms" />
         </SelectTrigger>
@@ -363,13 +358,22 @@ export default function TrafficPage() {
 
   useEffect(() => {
     setPage(0);
-  }, [filters.platform, filters.search]);
+    setSearchInput('');
+    setFilters({ platform: '', search: '' });
+  }, [brand?.id]);
 
   useEffect(() => {
     const id = window.setTimeout(() => {
-      setFilters((prevFilters) =>
-        prevFilters.search === searchInput ? prevFilters : { ...prevFilters, search: searchInput },
-      );
+      setFilters((prevFilters) => {
+        if (prevFilters.search === searchInput) {
+          return prevFilters;
+        }
+        setPage(0);
+        return {
+          ...prevFilters,
+          search: searchInput,
+        };
+      });
     }, 300);
 
     return () => window.clearTimeout(id);
@@ -409,6 +413,7 @@ export default function TrafficPage() {
   }, [brand, page, filters.platform, filters.search]);
 
   const handleFiltersChange = useCallback((patch: Partial<TrafficFilters>) => {
+    setPage(0);
     setFilters((f) => ({ ...f, ...patch }));
   }, []);
 

--- a/web/src/lib/actions/traffic.ts
+++ b/web/src/lib/actions/traffic.ts
@@ -209,8 +209,8 @@ export async function getTrafficLogs(
   }
 
   if (search) {
-    // Escape % and _ for ILIKE to treat them as literals, not wildcards
-    const escaped = search.replace(/[%_]/g, '\\$&');
+    // Escape \, % and _ for ILIKE to treat them as literals, not wildcards
+    const escaped = search.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
     query = query.ilike('url', `%${escaped}%`);
   }
 

--- a/web/src/lib/actions/traffic.ts
+++ b/web/src/lib/actions/traffic.ts
@@ -183,16 +183,43 @@ export async function getTrafficTrend(brandId: string, days = 7): Promise<Traffi
 
 export async function getTrafficLogs(
   brandId: string,
-  opts?: { limit?: number; offset?: number },
+  opts?: {
+    limit?: number;
+    offset?: number;
+    platform?: string;
+    search?: string;
+    days?: number;
+  },
 ): Promise<{ logs: TrafficLog[]; total: number }> {
   const supabase = await createClient();
   const limit = opts?.limit ?? 20;
   const offset = opts?.offset ?? 0;
+  const platform = opts?.platform;
+  const search = opts?.search;
+  const days = opts?.days;
 
-  const { data, error, count } = await supabase
+  let query = supabase
     .from('ai_traffic_logs')
     .select('*', { count: 'exact' })
-    .eq('brand_id', brandId)
+    .eq('brand_id', brandId);
+
+  // Apply filters
+  if (platform) {
+    query = query.eq('source_platform', platform);
+  }
+
+  if (search) {
+    // Escape % and _ for ILIKE to treat them as literals, not wildcards
+    const escaped = search.replace(/[%_]/g, '\\$&');
+    query = query.ilike('url', `%${escaped}%`);
+  }
+
+  if (days) {
+    const from = new Date(Date.now() - days * 86400000).toISOString();
+    query = query.gte('created_at', from);
+  }
+
+  const { data, error, count } = await query
     .order('created_at', { ascending: false })
     .range(offset, offset + limit - 1);
 


### PR DESCRIPTION
# Traffic: Add pagination and filtering to AI Referral Visits table

## Problem

The "Recent AI Referral Visits" table on the AI Traffic page is locked to the 10 most recent rows. A "N total" badge advertises how many visits exist, but there is no way to see past the first 10 — and no way to answer questions like "which of my pages get visits from Perplexity?".

Currently:
- All traffic logs exist in the database
- UI only displays the first 10, with no pagination
- No way to filter by platform or search by URL
- Users cannot explore all their AI traffic data

## Fix

### Server action (`web/src/lib/actions/traffic.ts`)

Extended `getTrafficLogs` to accept filtering options:

- `platform?: string` → `.eq('source_platform', platform)` for exact AI platform filtering
- `search?: string` → `.ilike('url', ...)` with wildcard escaping (`%` and `_`) for case-insensitive URL/path search
- `days?: number` → `.gte('created_at', ...)` (future-proof for #451 time-range picker)

The returned `total` is computed using the same filtered query, so pagination and the badge always reflect the filtered result set.

### UI (`web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx`)

#### Filter bar

- Platform dropdown populated from `summary.platformBreakdown` (plus "All platforms")
- URL search input with a 300 ms debounced server search
- "Clear filters" button shown only when filters are active

#### Pagination

- Added table pagination using the existing `TablePager` pattern
- Displays current row range (`1–10 of 60`)
- Previous/Next controls with proper disabled states

#### State management

- `filters` state stores the active platform and search filters
- `searchInput` state keeps the search input responsive while debouncing server requests
- Search debouncing is handled in the parent component before updating `filters.search`
- `page` automatically resets to the first page whenever filters change
- Separate loading states:
- `isLoadingSummary` for KPIs/charts
- `isLoadingLogs` for the visit log table

#### Empty states

- Filtered with no results → **"No matching visits"**
- No filters and no data → **"No visits yet"**
- Loading spinner displayed while visit logs are being fetched

## Implementation Details

- Debounce is implemented with a 300 ms timeout in the parent component
- User search strings escape `%` and `_` before building the Supabase `ILIKE` query
- All filters are composed into a single Supabase query, so both results and counts stay consistent
- Pagination resets whenever filters change to prevent invalid page states
- Platform options are generated dynamically from the summary data
- The"AI referral visits" table data changes independently from the dashboard summary. Separating loadSummary() and loadLogs() prevents unnecessary re-fetching of KPIs and charts when users paginate or filter the visit log, reducing unnecessary requests


## After this fix

- All visits are reachable through pagination (10 rows per page)
- Platform filter and URL search execute server-side
- Platform and search filters can be combined
- Changing filters resets pagination to the first page
- Badge reflects the filtered total
- Clearing filters restores the complete dataset
- Friendly empty state for filtered results
- KPIs/charts load once; only the visit log table reloads during filtering or pagination
- Search input is debounced (~300 ms) to reduce unnecessary requests


## Testing

Test data: traffic logs seeded across multiple AI platforms and URLs.

**cases tested manually:**

- Filter by Perplexity → verify only Perplexity rows appear
- Search for `/docs` → verify only matching URLs appear
- Combine platform + search filters
- Navigate to page 2, then change platform → verify pagination resets to page 1
- Clear filters → verify all rows become available again
- Verify the total badge reflects the filtered count

<img width="956" height="518" alt="Screenshot 2026-07-17 105511" src="https://github.com/user-attachments/assets/662d0cd9-d2d8-4e43-b0b0-fecdb88d15e1" />
<img width="952" height="514" alt="Screenshot 2026-07-17 105526" src="https://github.com/user-attachments/assets/d7a5de60-d9d4-4279-95b6-f9cd46aaf6ef" />


## Related issue
closes #452 
<!-- e.g. Closes #123 -->

## Type of change

<!-- Check all that apply -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
