### PR TITLE
fix(brands): recover from suggestion failures and stop Back/Continue duplicating brands

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/client';
-import { createBrand } from '@/lib/actions/brand';
+import { createBrand, updateBrand } from '@/lib/actions/brand';
+import { syncDomains } from '@/lib/actions/brand-domain';
 import { createTopics } from '@/lib/actions/topic';
 import { savePromptSet } from '@/lib/actions/prompt';
 import { addCompetitor } from '@/lib/actions/competitor';
@@ -215,7 +216,7 @@ const TOTAL_STEPS = 5;
 
 export default function NewBrandPage() {
   const router = useRouter();
-  const { addBrand, setActiveBrand } = useBrandStore();
+  const { addBrand, setActiveBrand, updateBrand: updateBrandInStore } = useBrandStore();
 
   const [step, setStep] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
@@ -238,6 +239,7 @@ export default function NewBrandPage() {
   const [selectedTopics, setSelectedTopics] = useState<Set<string>>(new Set());
   const [customTopic, setCustomTopic] = useState('');
   const [loadingTopics, setLoadingTopics] = useState(false);
+  const [topicSuggestError, setTopicSuggestError] = useState(false);
   const [topicLoadingMsg, setTopicLoadingMsg] = useState('');
   const topicMsgIdx = useRef(0);
 
@@ -269,6 +271,7 @@ export default function NewBrandPage() {
   }
   const [suggestedCompetitors, setSuggestedCompetitors] = useState<CompetitorItem[]>([]);
   const [loadingCompetitors, setLoadingCompetitors] = useState(false);
+  const [competitorSuggestError, setCompetitorSuggestError] = useState(false);
   const [competitorName, setCompetitorName] = useState('');
   const [competitorDomain, setCompetitorDomain] = useState('');
   const [savingCompetitors, setSavingCompetitors] = useState(false);
@@ -353,35 +356,60 @@ export default function NewBrandPage() {
   const handleCreateBrand = async () => {
     setIsLoading(true);
     try {
-      const supabase = createClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) throw new Error('Not authenticated');
-
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('organization_id')
-        .eq('id', user.id)
-        .single();
-
-      if (!profile?.organization_id) throw new Error('No organization found');
-
       const logoUrl = domain ? getFaviconUrl(domain) : undefined;
 
-      const brand = await createBrand({
-        organizationId: profile.organization_id,
-        name: brandName.trim(),
-        logoUrl,
-        description: description.trim() || undefined,
-        region,
-        language,
-        domains: domain ? [{ domain, isPrimary: true }] : [],
-      });
+      // Back → Continue must not create a second brand (#447): once the brand
+      // exists, re-submitting this step updates it in place instead.
+      if (createdBrand) {
+        let brand = await updateBrand(createdBrand.id, {
+          name: brandName.trim(),
+          logoUrl: logoUrl ?? null,
+          description: description.trim() || null,
+          region,
+          language,
+        });
 
-      setCreatedBrand(brand);
-      addBrand(brand);
-      setActiveBrand(brand.id);
+        const previousDomain =
+          createdBrand.domains.find((d) => d.isPrimary)?.domain ?? createdBrand.domains[0]?.domain;
+        if (domain !== (previousDomain ?? '')) {
+          const domains = await syncDomains(
+            createdBrand.id,
+            domain ? [{ domain, isPrimary: true }] : [],
+          );
+          brand = { ...brand, domains };
+        }
+
+        setCreatedBrand(brand);
+        updateBrandInStore(brand.id, brand);
+      } else {
+        const supabase = createClient();
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('organization_id')
+          .eq('id', user.id)
+          .single();
+
+        if (!profile?.organization_id) throw new Error('No organization found');
+
+        const brand = await createBrand({
+          organizationId: profile.organization_id,
+          name: brandName.trim(),
+          logoUrl,
+          description: description.trim() || undefined,
+          region,
+          language,
+          domains: domain ? [{ domain, isPrimary: true }] : [],
+        });
+
+        setCreatedBrand(brand);
+        addBrand(brand);
+        setActiveBrand(brand.id);
+      }
 
       setStep(3);
 
@@ -389,7 +417,7 @@ export default function NewBrandPage() {
         fetchTopicSuggestions();
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to create brand');
+      toast.error(err instanceof Error ? err.message : 'Failed to save brand');
     } finally {
       setIsLoading(false);
     }
@@ -399,6 +427,7 @@ export default function NewBrandPage() {
 
   const fetchTopicSuggestions = async () => {
     setLoadingTopics(true);
+    setTopicSuggestError(false);
     try {
       const supabase = createClient();
       const {
@@ -427,8 +456,10 @@ export default function NewBrandPage() {
       setSuggestedTopics(names);
       setSelectedTopics(new Set(names.slice(0, 7)));
     } catch (err) {
+      // Inline banner + Try again instead of a transient toast (#447) — a
+      // toast leaves the user stranded on an empty step with no way forward.
       console.error('Topic suggestion error:', err);
-      toast.error('Failed to generate topic suggestions');
+      setTopicSuggestError(true);
     } finally {
       setLoadingTopics(false);
     }
@@ -550,6 +581,7 @@ export default function NewBrandPage() {
 
   const fetchCompetitorSuggestions = async () => {
     setLoadingCompetitors(true);
+    setCompetitorSuggestError(false);
     try {
       const supabase = createClient();
       const {
@@ -582,7 +614,7 @@ export default function NewBrandPage() {
       );
     } catch (err) {
       console.error('Competitor suggestion error:', err);
-      toast.error('Failed to generate competitor suggestions');
+      setCompetitorSuggestError(true);
     } finally {
       setLoadingCompetitors(false);
     }
@@ -856,6 +888,16 @@ export default function NewBrandPage() {
                 </div>
               ) : (
                 <div className="space-y-2">
+                  {topicSuggestError && (
+                    <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
+                      <span>
+                        Couldn&apos;t fetch topic suggestions right now — add your own below.
+                      </span>
+                      <Button variant="outline" size="sm" onClick={fetchTopicSuggestions}>
+                        Try again
+                      </Button>
+                    </div>
+                  )}
                   {suggestedTopics.map((topic) => {
                     const isSelected = selectedTopics.has(topic);
                     return (
@@ -1074,6 +1116,16 @@ export default function NewBrandPage() {
             </div>
           ) : (
             <div className="space-y-4">
+              {competitorSuggestError && (
+                <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
+                  <span>
+                    Couldn&apos;t fetch competitor suggestions right now — add them manually below.
+                  </span>
+                  <Button variant="outline" size="sm" onClick={fetchCompetitorSuggestions}>
+                    Try again
+                  </Button>
+                </div>
+              )}
               {suggestedCompetitors.length > 0 && (
                 <div className="space-y-2">
                   <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">

--- a/web/src/lib/actions/brand.ts
+++ b/web/src/lib/actions/brand.ts
@@ -146,6 +146,8 @@ interface UpdateBrandInput {
   logoUrl?: string | null;
   industry?: string | null;
   description?: string | null;
+  region?: string;
+  language?: string;
 }
 
 export async function updateBrand(id: string, updates: UpdateBrandInput): Promise<Brand> {
@@ -159,6 +161,8 @@ export async function updateBrand(id: string, updates: UpdateBrandInput): Promis
   if ('logoUrl' in updates) payload.logo_url = updates.logoUrl ?? null;
   if ('industry' in updates) payload.industry = updates.industry ?? null;
   if ('description' in updates) payload.description = updates.description ?? null;
+  if (updates.region !== undefined) payload.region = updates.region;
+  if (updates.language !== undefined) payload.language = updates.language;
 
   const { data, error } = await supabase
     .from('brands')


### PR DESCRIPTION
## Summary

The dashboard Add-a-new-brand flow had no recovery path when topic suggestion failed — reported twice from internal use. A transient toast, an empty suggestion list, and a (correctly) disabled continue button left the user stranded on step 3. Worse, the natural retry — Back to step 2, Continue again — called `createBrand` unconditionally and inserted a **duplicate brand** on every round-trip.

This PR ports the #443 onboarding treatment to this flow and makes the step-2 submit idempotent:

- **Topic suggestion failure (step 3)**: amber inline banner with a **Try again** button, plus copy pointing at the custom-topic input as the manual fallback. Replaces the toast-only handling.
- **Competitor suggestion failure (step 5)**: same banner + Try again, pointing at the manual add inputs.
- **Back→Continue no longer duplicates the brand**: once `createdBrand` exists, re-submitting step 2 updates the brand in place — `updateBrand` (extended with `region`/`language` support) — and syncs the domain row via `syncDomains` only when the website actually changed. The brand store is updated so the brand switcher reflects edits immediately.
- Step gating unchanged: still no advancing past step 3 with 0 topics or past step 4 with 0 prompts.

## Related issue

Closes #447

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Stop the aeo-server, then Dashboard → Brands → Add a new brand → fill steps 1–2 → Continue.
2. Step 3 shows the amber banner (no toast); start the server and hit **Try again** → suggestions load; the custom-topic input works as fallback throughout.
3. From step 3 go **Back** → Continue again: the Brands list still has **one** brand, and any field changed on steps 1–2 (e.g. region) is reflected on it.
4. Repeat the failure scenario on step 5 → same banner; **Try again** recovers; manual competitor add still works.
5. Gating: with 0 selected topics "Looks good" stays disabled; with 0 prompts step 4's Continue stays disabled.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR