### PR TITLE
feat(prompts): collapse the suggestions card to a one-line strip by default

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
@@ -4,7 +4,18 @@ import { useEffect, useState, useCallback, useTransition } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Sparkles, Plus, X, RefreshCw, Loader2, TrendingUp, Tag, Info } from 'lucide-react';
+import {
+  Sparkles,
+  Plus,
+  X,
+  RefreshCw,
+  Loader2,
+  TrendingUp,
+  Tag,
+  Info,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import {
   getPromptSuggestions,
@@ -19,12 +30,40 @@ interface Props {
   onAccepted?: () => void;
 }
 
+/** localStorage key remembering whether the card is expanded across visits. */
+const EXPANDED_KEY = 'aeo:prompt-suggestions-expanded';
+
 export function SuggestionsCard({ brandId, onAccepted }: Props) {
   const [suggestions, setSuggestions] = useState<PromptSuggestion[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [pendingId, setPendingId] = useState<string | null>(null);
+  // Collapsed by default so the card is a one-line strip and the prompt table
+  // stays above the fold; the user's last choice is remembered. Starts false
+  // on both server and client (no hydration mismatch), then the effect below
+  // restores the stored preference.
+  const [expanded, setExpanded] = useState(false);
   const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(EXPANDED_KEY) === '1') setExpanded(true);
+    } catch {
+      // Storage unavailable (private mode) — stay collapsed.
+    }
+  }, []);
+
+  const toggleExpanded = () => {
+    setExpanded((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(EXPANDED_KEY, next ? '1' : '0');
+      } catch {
+        // Preference just won't persist.
+      }
+      return next;
+    });
+  };
 
   const load = useCallback(
     async (autoRefresh = false) => {
@@ -54,6 +93,9 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
 
   useEffect(() => {
     if (!loading && window.location.hash === '#prompt-opportunities') {
+      // Deep links mean "show me the suggestions" — expand (without touching
+      // the stored preference) before scrolling the card into view.
+      setExpanded(true);
       document.getElementById('prompt-opportunities')?.scrollIntoView();
     }
   }, [loading]);
@@ -101,9 +143,19 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
 
   return (
     <Card id="prompt-opportunities">
-      <CardHeader className="pb-3">
+      <CardHeader className={expanded ? 'pb-3' : 'py-4'}>
         <div className="flex items-center justify-between gap-4 flex-wrap">
-          <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={toggleExpanded}
+            aria-expanded={expanded}
+            className="flex items-center gap-2 text-left"
+          >
+            {expanded ? (
+              <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
+            ) : (
+              <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+            )}
             <Sparkles className="h-4 w-4 text-primary" />
             <CardTitle className="text-sm font-medium">Prompt Suggestions</CardTitle>
             <Info
@@ -115,107 +167,122 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
                 competitors cited in AI answers.
               </title>
             </Info>
-          </div>
-          <Button
-            onClick={handleRefresh}
-            disabled={refreshing}
-            size="sm"
-            variant="outline"
-            className="gap-2"
-          >
-            {refreshing ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            {loading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            ) : suggestions.length > 0 ? (
+              <Badge variant="secondary" className="text-xs tabular-nums">
+                {suggestions.length}
+              </Badge>
             ) : (
-              <RefreshCw className="h-3.5 w-3.5" />
+              !expanded && (
+                <span className="text-xs text-muted-foreground">no new ideas — expand</span>
+              )
             )}
-            {refreshing ? 'Generating…' : 'Refresh'}
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent>
-        {loading ? (
-          <div className="flex items-center justify-center py-10">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-          </div>
-        ) : suggestions.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-10 text-center">
-            <Sparkles className="h-8 w-8 text-muted-foreground/40 mb-2" />
-            <p className="text-sm font-medium mb-1">No suggestions right now</p>
-            <p className="text-xs text-muted-foreground mb-3 max-w-sm">
-              Click refresh to generate new prompt ideas tailored to your brand and competitor
-              activity.
-            </p>
-            <Button onClick={handleRefresh} disabled={refreshing} size="sm" className="gap-2">
+          </button>
+          {expanded && (
+            <Button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              size="sm"
+              variant="outline"
+              className="gap-2"
+            >
               {refreshing ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
               ) : (
-                <Sparkles className="h-3.5 w-3.5" />
+                <RefreshCw className="h-3.5 w-3.5" />
               )}
-              Generate Suggestions
+              {refreshing ? 'Generating…' : 'Refresh'}
             </Button>
-          </div>
-        ) : (
-          <ul className="space-y-2">
-            {suggestions.map((s) => {
-              const busy = pendingId === s.id;
-              return (
-                <li
-                  key={s.id}
-                  className="group flex items-start gap-3 rounded-lg border bg-muted/20 p-3 transition-colors hover:bg-muted/40"
-                >
-                  <div className="flex-1 min-w-0 space-y-1.5">
-                    <p className="text-sm font-medium leading-snug">{s.suggestedText}</p>
-                    <div className="flex flex-wrap items-center gap-1.5">
-                      {s.topicName && (
-                        <Badge variant="outline" className="gap-1 text-xs">
-                          <Tag className="h-3 w-3" />
-                          {s.topicName}
-                        </Badge>
-                      )}
-                      {s.estVolume != null && s.estVolume > 0 && (
-                        <Badge variant="outline" className="gap-1 text-xs tabular-nums">
-                          <TrendingUp className="h-3 w-3" />~{s.estVolume.toLocaleString()}/mo
-                        </Badge>
+          )}
+        </div>
+      </CardHeader>
+      {expanded && (
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center justify-center py-10">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : suggestions.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-10 text-center">
+              <Sparkles className="h-8 w-8 text-muted-foreground/40 mb-2" />
+              <p className="text-sm font-medium mb-1">No suggestions right now</p>
+              <p className="text-xs text-muted-foreground mb-3 max-w-sm">
+                Click refresh to generate new prompt ideas tailored to your brand and competitor
+                activity.
+              </p>
+              <Button onClick={handleRefresh} disabled={refreshing} size="sm" className="gap-2">
+                {refreshing ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Sparkles className="h-3.5 w-3.5" />
+                )}
+                Generate Suggestions
+              </Button>
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {suggestions.map((s) => {
+                const busy = pendingId === s.id;
+                return (
+                  <li
+                    key={s.id}
+                    className="group flex items-start gap-3 rounded-lg border bg-muted/20 p-3 transition-colors hover:bg-muted/40"
+                  >
+                    <div className="flex-1 min-w-0 space-y-1.5">
+                      <p className="text-sm font-medium leading-snug">{s.suggestedText}</p>
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        {s.topicName && (
+                          <Badge variant="outline" className="gap-1 text-xs">
+                            <Tag className="h-3 w-3" />
+                            {s.topicName}
+                          </Badge>
+                        )}
+                        {s.estVolume != null && s.estVolume > 0 && (
+                          <Badge variant="outline" className="gap-1 text-xs tabular-nums">
+                            <TrendingUp className="h-3 w-3" />~{s.estVolume.toLocaleString()}/mo
+                          </Badge>
+                        )}
+                      </div>
+                      {s.reason && (
+                        <p className="text-xs text-muted-foreground leading-relaxed">{s.reason}</p>
                       )}
                     </div>
-                    {s.reason && (
-                      <p className="text-xs text-muted-foreground leading-relaxed">{s.reason}</p>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-1 shrink-0">
-                    <Button
-                      size="icon"
-                      variant="outline"
-                      className="h-8 w-8"
-                      onClick={() => handleAccept(s)}
-                      disabled={busy}
-                      title="Add to tracked prompts"
-                      aria-label="Add to tracked prompts"
-                    >
-                      {busy ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <Plus className="h-3.5 w-3.5" />
-                      )}
-                    </Button>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="h-8 w-8 text-muted-foreground"
-                      onClick={() => handleDismiss(s)}
-                      disabled={busy}
-                      title="Dismiss suggestion"
-                      aria-label="Dismiss suggestion"
-                    >
-                      <X className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </CardContent>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Button
+                        size="icon"
+                        variant="outline"
+                        className="h-8 w-8"
+                        onClick={() => handleAccept(s)}
+                        disabled={busy}
+                        title="Add to tracked prompts"
+                        aria-label="Add to tracked prompts"
+                      >
+                        {busy ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Plus className="h-3.5 w-3.5" />
+                        )}
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-muted-foreground"
+                        onClick={() => handleDismiss(s)}
+                        disabled={busy}
+                        title="Dismiss suggestion"
+                        aria-label="Dismiss suggestion"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

After #466 moved the Prompt Suggestions card to the top of All Prompts, its expanded height (~400px with 5 suggestions) pushed the prompt table below the fold on every visit — users had to scroll to reach the page's main content.

The card now collapses to a **single header strip by default**: chevron + title + a count badge (small spinner while loading, a "no new ideas — expand" hint when empty). The table is back above the fold while the suggestions stay discoverable at the very top.

- Clicking the header toggles the card; the choice **persists per browser** via `localStorage` — users who prefer it open are welcomed that way next visit.
- The `#prompt-opportunities` deep link (the #459 "See all" flow) **auto-expands** the card before scrolling into view, without overwriting the stored preference.
- The Refresh button and card body render only when expanded; card internals (generate, accept with `onAccepted`, dismiss) are unchanged.

## Related issue

Follow-up to #461/#466 (internal layout feedback: the expanded card at the top forces scrolling to the table).

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open Prompts → All Prompts: the suggestions card is a one-line strip with a count badge; the table is visible without scrolling.
2. Click the strip → full suggestions list + Refresh button appear; accept/dismiss/generate all work as before.
3. Reload → the card opens in whatever state you left it.
4. Visit `/dashboard/prompts?tab=all#prompt-opportunities` cold → the card auto-expands and scrolls into view.
5. Clear suggestions (or use a brand with none) → collapsed strip shows "no new ideas — expand"; expanded shows the Generate CTA.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR