### PR TITLE
fix(proxy): bypass next-intl for RSC and server-action requests

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -55,6 +55,30 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(new URL('/dashboard', request.url));
   }
 
+  // Workaround for a Next.js framework issue (vercel/next.js#91723): RSC
+  // prefetch/navigation requests and server-action POSTs that go through
+  // next-intl's middleware intermittently die server-side with "The router
+  // state header was sent but could not be parsed" — and the client then
+  // holds its whole server-action queue behind the failed transition, which
+  // froze the Prompts page. With a single 'en' locale the only thing the
+  // intl middleware does for these requests is the /en rewrite, so do that
+  // by hand and skip the intl machinery entirely.
+  const isRscOrAction = request.headers.has('rsc') || request.headers.has('next-action');
+  if (isRscOrAction) {
+    const needsLocalePrefix = !(pathname === '/en' || pathname.startsWith('/en/'));
+    const response = needsLocalePrefix
+      ? NextResponse.rewrite(new URL(`/en${pathname}${request.nextUrl.search}`, request.url), {
+          request,
+        })
+      : NextResponse.next({ request });
+    if (supabaseResponse) {
+      supabaseResponse.cookies.getAll().forEach((cookie) => {
+        response.cookies.set(cookie.name, cookie.value, cookie);
+      });
+    }
+    return response;
+  }
+
   const intlResponse = intlMiddleware(request);
 
   if (supabaseResponse) {


### PR DESCRIPTION
## Summary

Soft navigations to the Prompts page (e.g. sidebar Visibility → Prompts) still froze after #474. Verified chain:

1. A client-side navigation's RSC request carries the router state tree through the middleware.
2. It intermittently dies server-side with `Error: The router state header was sent but could not be parsed` — captured in Vercel function logs; a known framework-level issue for apps with a broad proxy matcher on Vercel (https://github.com/vercel/next.js/issues/91723). #474 removed the page's own mount-time trigger, but any navigation INTO the page is still an RSC request and can hit the same bug.
3. The failed transition never completes, and Next holds all queued **server actions** behind it — so the page's data fetch never dispatches and the table spins forever.

Per the upstream issue, the failures disappear when the middleware stops processing these requests. With a single `'en'` locale, the only thing next-intl's middleware does for them is the `/en` rewrite — so for any request carrying an `RSC` or `Next-Action` header, do that rewrite manually and skip the intl machinery entirely. Auth checks (Supabase session, protected-route redirect) still run first, and session cookies are still forwarded on the response. Document requests (no RSC header) keep flowing through next-intl unchanged.

## Related issue

Second half of the urgent "prompts page never loads" fix (#474 was the first). Upstream: vercel/next.js#91723.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. From `/dashboard/visibility` (Insights), click **Prompts** in the sidebar repeatedly — the table must load every time; no request in the Network tab may return 500/503.
2. Hard-reload `/dashboard/prompts?tab=all` — loads normally.
3. Navigate across all sidebar pages — locale routing (`/en` rewrite) still works, sign-in/sign-out unaffected.
4. Any server action (track a fan-out query, accept a suggestion) still works after several navigations.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR