### PR TITLE
fix(web): align prompt loading spinner styles

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -711,8 +711,8 @@ export default function PromptsPage() {
           </div>
 
           {loading ? (
-            <div className="flex items-center justify-center min-h-[300px]">
-              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            <div className="flex items-center justify-center py-10">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
             </div>
           ) : volumes.length === 0 ? (
             <Card>
@@ -1065,8 +1065,8 @@ function AllPromptsTab({
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[300px]">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <div className="flex items-center justify-center py-10">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Align the loading states on the Prompts page by updating the two table/insights loading spinners to match the existing Prompt Suggestions card.

### Changes
- Replace the large (`h-8 w-8`) loading spinner with the compact (`h-5 w-5`) spinner.
- Replace the `min-h-[300px]` loading container with a compact `py-10` container.
- Apply the same loading style to both the **All Prompts** table and **Insights** loading states for a consistent UI.

## Related issue

Closes #469 

## Type of change

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR