### PR TITLE
fix(insights): use the same denominator for brand and competitor averages

### DIFF
--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -1219,13 +1219,23 @@ export async function getCompetitorComparison(
       ? prevWin.brand_sum_visibility / prevWin.brand_row_count
       : null;
 
+  // Competitor averages use the SAME denominator as the brand's — every
+  // filtered result row, not just the rows where the competitor happened to
+  // appear. A competitor absent from a response scores 0 for it, exactly
+  // like the brand does. Dividing by the appearance count instead graded
+  // competitors only on their best runs and could rank a rarely-seen
+  // competitor above a frequently-mentioned brand.
   const curCompAvg = new Map<string, number>();
-  for (const c of curWin?.by_competitor ?? []) {
-    if (c.row_count > 0) curCompAvg.set(c.competitor_id, c.sum_visibility / c.row_count);
+  if (curWin && curWin.brand_row_count > 0) {
+    for (const c of curWin.by_competitor) {
+      curCompAvg.set(c.competitor_id, c.sum_visibility / curWin.brand_row_count);
+    }
   }
   const prevCompAvg = new Map<string, number>();
-  for (const c of prevWin?.by_competitor ?? []) {
-    if (c.row_count > 0) prevCompAvg.set(c.competitor_id, c.sum_visibility / c.row_count);
+  if (prevWin && prevWin.brand_row_count > 0) {
+    for (const c of prevWin.by_competitor) {
+      prevCompAvg.set(c.competitor_id, c.sum_visibility / prevWin.brand_row_count);
+    }
   }
 
   const brandName = (brand?.name as string) ?? 'Your Brand';
@@ -1259,7 +1269,9 @@ export async function getCompetitorComparison(
   ];
 
   for (const c of agg.by_competitor) {
-    const avg = c.row_count > 0 ? Math.round(c.sum_visibility / c.row_count) : 0;
+    // Same-denominator rule as the window averages above (agg.brand_row_count
+    // is guaranteed > 0 by the early return).
+    const avg = Math.round(c.sum_visibility / agg.brand_row_count);
     entries.push({
       name: competitorDisplayName(c.name, c.competitor_id),
       avgVisibilityScore: avg,
@@ -1317,7 +1329,12 @@ export async function getCompetitorComparison(
     row[brandName] = bp && bp.count > 0 ? Math.round(bp.totalScore / bp.count) : 0;
     for (const [compName, pm] of compByProvider) {
       const cp = pm.get(provider);
-      row[compName] = cp && cp.count > 0 ? Math.round(cp.totalScore / cp.count) : 0;
+      // Same-denominator rule: divide by the provider bucket's total run
+      // count (the brand's, which spans every filtered row), not the
+      // competitor's appearance count. Competitor rows are a subset of the
+      // brand's, so bp always exists when cp does.
+      const denom = bp?.count ?? 0;
+      row[compName] = cp && denom > 0 ? Math.round(cp.totalScore / denom) : 0;
     }
     return row;
   });

--- a/web/src/lib/mcp/data.ts
+++ b/web/src/lib/mcp/data.ts
@@ -998,7 +998,11 @@ export async function getCompetitorComparisonFor(
   const competitors = comp.by_competitor.map((c) => ({
     competitor_id: c.competitor_id,
     name: c.name && c.name.trim() !== '' ? c.name : c.competitor_id,
-    avg_visibility_score: c.row_count > 0 ? Math.round(Number(c.sum_visibility) / c.row_count) : 0,
+    // Same denominator as the brand's average (every filtered row, absence
+    // counts as 0) — mirrors getCompetitorComparison in actions/tracking.ts
+    // so the MCP surface ranks brands the same way the Insights page does.
+    avg_visibility_score:
+      comp.brand_row_count > 0 ? Math.round(Number(c.sum_visibility) / comp.brand_row_count) : 0,
     total_mentions: Number(c.total_mentions),
     total_citations: Number(c.total_citations),
     appearance_count: c.row_count,


### PR DESCRIPTION
## Summary

On the Insights page, a brand could rank last on the competitor leaderboard despite having far more mentions and citations than every competitor. The leaderboard sorts by average visibility score, and that average was computed asymmetrically:

- **Brand**: visibility sum ÷ **every filtered result row**.
- **Competitor**: visibility sum ÷ **its own appearance row count** — `competitor_mentions` records every *configured* competitor per run, so this equals the number of runs since that competitor was added to the brand's list.

On wide date ranges (All time) a recently added competitor was graded only on its recent window while the brand carried its entire history (including thousands of early zero-score runs), so a competitor seen in ~4% of the brand's runs could post a far higher average and outrank it.

Competitor sums are now divided by the same total run count as the brand's — absence from a response counts as 0, exactly like it does for the brand — in all four places that did this division:

- the displayed leaderboard average,
- the delta-window (current vs previous period) averages behind the ↑/↓ badge,
- the per-provider comparison chart rows,
- the MCP `get_competitor_comparison` surface (`web/src/lib/mcp/data.ts`), which mirrors the same math so API answers rank brands the same way the page does. Its `appearance_count` field is unchanged (still the honest appearance count).

No SQL/migration changes — the `competitor_aggregates` RPC already returns the total row count per window; only the JS division changed. Verified against production data for the reporting brand: with the shared denominator the brand moves from last place to ahead of every competitor except the one that genuinely out-cites it.

Trade-off, deliberate: a competitor added recently is counted as 0 for runs before it existed. That is consistent (the brand is subject to the same rule for its whole history) and beats comparing different time windows across rows of the same table.

## Related issue

None — raised from internal dogfooding feedback.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open `/dashboard/insights` for a brand with competitors and pick **All** as the date range.
2. In the Leaderboard, a brand with more mentions/citations than a competitor that appears in only a small share of runs should now rank above it.
3. The "AI Visibility — Brand vs Competitors" chart shows the same relative ordering per provider.
4. Narrow ranges (24h/7d) still work; the ↑/↓ delta badges still render.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR