### PR TITLE
feat(citations): move Source Types into a sources-card tab, full-width card

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -1350,7 +1350,7 @@ export default function CitationsPage() {
 
   const activeBrandId = brand?.id ?? null;
 
-  const [sourceTab, setSourceTab] = useState<'domains' | 'urls' | 'gaps'>('domains');
+  const [sourceTab, setSourceTab] = useState<'domains' | 'urls' | 'gaps' | 'types'>('domains');
   const [gaps, setGaps] = useState<CitationGaps | null>(null);
   const [gapsLoading, setGapsLoading] = useState(false);
 
@@ -1572,7 +1572,7 @@ export default function CitationsPage() {
           variant="outline"
           className="gap-2"
           onClick={handleExportCsv}
-          disabled={isExporting || sourceTab === 'gaps' || isLoading}
+          disabled={isExporting || sourceTab === 'gaps' || sourceTab === 'types' || isLoading}
         >
           {isExporting ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -1603,62 +1603,60 @@ export default function CitationsPage() {
             ))}
           </div>
 
-          <div className="grid gap-4 lg:grid-cols-5">
-            <Card className="lg:col-span-3">
-              <CardHeader>
-                <CardTitle className="text-base">{t('sourcesTitle')}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <Tabs
-                  value={sourceTab}
-                  onValueChange={(v) => setSourceTab(v as 'domains' | 'urls' | 'gaps')}
-                >
-                  <TabsList>
-                    <TabsTrigger value="domains">
-                      {t('tabDomains')} ({data?.totals.domains ?? 0})
-                    </TabsTrigger>
-                    <TabsTrigger value="urls">
-                      {t('tabUrls')} ({data?.totals.urls ?? 0})
-                    </TabsTrigger>
-                    <TabsTrigger value="gaps">Competitor Gaps</TabsTrigger>
-                  </TabsList>
-                  {/* keepMounted: data is already in memory, so mount both panels
-                      once and make switching a pure CSS visibility toggle (#299). */}
-                  <TabsContent value="domains" keepMounted className="mt-4">
-                    <DomainsTable
-                      rows={data?.rows ?? []}
-                      brandId={activeBrandId ?? ''}
-                      onAdded={loadData}
-                      page={domainPager.page}
-                      onPage={domainPager.setPage}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">{t('sourcesTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Tabs
+                value={sourceTab}
+                onValueChange={(v) => setSourceTab(v as 'domains' | 'urls' | 'gaps' | 'types')}
+              >
+                <TabsList>
+                  <TabsTrigger value="domains">
+                    {t('tabDomains')} ({data?.totals.domains ?? 0})
+                  </TabsTrigger>
+                  <TabsTrigger value="urls">
+                    {t('tabUrls')} ({data?.totals.urls ?? 0})
+                  </TabsTrigger>
+                  <TabsTrigger value="gaps">Competitor Gaps</TabsTrigger>
+                  <TabsTrigger value="types">{t('sourceTypesTitle')}</TabsTrigger>
+                </TabsList>
+                {/* keepMounted: data is already in memory, so mount these panels
+                    once and make switching a pure CSS visibility toggle (#299).
+                    Competitor Gaps stays lazy — it fetches on activation. */}
+                <TabsContent value="domains" keepMounted className="mt-4">
+                  <DomainsTable
+                    rows={data?.rows ?? []}
+                    brandId={activeBrandId ?? ''}
+                    onAdded={loadData}
+                    page={domainPager.page}
+                    onPage={domainPager.setPage}
+                  />
+                </TabsContent>
+                <TabsContent value="urls" keepMounted className="mt-4">
+                  <UrlsTable
+                    rows={data?.urlRows ?? []}
+                    page={urlPager.page}
+                    onPage={urlPager.setPage}
+                  />
+                </TabsContent>
+                <TabsContent value="gaps" className="mt-4">
+                  <CompetitorGapsTab loading={gapsLoading} gaps={gaps} />
+                </TabsContent>
+                <TabsContent value="types" keepMounted className="mt-4">
+                  {/* Cap the width: the donut sizes itself to its container, and
+                      an unbounded full-width chart dwarfs the legend (#486). */}
+                  <div className="mx-auto w-full max-w-md">
+                    <SourceTypeDonut
+                      data={data?.sourceTypeBreakdown ?? []}
+                      total={data?.totals.domains ?? 0}
                     />
-                  </TabsContent>
-                  <TabsContent value="urls" keepMounted className="mt-4">
-                    <UrlsTable
-                      rows={data?.urlRows ?? []}
-                      page={urlPager.page}
-                      onPage={urlPager.setPage}
-                    />
-                  </TabsContent>
-                  <TabsContent value="gaps" className="mt-4">
-                    <CompetitorGapsTab loading={gapsLoading} gaps={gaps} />
-                  </TabsContent>
-                </Tabs>
-              </CardContent>
-            </Card>
-
-            <Card className="lg:col-span-2">
-              <CardHeader>
-                <CardTitle className="text-base">{t('sourceTypesTitle')}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <SourceTypeDonut
-                  data={data?.sourceTypeBreakdown ?? []}
-                  total={data?.totals.domains ?? 0}
-                />
-              </CardContent>
-            </Card>
-          </div>
+                  </div>
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
         </>
       )}
     </div>
@@ -1679,19 +1677,12 @@ function CitationsSkeleton() {
           </Card>
         ))}
       </div>
-      <div className="grid gap-4 lg:grid-cols-5">
-        <Card className="lg:col-span-3">
-          <CardContent className="pt-6">
-            <Skeleton className="mb-4 h-8 w-48" />
-            <Skeleton className="h-64 w-full" />
-          </CardContent>
-        </Card>
-        <Card className="lg:col-span-2">
-          <CardContent className="pt-6">
-            <Skeleton className="h-56 w-full" />
-          </CardContent>
-        </Card>
-      </div>
+      <Card>
+        <CardContent className="pt-6">
+          <Skeleton className="mb-4 h-8 w-48" />
+          <Skeleton className="h-64 w-full" />
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

On `/dashboard/citations` the Source Types donut lived in its own `lg:col-span-2` card beside the sources card. At common widths the donut + legend overflowed and forced **horizontal page scroll**, while the page's main content (Domains / URLs / Competitor Gaps tables) was squeezed into 3/5 of the width.

- The donut is now a fourth **Source Types** tab in the sources card, after Competitor Gaps, rendering the existing `SourceTypeDonut` with the same `sourceTypeBreakdown` / `totals.domains` props.
- The right-hand card and the `lg:grid-cols-5` wrapper are gone — the sources card spans the full content width.
- The new panel is `keepMounted` like Domains/URLs (its data arrives with the same payload, per the #299 convention); Competitor Gaps keeps its lazy load on activation.
- The donut is capped at `max-w-md` and centered so the full-width panel can't dwarf it or introduce overflow at any viewport width.
- `CitationsSkeleton` mirrors the new single-card layout; CSV export stays disabled on the non-table tabs (Gaps and now Types).

## Related issue

Closes #486

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open `/dashboard/citations` — the sources card spans the full content width and shows four tabs: Domains / URLs / Competitor Gaps / Source Types.
2. Open the **Source Types** tab — the same donut + legend the removed side card showed, centered, with no horizontal scroll at any viewport width (check narrow laptop widths where the old layout overflowed).
3. Domains/URLs pagination and the Competitor Gaps lazy load work unchanged; date/platform filters re-filter all four tabs.
4. Export CSV is enabled on Domains/URLs and disabled on Competitor Gaps and Source Types.
5. Reload the page — the loading skeleton is a single full-width card.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR