### PR TITLE
fix(prompts): load suggestions only when the card is expanded

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
@@ -35,7 +35,8 @@ const EXPANDED_KEY = 'aeo:prompt-suggestions-expanded';
 
 export function SuggestionsCard({ brandId, onAccepted }: Props) {
   const [suggestions, setSuggestions] = useState<PromptSuggestion[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [pendingId, setPendingId] = useState<string | null>(null);
   // Collapsed by default so the card is a one-line strip and the prompt table
@@ -51,6 +52,12 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
     } catch {
       // Storage unavailable (private mode) — stay collapsed.
     }
+    if (window.location.hash === '#prompt-opportunities') {
+      // Deep links mean "show me the suggestions" — expand (without touching
+      // the stored preference) and scroll the card into view.
+      setExpanded(true);
+      document.getElementById('prompt-opportunities')?.scrollIntoView();
+    }
   }, []);
 
   const toggleExpanded = () => {
@@ -65,46 +72,43 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
     });
   };
 
-  const load = useCallback(
-    async (autoRefresh = false) => {
-      try {
-        const { suggestions: s, stale } = await getPromptSuggestions(brandId);
-        if (autoRefresh && stale) {
-          setRefreshing(true);
-          const fresh = await refreshPromptSuggestions(brandId);
-          setSuggestions(fresh);
-          setRefreshing(false);
-        } else {
-          setSuggestions(s);
-        }
-      } catch (err) {
-        console.error('Failed to load suggestions:', err);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [brandId],
-  );
-
-  useEffect(() => {
+  const load = useCallback(async () => {
     setLoading(true);
-    load(false);
-  }, [load]);
+    try {
+      const { suggestions: s } = await getPromptSuggestions(brandId);
+      setSuggestions(s);
+      setLoaded(true);
+    } catch (err) {
+      console.error('Failed to load suggestions:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [brandId]);
+
+  // Fetch ONLY once the card is actually expanded — never on page load. The
+  // collapsed strip must not fire a server action: when this card moved to
+  // the All Prompts tab its mount-time call became the FIRST action in
+  // Next's serialized queue and every hiccup in it stalled the prompt
+  // table's own data fetch behind it (the "table spins forever" bug). While
+  // collapsed the card costs zero requests, exactly like before the move.
+  useEffect(() => {
+    setLoaded(false);
+    setSuggestions([]);
+  }, [brandId]);
 
   useEffect(() => {
-    if (!loading && window.location.hash === '#prompt-opportunities') {
-      // Deep links mean "show me the suggestions" — expand (without touching
-      // the stored preference) before scrolling the card into view.
-      setExpanded(true);
-      document.getElementById('prompt-opportunities')?.scrollIntoView();
+    if (expanded && !loaded && !loading) {
+      load();
     }
-  }, [loading]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded, loaded, brandId]);
 
   const handleRefresh = async () => {
     setRefreshing(true);
     try {
       const fresh = await refreshPromptSuggestions(brandId);
       setSuggestions(fresh);
+      setLoaded(true);
       toast.success('Suggestions refreshed');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Refresh failed');
@@ -169,13 +173,17 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
             </Info>
             {loading ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-            ) : suggestions.length > 0 ? (
+            ) : loaded && suggestions.length > 0 ? (
               <Badge variant="secondary" className="text-xs tabular-nums">
                 {suggestions.length}
               </Badge>
-            ) : (
+            ) : loaded ? (
               !expanded && (
                 <span className="text-xs text-muted-foreground">no new ideas — expand</span>
+              )
+            ) : (
+              !expanded && (
+                <span className="text-xs text-muted-foreground">expand for AI prompt ideas</span>
               )
             )}
           </button>


### PR DESCRIPTION
## Summary

The "prompts table spins forever" regression started exactly when the suggestions card moved to the All Prompts tab (#466). Mechanism: the card fired its server action on every page mount, becoming the **first entry in Next's serialized action queue** — so any hiccup in that one request (the router-state-header framework issue worked around in #474/#475, a slow upstream) stalled the table's own data fetch queued behind it. Before the move the card lived on a secondary tab and fired nothing at page load, which is why the problem never existed then.

Fix: the collapsed strip now costs **zero requests**. Suggestions load the first time the card is actually expanded (the `#prompt-opportunities` deep link auto-expands and therefore loads). The count badge appears once loaded; before that the strip shows a neutral "expand for AI prompt ideas" hint. Page load is back to exactly one server action — the table's — matching the pre-#466 behavior.

Verified in the browser on the exact failing scenario: sidebar Visibility → Prompts now renders the full table (107 prompts) with the collapsed strip issuing no requests.

## Related issue

Final piece of the urgent "prompts page never loads" fix (#474, #475 were mitigations at other layers).

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. From Visibility (Insights), click **Prompts** in the sidebar — the table loads; the Network tab shows no suggestions request while the strip is collapsed.
2. Expand the strip — suggestions fetch now; count badge appears; accept/dismiss/refresh work as before.
3. Visit `/dashboard/prompts?tab=all#prompt-opportunities` — the card auto-expands, loads, and scrolls into view.
4. Switch brands — expanding again fetches the new brand's suggestions.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR