### PR TITLE
fix(prompts): stop suggestion refresh failing on high-volume estimates

### DIFF
--- a/server/src/routes/prompts.js
+++ b/server/src/routes/prompts.js
@@ -142,11 +142,16 @@ const newSuggestionSchema = z.object({
           .describe(
             'One sentence explaining why this prompt matters for the brand (gap, trend, competitor coverage)',
           ),
+        // No .max() ceiling: the prompt tells the model to calibrate volumes
+        // against the brand's real tracked volumes, so on high-volume brands
+        // it legitimately estimates six figures — a hard schema cap then
+        // rejects the WHOLE batch deterministically ("No object generated"),
+        // and retrying can't help. Out-of-range protection is a clamp at the
+        // insert site instead.
         estVolume: z
           .number()
           .int()
           .min(0)
-          .max(100000)
           .describe('Estimated monthly AI search volume (rough)'),
       }),
     )
@@ -205,12 +210,20 @@ Suggest the next 8 prompts this brand should start tracking, with topic, reason 
   const promptModel = process.env.PROMPT_SUGGESTION_MODEL || 'google/gemini-3-flash-preview';
   const aiModel = resolveModel(promptModel);
 
-  const { object } = await generateObject({
-    model: aiModel,
-    schema: newSuggestionSchema,
-    system,
-    prompt: userPrompt,
-  });
+  // #379 pattern — bounded retry: generateObject throws "No object generated:
+  // response did not match schema" when the model misses a constraint (short
+  // reason, <6 items, non-integer estVolume, …); a fresh sample usually
+  // passes, so one miss must not fail the whole refresh.
+  const { object } = await withRetry(
+    () =>
+      generateObject({
+        model: aiModel,
+        schema: newSuggestionSchema,
+        system,
+        prompt: userPrompt,
+      }),
+    { attempts: 3, baseDelayMs: 500, label: 'suggestion-refresh' },
+  );
 
   return object.suggestions;
 }
@@ -259,7 +272,9 @@ router.post(
           topic_name: s.topic,
           topic_id: topicId,
           reason: s.reason,
-          est_volume: s.estVolume,
+          // Sanity clamp replacing the removed schema ceiling — one absurd
+          // estimate must cap out, not reject the whole generated batch.
+          est_volume: Math.min(s.estVolume, 10_000_000),
           source: 'llm',
           status: 'new',
           expires_at: expiresAt,

--- a/server/src/routes/prompts.js
+++ b/server/src/routes/prompts.js
@@ -148,11 +148,7 @@ const newSuggestionSchema = z.object({
         // rejects the WHOLE batch deterministically ("No object generated"),
         // and retrying can't help. Out-of-range protection is a clamp at the
         // insert site instead.
-        estVolume: z
-          .number()
-          .int()
-          .min(0)
-          .describe('Estimated monthly AI search volume (rough)'),
+        estVolume: z.number().int().min(0).describe('Estimated monthly AI search volume (rough)'),
       }),
     )
     .min(6)


### PR DESCRIPTION
## Summary

Generating prompt suggestions from the Prompts page failed with **"No object generated: response did not match schema."** — reproducibly, on every attempt.

**Root cause**: the refresh endpoint's `generateObject` schema capped `estVolume` at `.max(100000)`. The generation prompt shows the model the brand's real tracked volumes and explicitly asks it to *calibrate estimates against them* — so on a brand with high tracked volumes the model legitimately returns six-figure estimates. One over-cap value makes zod reject the **entire** batch, and because the calibration instruction reproduces the same magnitudes every time, the failure is deterministic (reproduced against the production code path with a real brand context: `suggestions[3].estVolume = 112800 > 100000` — the other 7 suggestions were fine and the JSON was valid).

**Fix**:
- Remove the `.max(100000)` ceiling from the schema; out-of-range protection is now a `Math.min(estVolume, 10_000_000)` clamp at the insert site — one absurd estimate caps out instead of sinking the whole batch.
- Wrap the `generateObject` call in the bounded `withRetry` (3 attempts) that the onboarding suggestion endpoint already uses (#379 pattern), so genuinely transient schema misses — short reason, missing item — get a fresh sample instead of failing the request.

Verified with the same context that failed before: two consecutive runs both return 8 valid suggestions.

## Related issue

None — reported from local testing.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Pick a brand whose tracked prompts have high analyzed AI volumes (six-figure top volumes).
2. On `/dashboard/prompts`, expand the Prompt Suggestions card and hit **Refresh**.
3. Suggestions generate successfully; previously this returned the schema error every time.
4. Stored `est_volume` values are plausible (clamped at 10M as a sanity bound).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR