### PR TITLE
feat(prompts): Add prompt dialog on the All Prompts tab

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -27,6 +27,14 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { CompetitionBars } from '@/components/ui/competition-bars';
 import {
   TrendingUp,
@@ -39,6 +47,7 @@ import {
   Loader2,
   RefreshCw,
   Pencil,
+  Plus,
   Settings2,
   Download,
   ChevronUp,
@@ -47,7 +56,8 @@ import {
 import { cn } from '@/lib/utils';
 import { useBrandStore } from '@/stores/use-brand-store';
 import { analyzePromptVolumesBatch, refreshVolumes, type VolumeQuota } from '@/lib/actions/volumes';
-import { getPromptsPageData } from '@/lib/actions/prompt';
+import { addPromptToBrand, getPromptsPageData } from '@/lib/actions/prompt';
+import { useUserRole } from '@/hooks/use-user-role';
 import { type PromptVisibilitySummary } from '@/lib/actions/tracking';
 import { aggregatePromptVolumeClusters } from '@/lib/prompt-volume-clusters';
 import type { PromptVolume, Prompt } from '@/types';
@@ -224,6 +234,108 @@ function visibilityBarClass(score: number): string {
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
+/**
+ * Quick-add dialog for the active brand (#460). Text only — platforms/models
+ * are derived server-side from the brand's most recent active prompt (same
+ * promote flow as tracking a fan-out query). Plan-limit and other user-facing
+ * failures come back as a value and render inside the dialog instead of the
+ * masked production digest (#427).
+ */
+function AddPromptDialog({
+  brandId,
+  open,
+  onClose,
+  onAdded,
+}: {
+  brandId: string;
+  open: boolean;
+  onClose: () => void;
+  onAdded: () => void;
+}) {
+  const [text, setText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const handleClose = () => {
+    if (saving) return;
+    setText('');
+    setError(null);
+    onClose();
+  };
+
+  const handleAdd = async () => {
+    if (!text.trim() || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await addPromptToBrand(brandId, text);
+      if ('error' in result) {
+        setError(result.error);
+        return;
+      }
+      setText('');
+      onClose();
+      toast.success('Prompt added — it will be picked up by the next tracking run.');
+      onAdded();
+    } catch {
+      setError('Failed to add prompt. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <Plus className="h-4 w-4" />
+            Add Prompt
+          </DialogTitle>
+          <DialogDescription>
+            Track a new prompt for this brand. Platforms and models follow your existing prompts —
+            fine-tune later from the brand&apos;s Manage prompts page.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Input
+            autoFocus
+            placeholder="e.g. Best project management tools for startups"
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              if (error) setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAdd();
+            }}
+            disabled={saving}
+          />
+          {error && <p className="text-xs text-red-500">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={handleClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleAdd} disabled={saving || !text.trim()}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Adding…
+              </>
+            ) : (
+              <>
+                <Plus className="mr-2 h-4 w-4" />
+                Add Prompt
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function KpiCard({
   title,
   icon: Icon,
@@ -275,6 +387,8 @@ export default function PromptsPage() {
   const [analyzing, setAnalyzing] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [quota, setQuota] = useState<VolumeQuota | null>(null);
+  const [addPromptOpen, setAddPromptOpen] = useState(false);
+  const { canManage } = useUserRole();
 
   const activeBrandId = useBrandStore((s) => s.activeBrandId);
   const activeBrand = useBrandStore(
@@ -565,6 +679,17 @@ export default function PromptsPage() {
             <TabsTrigger value="insights">Insights</TabsTrigger>
           </TabsList>
           <div className="flex items-center gap-2">
+            {tab === 'all' && canManage && (
+              <Button
+                type="button"
+                size="sm"
+                className="gap-2"
+                onClick={() => setAddPromptOpen(true)}
+              >
+                <Plus className="h-4 w-4" />
+                Add prompt
+              </Button>
+            )}
             {tab === 'all' && (
               <span title={!canExport ? PROMPT_EXPORT_HINT : undefined}>
                 <Button
@@ -637,6 +762,7 @@ export default function PromptsPage() {
             activeBrandId={activeBrandId}
             volumeByPromptId={volumeByPromptId}
             visibility={visibility}
+            onAddPrompt={canManage ? () => setAddPromptOpen(true) : undefined}
           />
         </TabsContent>
 
@@ -988,6 +1114,15 @@ export default function PromptsPage() {
           )}
         </TabsContent>
       </Tabs>
+
+      {activeBrandId && (
+        <AddPromptDialog
+          brandId={activeBrandId}
+          open={addPromptOpen}
+          onClose={() => setAddPromptOpen(false)}
+          onAdded={loadData}
+        />
+      )}
     </div>
   );
 }
@@ -1000,12 +1135,15 @@ function AllPromptsTab({
   activeBrandId,
   volumeByPromptId,
   visibility,
+  onAddPrompt,
 }: {
   loading: boolean;
   prompts: Prompt[];
   activeBrandId: string;
   volumeByPromptId: Map<string, PromptVolume>;
   visibility: Record<string, PromptVisibilitySummary>;
+  /** Opens the Add Prompt dialog; undefined when the user can't write (member role). */
+  onAddPrompt?: () => void;
 }) {
   const [search, setSearch] = useState('');
   const searchParams = useSearchParams();
@@ -1082,12 +1220,20 @@ function AllPromptsTab({
               Add prompts to your brand to start tracking their AI visibility.
             </p>
           </div>
-          <Link href={`/dashboard/brands/${activeBrandId}/prompts`}>
-            <Button size="sm" className="gap-2">
-              <Pencil className="h-4 w-4" />
-              Manage prompts
-            </Button>
-          </Link>
+          <div className="flex items-center gap-2">
+            {onAddPrompt && (
+              <Button size="sm" className="gap-2" onClick={onAddPrompt}>
+                <Plus className="h-4 w-4" />
+                Add prompt
+              </Button>
+            )}
+            <Link href={`/dashboard/brands/${activeBrandId}/prompts`}>
+              <Button size="sm" variant={onAddPrompt ? 'outline' : 'default'} className="gap-2">
+                <Pencil className="h-4 w-4" />
+                Manage prompts
+              </Button>
+            </Link>
+          </div>
         </CardContent>
       </Card>
     );

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -35,6 +35,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { CompetitionBars } from '@/components/ui/competition-bars';
 import {
   TrendingUp,
@@ -52,15 +59,20 @@ import {
   Download,
   ChevronUp,
   ChevronDown,
+  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useBrandStore } from '@/stores/use-brand-store';
 import { analyzePromptVolumesBatch, refreshVolumes, type VolumeQuota } from '@/lib/actions/volumes';
 import { addPromptToBrand, getPromptsPageData } from '@/lib/actions/prompt';
 import { useUserRole } from '@/hooks/use-user-role';
+import { usePlanContext } from '@/components/providers/plan-provider';
+import { MODEL_GROUPS, ALL_MODELS, SCRAPER_GROUPS, ALL_SCRAPERS } from '@/config/prompt-options';
+import { PLANS } from '@/config/plans';
+import { getTopics } from '@/lib/actions/topic';
 import { type PromptVisibilitySummary } from '@/lib/actions/tracking';
 import { aggregatePromptVolumeClusters } from '@/lib/prompt-volume-clusters';
-import type { PromptVolume, Prompt } from '@/types';
+import type { PromptVolume, Prompt, Topic } from '@/types';
 import { toast } from 'sonner';
 import { toCsv } from '@/lib/csv';
 import { compareNullsLast, type SortDir } from './prompt-sort';
@@ -235,45 +247,99 @@ function visibilityBarClass(score: number): string {
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
 /**
- * Quick-add dialog for the active brand (#460). Text only — platforms/models
- * are derived server-side from the brand's most recent active prompt (same
- * promote flow as tracking a fan-out query). Plan-limit and other user-facing
- * failures come back as a value and render inside the dialog instead of the
- * masked production digest (#427).
+ * Quick-add dialog for the active brand (#460). Same mechanism as the Add
+ * Prompt card on brands/[id]/prompts: topic select + the grouped
+ * Platform & Models picker (plan-filtered, shopping hidden unless the brand
+ * opted in), all allowed engines selected by default. Plan-limit and other
+ * user-facing failures come back as a value and render inside the dialog
+ * instead of the masked production digest (#427).
  */
 function AddPromptDialog({
   brandId,
+  shoppingEnabled,
   open,
   onClose,
   onAdded,
 }: {
   brandId: string;
+  shoppingEnabled: boolean;
   open: boolean;
   onClose: () => void;
   onAdded: () => void;
 }) {
+  const { planId, allowedModelIds: planAllowedModelIds } = usePlanContext();
+
+  const allowedScraperIds = useMemo(() => {
+    const allowed = PLANS[planId].limits.allowedScrapers;
+    const ids = allowed ? [...allowed] : ALL_SCRAPERS.map((s) => s.id);
+    // Shopping tracking is opt-in per brand (#155): hide the engine entirely
+    // when the pref is off. The write actions strip it server-side too.
+    return shoppingEnabled ? ids : ids.filter((id) => id !== 'chatgpt-shopping');
+  }, [planId, shoppingEnabled]);
+  const allowedModelIds = useMemo(
+    () => planAllowedModelIds ?? ALL_MODELS.map((m) => m.id),
+    [planAllowedModelIds],
+  );
+  const visibleScrapers = useMemo(
+    () => ALL_SCRAPERS.filter((s) => allowedScraperIds.includes(s.id)),
+    [allowedScraperIds],
+  );
+  const visibleModels = useMemo(
+    () => ALL_MODELS.filter((m) => allowedModelIds.includes(m.id)),
+    [allowedModelIds],
+  );
+
   const [text, setText] = useState('');
+  const [category, setCategory] = useState('');
+  const [scrapers, setScrapers] = useState<string[]>([]);
+  const [models, setModels] = useState<string[]>([]);
+  const [topics, setTopics] = useState<Topic[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  const handleClose = () => {
-    if (saving) return;
+  // Reset to a fresh form on every open: all allowed engines pre-selected
+  // (matching the brand page's defaults) and topics fetched lazily — the
+  // dialog must cost zero requests until it is actually opened.
+  useEffect(() => {
+    if (!open) return;
     setText('');
     setError(null);
+    setScrapers(allowedScraperIds);
+    setModels(allowedModelIds);
+    let cancelled = false;
+    getTopics(brandId)
+      .then((t) => {
+        if (cancelled) return;
+        setTopics(t);
+        setCategory((prev) => prev || (t[0]?.name ?? ''));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, brandId]);
+
+  const handleClose = () => {
+    if (saving) return;
     onClose();
   };
 
   const handleAdd = async () => {
-    if (!text.trim() || saving) return;
+    if (!text.trim() || (scrapers.length === 0 && models.length === 0) || saving) return;
     setSaving(true);
     setError(null);
     try {
-      const result = await addPromptToBrand(brandId, text);
+      const result = await addPromptToBrand(brandId, {
+        text,
+        category: category || undefined,
+        platforms: scrapers,
+        models,
+      });
       if ('error' in result) {
         setError(result.error);
         return;
       }
-      setText('');
       onClose();
       toast.success('Prompt added — it will be picked up by the next tracking run.');
       onAdded();
@@ -286,18 +352,17 @@ function AddPromptDialog({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-base">
             <Plus className="h-4 w-4" />
             Add Prompt
           </DialogTitle>
           <DialogDescription>
-            Track a new prompt for this brand. Platforms and models follow your existing prompts —
-            fine-tune later from the brand&apos;s Manage prompts page.
+            Track a new prompt for this brand across the selected platforms.
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-2">
+        <div className="space-y-3">
           <Input
             autoFocus
             placeholder="e.g. Best project management tools for startups"
@@ -311,13 +376,148 @@ function AddPromptDialog({
             }}
             disabled={saving}
           />
+
+          {/* Topic */}
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Topic</label>
+            {topics.length > 0 ? (
+              <Select value={category || null} onValueChange={(v) => v && setCategory(String(v))}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a topic" />
+                </SelectTrigger>
+                <SelectContent>
+                  {topics.map((topic) => (
+                    <SelectItem key={topic.id} value={topic.name}>
+                      {topic.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <p className="text-xs text-muted-foreground py-2">
+                No topics defined yet. Add topics in brand settings.
+              </p>
+            )}
+          </div>
+
+          {/* Platform & Models — combined select, same as brands/[id]/prompts */}
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Platform & Models
+            </label>
+            <Select
+              value="__placeholder__"
+              onValueChange={(v) => {
+                if (!v || v === '__placeholder__') return;
+                const id = String(v);
+                if (visibleModels.some((m) => m.id === id) && !models.includes(id)) {
+                  setModels((prev) => [...prev, id]);
+                } else if (visibleScrapers.some((s) => s.id === id) && !scrapers.includes(id)) {
+                  setScrapers((prev) => [...prev, id]);
+                }
+              }}
+            >
+              <SelectTrigger className="w-full">
+                <span className="truncate text-muted-foreground">
+                  {models.length + scrapers.length > 0
+                    ? `${models.length + scrapers.length} selected`
+                    : 'Select platform & models'}
+                </span>
+              </SelectTrigger>
+              <SelectContent>
+                {SCRAPER_GROUPS.map((group) => {
+                  const groupScrapers = group.scrapers.filter((s) =>
+                    visibleScrapers.some((vs) => vs.id === s.id),
+                  );
+                  if (groupScrapers.length === 0) return null;
+                  return (
+                    <div key={group.provider}>
+                      <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
+                        {group.provider} (Scraper)
+                      </div>
+                      {groupScrapers.map((s) => (
+                        <SelectItem key={s.id} value={s.id} disabled={scrapers.includes(s.id)}>
+                          <div>
+                            <div>{s.label}</div>
+                            <div className="text-[10px] text-muted-foreground font-mono">
+                              {s.id}
+                            </div>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </div>
+                  );
+                })}
+                {MODEL_GROUPS.map((group) => {
+                  const groupModels = group.models.filter((m) =>
+                    visibleModels.some((vm) => vm.id === m.id),
+                  );
+                  if (groupModels.length === 0) return null;
+                  return (
+                    <div key={group.provider}>
+                      <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
+                        {group.provider} (API)
+                      </div>
+                      {groupModels.map((m) => (
+                        <SelectItem key={m.id} value={m.id} disabled={models.includes(m.id)}>
+                          <div>
+                            <div>{m.label}</div>
+                            <div className="text-[10px] text-muted-foreground font-mono">
+                              {m.id}
+                            </div>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </div>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+            {(models.length > 0 || scrapers.length > 0) && (
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {scrapers.map((id) => {
+                  const s = ALL_SCRAPERS.find((as_) => as_.id === id);
+                  return (
+                    <Badge key={id} variant="outline" className="gap-1 text-xs">
+                      {s?.label ?? id}
+                      <button
+                        type="button"
+                        onClick={() => setScrapers((p) => p.filter((i) => i !== id))}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  );
+                })}
+                {models.map((id) => {
+                  const m = ALL_MODELS.find((am) => am.id === id);
+                  return (
+                    <Badge key={id} variant="secondary" className="gap-1 text-xs">
+                      {m?.label ?? id}
+                      <button
+                        type="button"
+                        onClick={() => setModels((p) => p.filter((i) => i !== id))}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
           {error && <p className="text-xs text-red-500">{error}</p>}
         </div>
         <DialogFooter>
           <Button type="button" variant="outline" onClick={handleClose} disabled={saving}>
             Cancel
           </Button>
-          <Button type="button" onClick={handleAdd} disabled={saving || !text.trim()}>
+          <Button
+            type="button"
+            onClick={handleAdd}
+            disabled={saving || !text.trim() || (scrapers.length === 0 && models.length === 0)}
+          >
             {saving ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -1118,6 +1318,7 @@ export default function PromptsPage() {
       {activeBrandId && (
         <AddPromptDialog
           brandId={activeBrandId}
+          shoppingEnabled={!!activeBrand?.shoppingModeEnabled}
           open={addPromptOpen}
           onClose={() => setAddPromptOpen(false)}
           onAdded={loadData}

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -389,21 +389,25 @@ export async function addPromptToSet(input: AddPromptInput): Promise<Prompt> {
 export type AddPromptToBrandResult = { prompt: Prompt } | { error: string };
 
 /**
- * Add a single prompt to a brand from the main Prompts page (#460). Mirrors
- * trackFanoutQuery's promote flow: earliest prompt set, platforms/models
- * derived from its most recent active prompt.
+ * Add a single prompt to a brand from the main Prompts page (#460). Same
+ * write path as the brand page's Add Prompt card (addPromptToSet with the
+ * caller's topic/platform/model choices); the brand's earliest prompt set is
+ * the target, created on the fly when the brand has none yet.
  *
- * User-facing failures (plan limit, no prompt set) come back as a VALUE:
+ * User-facing failures (plan limit, empty selection) come back as a VALUE:
  * production masks every error thrown from a server action, so a thrown
  * PlanLimitError would reach users as the meaningless digest message (#427).
  */
 export async function addPromptToBrand(
   brandId: string,
-  text: string,
+  input: { text: string; category?: string; platforms: string[]; models?: string[] },
 ): Promise<AddPromptToBrandResult> {
   const supabase = await createClient();
-  const trimmed = text.trim();
+  const trimmed = input.text.trim();
   if (!trimmed) return { error: 'Prompt text is required.' };
+  if (input.platforms.length === 0 && (input.models ?? []).length === 0) {
+    return { error: 'Select at least one platform or model.' };
+  }
 
   const { data: ps, error: psErr } = await supabase
     .from('prompt_sets')
@@ -412,32 +416,29 @@ export async function addPromptToBrand(
     .order('created_at', { ascending: true })
     .limit(1)
     .maybeSingle();
-  if (psErr || !ps) {
-    return { error: 'No prompt set exists for this brand. Create one first.' };
+  if (psErr) return { error: psErr.message };
+
+  let promptSetId = ps?.id as string | undefined;
+  if (!promptSetId) {
+    const { data: createdSet, error: setErr } = await supabase
+      .from('prompt_sets')
+      .insert({ brand_id: brandId, name: 'Prompts' })
+      .select('id')
+      .single();
+    if (setErr || !createdSet) {
+      return { error: setErr?.message ?? 'Failed to create a prompt set for this brand.' };
+    }
+    promptSetId = createdSet.id as string;
   }
-
-  const { data: defaults } = await supabase
-    .from('prompts')
-    .select('platforms, models')
-    .eq('prompt_set_id', ps.id)
-    .eq('is_active', true)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  const platforms =
-    Array.isArray(defaults?.platforms) && defaults!.platforms.length > 0
-      ? (defaults!.platforms as string[])
-      : ['chatgpt-web'];
-  const models = Array.isArray(defaults?.models) ? (defaults!.models as string[]) : [];
 
   let created: Prompt;
   try {
     created = await addPromptToSet({
-      promptSetId: ps.id as string,
+      promptSetId,
       text: trimmed,
-      platforms,
-      models,
+      category: input.category,
+      platforms: input.platforms,
+      models: input.models ?? [],
     });
   } catch (err) {
     if (err instanceof PlanLimitError) return { error: err.message };

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -3,7 +3,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { revalidatePath } from 'next/cache';
 import type { PromptSet, Prompt, AIPlatform, PromptVolume } from '@/types';
-import { enforceLimit, getOrgPlan } from '@/lib/guards/plan-guard';
+import { enforceLimit, getOrgPlan, PlanLimitError } from '@/lib/guards/plan-guard';
 import { ALL_MODELS, ALL_SCRAPERS } from '@/config/prompt-options';
 import type { Plan } from '@/config/plans';
 import { getPromptVolumes, type VolumeQuota } from '@/lib/actions/volumes';
@@ -384,6 +384,68 @@ export async function addPromptToSet(input: AddPromptInput): Promise<Prompt> {
 
   revalidatePath('/dashboard/brands');
   return mapPromptRow(data as Record<string, unknown>);
+}
+
+export type AddPromptToBrandResult = { prompt: Prompt } | { error: string };
+
+/**
+ * Add a single prompt to a brand from the main Prompts page (#460). Mirrors
+ * trackFanoutQuery's promote flow: earliest prompt set, platforms/models
+ * derived from its most recent active prompt.
+ *
+ * User-facing failures (plan limit, no prompt set) come back as a VALUE:
+ * production masks every error thrown from a server action, so a thrown
+ * PlanLimitError would reach users as the meaningless digest message (#427).
+ */
+export async function addPromptToBrand(
+  brandId: string,
+  text: string,
+): Promise<AddPromptToBrandResult> {
+  const supabase = await createClient();
+  const trimmed = text.trim();
+  if (!trimmed) return { error: 'Prompt text is required.' };
+
+  const { data: ps, error: psErr } = await supabase
+    .from('prompt_sets')
+    .select('id')
+    .eq('brand_id', brandId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (psErr || !ps) {
+    return { error: 'No prompt set exists for this brand. Create one first.' };
+  }
+
+  const { data: defaults } = await supabase
+    .from('prompts')
+    .select('platforms, models')
+    .eq('prompt_set_id', ps.id)
+    .eq('is_active', true)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const platforms =
+    Array.isArray(defaults?.platforms) && defaults!.platforms.length > 0
+      ? (defaults!.platforms as string[])
+      : ['chatgpt-web'];
+  const models = Array.isArray(defaults?.models) ? (defaults!.models as string[]) : [];
+
+  let created: Prompt;
+  try {
+    created = await addPromptToSet({
+      promptSetId: ps.id as string,
+      text: trimmed,
+      platforms,
+      models,
+    });
+  } catch (err) {
+    if (err instanceof PlanLimitError) return { error: err.message };
+    throw err;
+  }
+
+  revalidatePath('/dashboard/prompts');
+  return { prompt: created };
 }
 
 export async function deletePrompt(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

The main Prompts page — the primary prompt surface in the sidebar — told users to add prompts in several places but offered no way to do it there; creation lived only under Brands → [brand] → Prompts. This adds an **Add prompt** button to the All Prompts tab header and to the empty state (previously a dead end), opening a dialog for the active brand.

The dialog mirrors the brand page's Add Prompt card mechanism:

- **Topic select** — the brand's topics, fetched lazily on dialog open only (zero cost on page load), defaulting to the first topic; a hint is shown when the brand has no topics yet.
- **Platform & Models picker** — the same grouped select (scraper groups + API model groups, label + mono id), plan-filtered, with `chatgpt-shopping` hidden unless the brand opted in (#155). All allowed engines are pre-selected and removable as badges, matching the brand page's defaults.
- **Plan-limit errors render inside the dialog**: the new `addPromptToBrand` action returns user-facing failures as a value (the `trackFanoutQuery` pattern) instead of throwing — production masks thrown server-action errors into a useless digest message (#427), so the real "plan limit reached" text now reaches the user.
- The write path is the existing `addPromptToSet` (same validation, plan filtering, shopping stripping, topic resolution). Target is the brand's earliest prompt set, **created on the fly** when the brand has none yet.
- After a successful add: dialog closes, the list refreshes, and a toast notes the prompt will be picked up by the next tracking run.
- **Role-gated**: the button (header and empty state) only renders for admin/manager (`useUserRole().canManage`).

## Related issue

Closes #460

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. As admin/manager on `/dashboard/prompts?tab=all`, click **Add prompt** in the header: the dialog opens with the brand's topics and all plan-allowed engines pre-selected.
2. Add a prompt: it appears in the list immediately (active), with a toast about the next tracking run.
3. Remove all engines from the picker: the Add button disables.
4. On a brand at its plan's prompt limit, the actual limit message renders inside the dialog — not a generic error.
5. On a brand with no prompts, the empty state shows the same Add prompt button next to Manage prompts.
6. As a member (read-only role), neither button renders.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR