### PR TITLE
fix(prompts): shallow-update tab/sort URL params instead of router.replace

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { useSearchParams } from 'next/navigation';
-import { Link, useRouter } from '@/i18n/navigation';
+import { Link } from '@/i18n/navigation';
 import dynamic from 'next/dynamic';
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -280,7 +280,6 @@ export default function PromptsPage() {
   const activeBrand = useBrandStore(
     (s) => s.brands.find((brand) => brand.id === s.activeBrandId) ?? null,
   );
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   const initialTab: TabId = (() => {
@@ -290,16 +289,19 @@ export default function PromptsPage() {
   const [tab, setTab] = useState<TabId>(initialTab);
 
   // Keep the URL in sync with the active tab so deep links / refreshes land
-  // back on the same view.
+  // back on the same view. Shallow history update on purpose: the tab is pure
+  // client state, and `router.replace` here fired an RSC round-trip whose
+  // prefetch render 500s server-side — the never-completing navigation then
+  // blocked Next's server-action queue, so the page's data fetch never even
+  // dispatched (the "prompts table spins forever" bug). replaceState updates
+  // the URL with no server request; Next's router syncs with the History API.
   useEffect(() => {
     const current = searchParams.get('tab');
     if (current === tab) return;
     const params = new URLSearchParams(Array.from(searchParams.entries()));
     params.set('tab', tab);
-    router.replace(`/dashboard/prompts?${params.toString()}`, {
-      scroll: false,
-    });
-  }, [tab, searchParams, router]);
+    window.history.replaceState(null, '', `?${params.toString()}`);
+  }, [tab, searchParams]);
 
   const loadData = useCallback(
     async (isCancelled?: () => boolean) => {
@@ -994,7 +996,6 @@ function AllPromptsTab({
   visibility: Record<string, PromptVisibilitySummary>;
 }) {
   const [search, setSearch] = useState('');
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   const rawSort = searchParams.get('sort');
@@ -1004,6 +1005,8 @@ function AllPromptsTab({
   // Click a header to sort: a new column starts at desc ("show me the extremes");
   // re-clicking the active column toggles desc⇄asc. Persisted to the URL so the
   // sort survives reloads and is shareable (matches the existing `tab` sync).
+  // Shallow history update — same reasoning as the tab sync: pure client
+  // state must not trigger an RSC round-trip that can block the action queue.
   const handleSort = useCallback(
     (key: AllPromptsSortKey) => {
       const params = new URLSearchParams(Array.from(searchParams.entries()));
@@ -1011,9 +1014,9 @@ function AllPromptsTab({
       params.set('tab', 'all');
       params.set('sort', key);
       params.set('dir', nextDir);
-      router.replace(`/dashboard/prompts?${params.toString()}`, { scroll: false });
+      window.history.replaceState(null, '', `?${params.toString()}`);
     },
-    [searchParams, router, activeSort, dir],
+    [searchParams, activeSort, dir],
   );
 
   const filtered = useMemo(() => {


### PR DESCRIPTION
## Summary

The All Prompts table spun forever on cold loads — in dev and in production. Root cause chain, verified live against production:

1. On mount, the tab-sync effect called `router.replace('?tab=all')`, firing an RSC round trip.
2. That request intermittently dies server-side with `Error: The router state header was sent but could not be parsed` (captured in Vercel function logs) — a known Next.js framework issue for apps with a broad proxy/middleware matcher on Vercel (https://github.com/vercel/next.js/issues/91723, related: 92907/92961). Our proxy matcher is necessarily broad (auth gate).
3. The failed navigation never completes, and Next holds every queued **server action** behind the pending transition — so `getPromptsPageData` never even dispatched. The suggestions card's call slipped through ahead of the replace; the table's never did.

Fix: the tab and sort keys are pure client state — the URL is only updated so deep links and reloads restore the view. `window.history.replaceState` does exactly that with **no server request** (Next's app router syncs with the History API), so the crashing RSC round trip is gone and the action queue can never be blocked by it again. Both call sites converted (tab sync + column sort); `useRouter` dropped from the page.

Verified in the browser: after the change the page load issues no `?tab=all&_rsc` request at all, and the URL still updates to `?tab=all`.

## Related issue

Direct fix for the urgent "prompts page never loads" report; the upstream framework issue remains open — if sporadic RSC navigation failures ever show up elsewhere, narrowing what the proxy does for RSC requests is the next lever.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Cold-open `/dashboard/prompts` in a fresh tab: the table loads; the Network tab shows no `?tab=all&_rsc` request and no 503s; the URL bar still gains `?tab=all`.
2. Switch tabs (All / Query Fan-out / Insights): URL follows, back/forward and reload land on the right tab.
3. Sort columns on All Prompts: `?sort=…&dir=…` appears in the URL without any server request; reload preserves the sort.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR