### PR TITLE
fix(fanout): replace full-enumeration pager with windowed pager with ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prompts / Query Fan-out: the High frequency pager no longer renders one button per page — replaced with a windowed pager (`‹ 1 … n-1 n n+1 … last ›`) that caps at ~9 elements, preventing overflow on brands with hundreds of pages; Previous/Next chevron buttons added, disabled at boundaries; ellipsis shown as a non-interactive span; all page numbers shown without ellipsis when total pages ≤ 7 (#446)
+
+
 ## [0.1.6] - 2026-07-12
 
 ### Added

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -278,6 +278,20 @@ function EmptyState() {
   );
 }
 
+function getPagerItems(page: number, totalPages: number): (number | '...')[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const items: (number | '...')[] = [1];
+  if (page > 3) items.push('...');
+  for (let p = Math.max(2, page - 1); p <= Math.min(totalPages - 1, page + 1); p++) {
+    items.push(p);
+  }
+  if (page < totalPages - 2) items.push('...');
+  items.push(totalPages);
+  return items;
+}
+
 function HighFrequencyView({
   subQueries,
   intents,
@@ -337,20 +351,44 @@ function HighFrequencyView({
       </Table>
       {totalPages > 1 && (
         <div className="flex items-center justify-center gap-1 pt-4">
-          {Array.from({ length: totalPages }, (_, i) => {
-            const p = i + 1;
-            return (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0 text-xs"
+            onClick={() => onPageChange(page - 1)}
+            disabled={page === 1}
+          >
+            ‹
+          </Button>
+          {getPagerItems(page, totalPages).map((item, idx) =>
+            item === '...' ? (
+              <span
+                key={`ellipsis-${idx}`}
+                className="flex h-7 w-7 items-center justify-center text-xs text-muted-foreground"
+              >
+                …
+              </span>
+            ) : (
               <Button
-                key={p}
-                variant={page === p ? 'default' : 'ghost'}
+                key={item}
+                variant={page === item ? 'default' : 'ghost'}
                 size="sm"
                 className="h-7 w-7 p-0 text-xs"
-                onClick={() => onPageChange(p)}
+                onClick={() => onPageChange(item as number)}
               >
-                {p}
+                {item}
               </Button>
-            );
-          })}
+            ),
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0 text-xs"
+            onClick={() => onPageChange(page + 1)}
+            disabled={page === totalPages}
+          >
+            ›
+          </Button>
         </div>
       )}
     </>


### PR DESCRIPTION
## Problem

The `HighFrequencyView` pager rendered one button per page using `Array.from({ length: totalPages })`. With `PAGE_SIZE = 10` and a few thousand sub-queries, this produced hundreds of buttons in a single non-wrapping flex row — the pager spanned the full card width, buttons got squeezed, and some page numbers were pushed out of view entirely.

Fixes #446.

## Solution

Replaced the full enumeration with a windowed pager:

- Added a pure `getPagerItems(page, totalPages)` helper that returns at most ~9 elements: `‹ 1 … n-1 n n+1 … last ›`
- When `totalPages ≤ 7`, all page numbers are shown with no ellipsis
- Added Previous (`‹`) and Next (`›`) chevron buttons at the ends, disabled on the first/last page
- Ellipsis (`…`) renders as a non-interactive muted `<span>`, not a button
- Existing button styling preserved (`h-7 w-7 p-0 text-xs`, `default` variant for current page, `ghost` for the rest)

No new dependencies — the helper is a small pure function.

## Acceptance criteria

- [x] With many pages (e.g. 500), the pager renders at most ~9 elements — it never overflows or wraps
- [x] The current page is always visible and highlighted; first/last pages are always one click away
- [x] Clicking a number, Previous, or Next changes the page exactly as before
- [x] With few pages (e.g. 3), all numbers show and there is no ellipsis

## Testing

- Manually tested with 3, 7, 8, and 500 total pages across multiple current page positions (first, middle, last, near boundaries)
- `yarn lint` — 0 errors (pre-existing warnings in other files only)
- `yarn typecheck` — clean
- `yarn format:check` — all files use Prettier code style