### PR TITLE
feat(prompts): Top Sources card on the prompt detail page

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -2,7 +2,6 @@
 
 import { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import Image from 'next/image';
 import dynamic from 'next/dynamic';
 const DynamicSourceTypeDonutChart = dynamic(
   () => import('./citations_charts').then((m) => m.SourceTypeDonutChartView),
@@ -53,7 +52,12 @@ import {
 import { toCsv } from '@/lib/csv';
 import type { Topic } from '@/types';
 import { SOURCE_CATEGORY_LABELS, type SourceCategory } from '@/lib/citations/classify';
-import { getFaviconUrl } from '@/lib/favicon';
+import {
+  CategoryBadge,
+  DomainFavicon,
+  PlatformsCell,
+  UsageBar,
+} from '@/components/citations/source-cells';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Dialog,
@@ -85,12 +89,7 @@ import {
 } from '@/components/ui/table';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
-import {
-  AIProviderAvatar,
-  getAIProviderDisplayName,
-  resolveAIProvider,
-  type AIProviderKey,
-} from '@/components/ai-provider-avatar';
+import { getAIProviderDisplayName, resolveAIProvider } from '@/components/ai-provider-avatar';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -105,17 +104,6 @@ const CATEGORY_COLORS: Record<SourceCategory, string> = {
   review: '#eab308',
   institutional: '#14b8a6',
   other: '#94a3b8',
-};
-
-const CATEGORY_BADGE_CLASSES: Record<SourceCategory, string> = {
-  you: 'border-indigo-500/30 bg-indigo-500/10 text-indigo-700 dark:text-indigo-300',
-  competitor: 'border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300',
-  editorial: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300',
-  forum: 'border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300',
-  social: 'border-purple-500/30 bg-purple-500/10 text-purple-700 dark:text-purple-300',
-  review: 'border-yellow-500/30 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300',
-  institutional: 'border-teal-500/30 bg-teal-500/10 text-teal-700 dark:text-teal-300',
-  other: 'border-slate-400/30 bg-slate-400/10 text-slate-700 dark:text-slate-300',
 };
 
 // AI platform / model friendly names — kept in sync with the insights page.
@@ -250,78 +238,6 @@ function buildPlatformOptions(rows: CitationsOverview['rows']): PlatformOption[]
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
-
-function CategoryBadge({ category }: { category: SourceCategory }) {
-  return (
-    <Badge
-      variant="outline"
-      className={cn(
-        'text-[10px] font-medium capitalize whitespace-nowrap',
-        CATEGORY_BADGE_CLASSES[category],
-      )}
-    >
-      {SOURCE_CATEGORY_LABELS[category]}
-    </Badge>
-  );
-}
-
-function ProviderDot({ provider }: { provider: AIProviderKey }) {
-  return <AIProviderAvatar provider={provider} />;
-}
-
-/**
- * Collapse model identifiers down to their underlying provider so the column
- * shows at most one dot per platform (ChatGPT, Claude, Gemini, ...). There
- * are only 7 known providers, so the row width stays stable regardless of
- * how many raw models fed into the domain.
- */
-function PlatformsCell({ models }: { models: string[] }) {
-  if (models.length === 0) {
-    return <span className="text-xs text-muted-foreground">—</span>;
-  }
-  const providers = Array.from(new Set(models.map((m) => resolveAIProvider(m)))).sort();
-  return (
-    <div className="flex items-center gap-1">
-      {providers.map((p) => (
-        <ProviderDot key={p} provider={p} />
-      ))}
-    </div>
-  );
-}
-
-function UsageBar({ pct }: { pct: number }) {
-  const clamped = Math.min(100, Math.max(0, pct));
-  return (
-    <div className="flex items-center gap-2">
-      <div className="h-1.5 w-20 rounded-full bg-muted overflow-hidden">
-        <div className="h-full rounded-full bg-primary" style={{ width: `${clamped}%` }} />
-      </div>
-      <span className="text-xs tabular-nums text-foreground">{pct.toFixed(1)}%</span>
-    </div>
-  );
-}
-
-function DomainFavicon({ domain }: { domain: string }) {
-  const [errored, setErrored] = useState(false);
-  if (errored) {
-    return (
-      <div className="flex h-6 w-6 items-center justify-center rounded border bg-muted">
-        <Globe className="h-3 w-3 text-muted-foreground" />
-      </div>
-    );
-  }
-  return (
-    <Image
-      src={getFaviconUrl(domain, 64)}
-      alt=""
-      width={20}
-      height={20}
-      unoptimized
-      className="h-5 w-5 rounded-sm border bg-white object-contain"
-      onError={() => setErrored(true)}
-    />
-  );
-}
 
 // ─── Donut ────────────────────────────────────────────────────────────────────
 

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -58,6 +58,7 @@ import {
   PlatformsCell,
   UsageBar,
 } from '@/components/citations/source-cells';
+import { PAGE_SIZE, TablePager, usePagination } from '@/components/table-pager';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Dialog,
@@ -956,86 +957,6 @@ function EmptyRows({
       <p className="mt-1 text-xs text-muted-foreground">
         Try widening your date range or removing filters.
       </p>
-    </div>
-  );
-}
-
-// ─── Pagination ───────────────────────────────────────────────────────────────
-
-const PAGE_SIZE = 100;
-
-/**
- * Per-table pagination state.
- * resetKey — pass a JSON.stringify of the active filters so the pager
- * automatically jumps back to page 0 whenever any filter changes.
- */
-export function usePagination(totalRows: number, resetKey: unknown) {
-  const [page, setPage] = useState(0);
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const resetKeyRef = useRef(resetKey);
-  if (resetKeyRef.current !== resetKey) {
-    resetKeyRef.current = resetKey;
-    setPage(0);
-  }
-
-  const totalPages = Math.max(1, Math.ceil(totalRows / PAGE_SIZE));
-  const clampedPage = Math.min(page, totalPages - 1);
-
-  return {
-    page: clampedPage,
-    setPage,
-    totalPages,
-    start: clampedPage * PAGE_SIZE,
-    end: Math.min((clampedPage + 1) * PAGE_SIZE, totalRows),
-  };
-}
-
-function TablePager({
-  page,
-  totalPages,
-  total,
-  start,
-  end,
-  onPage,
-}: {
-  page: number;
-  totalPages: number;
-  total: number;
-  start: number;
-  end: number;
-  onPage: (p: number) => void;
-}) {
-  if (totalPages <= 1) return null;
-
-  return (
-    <div className="flex items-center justify-between border-t px-4 py-3">
-      <span className="text-xs text-muted-foreground tabular-nums">
-        {start + 1}–{end} of {total}
-      </span>
-      <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 px-3 text-xs"
-          disabled={page === 0}
-          onClick={() => onPage(page - 1)}
-        >
-          Previous
-        </Button>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {page + 1} / {totalPages}
-        </span>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 px-3 text-xs"
-          disabled={page >= totalPages - 1}
-          onClick={() => onPage(page + 1)}
-        >
-          Next
-        </Button>
-      </div>
     </div>
   );
 }

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -40,6 +40,7 @@ import {
   PlatformsCell,
   UsageBar,
 } from '@/components/citations/source-cells';
+import { TablePager, usePagination } from '@/components/table-pager';
 import { groupByPlatform, type PlatformGroup } from './grouping';
 
 const PLATFORM_LABELS: Record<string, string> = {
@@ -171,36 +172,9 @@ function KpiCard({
   );
 }
 
-const TOP_SOURCES_PREVIEW = 10;
-
-function ShowAllToggle({
-  showAll,
-  total,
-  label,
-  onToggle,
-}: {
-  showAll: boolean;
-  total: number;
-  label: string;
-  onToggle: () => void;
-}) {
-  return (
-    <div className="pt-2">
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-7 text-xs text-muted-foreground"
-        onClick={onToggle}
-      >
-        {showAll ? 'Show fewer' : `Show all ${total} ${label}`}
-      </Button>
-    </div>
-  );
-}
-
 function TopSourceDomainsTable({ rows }: { rows: PromptTopSource[] }) {
-  const [showAll, setShowAll] = useState(false);
-  const visible = showAll ? rows : rows.slice(0, TOP_SOURCES_PREVIEW);
+  const pager = usePagination(rows.length, rows.length);
+  const pageRows = rows.slice(pager.start, pager.end);
 
   return (
     <div>
@@ -215,9 +189,12 @@ function TopSourceDomainsTable({ rows }: { rows: PromptTopSource[] }) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {visible.map((row, i) => (
+          {pageRows.map((row, i) => (
             <TableRow key={row.domain}>
-              <TableCell className="text-xs text-muted-foreground tabular-nums">{i + 1}</TableCell>
+              {/* Global rank — offset by page so rank is continuous across pages */}
+              <TableCell className="text-xs text-muted-foreground tabular-nums">
+                {pager.start + i + 1}
+              </TableCell>
               <TableCell>
                 <div className="flex min-w-0 items-center gap-2">
                   <DomainFavicon domain={row.domain} />
@@ -251,21 +228,21 @@ function TopSourceDomainsTable({ rows }: { rows: PromptTopSource[] }) {
           ))}
         </TableBody>
       </Table>
-      {(rows.length > TOP_SOURCES_PREVIEW || showAll) && (
-        <ShowAllToggle
-          showAll={showAll}
-          total={rows.length}
-          label="domains"
-          onToggle={() => setShowAll((prev) => !prev)}
-        />
-      )}
+      <TablePager
+        page={pager.page}
+        totalPages={pager.totalPages}
+        total={rows.length}
+        start={pager.start}
+        end={pager.end}
+        onPage={pager.setPage}
+      />
     </div>
   );
 }
 
 function TopSourceUrlsTable({ rows }: { rows: PromptTopSourceUrl[] }) {
-  const [showAll, setShowAll] = useState(false);
-  const visible = showAll ? rows : rows.slice(0, TOP_SOURCES_PREVIEW);
+  const pager = usePagination(rows.length, rows.length);
+  const pageRows = rows.slice(pager.start, pager.end);
 
   return (
     <div>
@@ -280,9 +257,12 @@ function TopSourceUrlsTable({ rows }: { rows: PromptTopSourceUrl[] }) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {visible.map((row, i) => (
+          {pageRows.map((row, i) => (
             <TableRow key={row.url}>
-              <TableCell className="text-xs text-muted-foreground tabular-nums">{i + 1}</TableCell>
+              {/* Global rank — offset by page so rank is continuous across pages */}
+              <TableCell className="text-xs text-muted-foreground tabular-nums">
+                {pager.start + i + 1}
+              </TableCell>
               <TableCell>
                 <div className="flex min-w-0 items-start gap-2">
                   <DomainFavicon domain={row.domain} />
@@ -318,14 +298,14 @@ function TopSourceUrlsTable({ rows }: { rows: PromptTopSourceUrl[] }) {
           ))}
         </TableBody>
       </Table>
-      {(rows.length > TOP_SOURCES_PREVIEW || showAll) && (
-        <ShowAllToggle
-          showAll={showAll}
-          total={rows.length}
-          label="URLs"
-          onToggle={() => setShowAll((prev) => !prev)}
-        />
-      )}
+      <TablePager
+        page={pager.page}
+        totalPages={pager.totalPages}
+        total={rows.length}
+        start={pager.start}
+        end={pager.end}
+        onPage={pager.setPage}
+      />
     </div>
   );
 }

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   type PromptDetailData,
   type PromptResultWithText,
   type PromptTopSource,
+  type PromptTopSourceUrl,
 } from '@/lib/actions/tracking';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -21,6 +22,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   ArrowLeft,
   ChevronDown,
@@ -171,81 +173,191 @@ function KpiCard({
 
 const TOP_SOURCES_PREVIEW = 10;
 
-function TopSourcesCard({ sources }: { sources: PromptTopSource[] }) {
-  const [showAll, setShowAll] = useState(false);
-  const visible = showAll ? sources : sources.slice(0, TOP_SOURCES_PREVIEW);
-  const hiddenCount = sources.length - visible.length;
+function ShowAllToggle({
+  showAll,
+  total,
+  label,
+  onToggle,
+}: {
+  showAll: boolean;
+  total: number;
+  label: string;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="pt-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 text-xs text-muted-foreground"
+        onClick={onToggle}
+      >
+        {showAll ? 'Show fewer' : `Show all ${total} ${label}`}
+      </Button>
+    </div>
+  );
+}
 
+function TopSourceDomainsTable({ rows }: { rows: PromptTopSource[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? rows : rows.slice(0, TOP_SOURCES_PREVIEW);
+
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[56px] text-xs">Rank</TableHead>
+            <TableHead className="text-xs">Domain</TableHead>
+            <TableHead className="text-xs">Platforms</TableHead>
+            <TableHead className="text-xs">Usage</TableHead>
+            <TableHead className="text-right text-xs">Citations</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {visible.map((row, i) => (
+            <TableRow key={row.domain}>
+              <TableCell className="text-xs text-muted-foreground tabular-nums">{i + 1}</TableCell>
+              <TableCell>
+                <div className="flex min-w-0 items-center gap-2">
+                  <DomainFavicon domain={row.domain} />
+                  <div className="flex min-w-0 flex-col">
+                    <span className="truncate text-sm font-medium">{row.domain}</span>
+                    <div className="flex items-center gap-1.5 pt-0.5">
+                      <CategoryBadge category={row.category} />
+                      <a
+                        href={`https://${row.domain}`}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="inline-flex items-center text-muted-foreground hover:text-foreground"
+                        aria-label={`Open ${row.domain} in a new tab`}
+                      >
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell>
+                <PlatformsCell models={row.models} />
+              </TableCell>
+              <TableCell>
+                <UsageBar pct={row.usagePct} />
+              </TableCell>
+              <TableCell className="text-right text-xs tabular-nums">
+                {row.totalCitations}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {(rows.length > TOP_SOURCES_PREVIEW || showAll) && (
+        <ShowAllToggle
+          showAll={showAll}
+          total={rows.length}
+          label="domains"
+          onToggle={() => setShowAll((prev) => !prev)}
+        />
+      )}
+    </div>
+  );
+}
+
+function TopSourceUrlsTable({ rows }: { rows: PromptTopSourceUrl[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? rows : rows.slice(0, TOP_SOURCES_PREVIEW);
+
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[56px] text-xs">Rank</TableHead>
+            <TableHead className="text-xs">URL</TableHead>
+            <TableHead className="text-xs">Platforms</TableHead>
+            <TableHead className="text-xs">Usage</TableHead>
+            <TableHead className="text-right text-xs">Citations</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {visible.map((row, i) => (
+            <TableRow key={row.url}>
+              <TableCell className="text-xs text-muted-foreground tabular-nums">{i + 1}</TableCell>
+              <TableCell>
+                <div className="flex min-w-0 items-start gap-2">
+                  <DomainFavicon domain={row.domain} />
+                  <div className="flex min-w-0 max-w-[480px] flex-col">
+                    <a
+                      href={row.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="truncate text-sm font-medium text-foreground hover:underline"
+                      title={row.title || row.url}
+                    >
+                      {row.title || row.url}
+                    </a>
+                    <div className="flex items-center gap-1.5 pt-0.5">
+                      <span className="truncate text-[11px] text-muted-foreground">
+                        {row.domain}
+                      </span>
+                      <CategoryBadge category={row.category} />
+                    </div>
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell>
+                <PlatformsCell models={row.models} />
+              </TableCell>
+              <TableCell>
+                <UsageBar pct={row.usagePct} />
+              </TableCell>
+              <TableCell className="text-right text-xs tabular-nums">
+                {row.totalCitations}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {(rows.length > TOP_SOURCES_PREVIEW || showAll) && (
+        <ShowAllToggle
+          showAll={showAll}
+          total={rows.length}
+          label="URLs"
+          onToggle={() => setShowAll((prev) => !prev)}
+        />
+      )}
+    </div>
+  );
+}
+
+function TopSourcesCard({
+  sources,
+  sourceUrls,
+}: {
+  sources: PromptTopSource[];
+  sourceUrls: PromptTopSourceUrl[];
+}) {
   return (
     <Card>
       <CardHeader className="pb-3">
         <CardTitle className="text-sm font-medium">Top Sources</CardTitle>
         <p className="text-xs text-muted-foreground">
-          Domains AI platforms cite when answering this prompt.
+          Sources AI platforms cite when answering this prompt.
         </p>
       </CardHeader>
       <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[56px] text-xs">Rank</TableHead>
-              <TableHead className="text-xs">Domain</TableHead>
-              <TableHead className="text-xs">Platforms</TableHead>
-              <TableHead className="text-xs">Usage</TableHead>
-              <TableHead className="text-right text-xs">Citations</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {visible.map((row, i) => (
-              <TableRow key={row.domain}>
-                <TableCell className="text-xs text-muted-foreground tabular-nums">
-                  {i + 1}
-                </TableCell>
-                <TableCell>
-                  <div className="flex min-w-0 items-center gap-2">
-                    <DomainFavicon domain={row.domain} />
-                    <div className="flex min-w-0 flex-col">
-                      <span className="truncate text-sm font-medium">{row.domain}</span>
-                      <div className="flex items-center gap-1.5 pt-0.5">
-                        <CategoryBadge category={row.category} />
-                        <a
-                          href={`https://${row.domain}`}
-                          target="_blank"
-                          rel="noreferrer noopener"
-                          className="inline-flex items-center text-muted-foreground hover:text-foreground"
-                          aria-label={`Open ${row.domain} in a new tab`}
-                        >
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <PlatformsCell models={row.models} />
-                </TableCell>
-                <TableCell>
-                  <UsageBar pct={row.usagePct} />
-                </TableCell>
-                <TableCell className="text-right text-xs tabular-nums">
-                  {row.totalCitations}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-        {(hiddenCount > 0 || showAll) && (
-          <div className="pt-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 text-xs text-muted-foreground"
-              onClick={() => setShowAll((prev) => !prev)}
-            >
-              {showAll ? 'Show fewer' : `Show all ${sources.length} sources`}
-            </Button>
-          </div>
-        )}
+        <Tabs defaultValue="domains">
+          <TabsList>
+            <TabsTrigger value="domains">Domains ({sources.length})</TabsTrigger>
+            <TabsTrigger value="urls">URLs ({sourceUrls.length})</TabsTrigger>
+          </TabsList>
+          <TabsContent value="domains" keepMounted className="mt-4">
+            <TopSourceDomainsTable rows={sources} />
+          </TabsContent>
+          <TabsContent value="urls" keepMounted className="mt-4">
+            <TopSourceUrlsTable rows={sourceUrls} />
+          </TabsContent>
+        </Tabs>
       </CardContent>
     </Card>
   );
@@ -518,8 +630,6 @@ export default function PromptDetailPage() {
         />
       </div>
 
-      {data.topSources.length > 0 && <TopSourcesCard sources={data.topSources} />}
-
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-sm font-medium">Platform Results</CardTitle>
@@ -546,6 +656,10 @@ export default function PromptDetailPage() {
           )}
         </CardContent>
       </Card>
+
+      {data.topSources.length > 0 && (
+        <TopSourcesCard sources={data.topSources} sourceUrls={data.topSourceUrls} />
+      )}
     </div>
   );
 }

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -7,14 +7,37 @@ import {
   getPromptDetail,
   type PromptDetailData,
   type PromptResultWithText,
+  type PromptTopSource,
 } from '@/lib/actions/tracking';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, ChevronDown, Clock, Eye, MessageSquareText, Quote } from 'lucide-react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  ArrowLeft,
+  ChevronDown,
+  Clock,
+  ExternalLink,
+  Eye,
+  MessageSquareText,
+  Quote,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { AIProviderAvatar, resolveAIProvider } from '@/components/ai-provider-avatar';
+import {
+  CategoryBadge,
+  DomainFavicon,
+  PlatformsCell,
+  UsageBar,
+} from '@/components/citations/source-cells';
 import { groupByPlatform, type PlatformGroup } from './grouping';
 
 const PLATFORM_LABELS: Record<string, string> = {
@@ -141,6 +164,88 @@ function KpiCard({
           <p className="text-2xl font-bold tabular-nums">{value}</p>
           <p className="text-xs text-muted-foreground">{title}</p>
         </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+const TOP_SOURCES_PREVIEW = 10;
+
+function TopSourcesCard({ sources }: { sources: PromptTopSource[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? sources : sources.slice(0, TOP_SOURCES_PREVIEW);
+  const hiddenCount = sources.length - visible.length;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium">Top Sources</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Domains AI platforms cite when answering this prompt.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[56px] text-xs">Rank</TableHead>
+              <TableHead className="text-xs">Domain</TableHead>
+              <TableHead className="text-xs">Platforms</TableHead>
+              <TableHead className="text-xs">Usage</TableHead>
+              <TableHead className="text-right text-xs">Citations</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {visible.map((row, i) => (
+              <TableRow key={row.domain}>
+                <TableCell className="text-xs text-muted-foreground tabular-nums">
+                  {i + 1}
+                </TableCell>
+                <TableCell>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <DomainFavicon domain={row.domain} />
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate text-sm font-medium">{row.domain}</span>
+                      <div className="flex items-center gap-1.5 pt-0.5">
+                        <CategoryBadge category={row.category} />
+                        <a
+                          href={`https://${row.domain}`}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="inline-flex items-center text-muted-foreground hover:text-foreground"
+                          aria-label={`Open ${row.domain} in a new tab`}
+                        >
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <PlatformsCell models={row.models} />
+                </TableCell>
+                <TableCell>
+                  <UsageBar pct={row.usagePct} />
+                </TableCell>
+                <TableCell className="text-right text-xs tabular-nums">
+                  {row.totalCitations}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        {(hiddenCount > 0 || showAll) && (
+          <div className="pt-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-muted-foreground"
+              onClick={() => setShowAll((prev) => !prev)}
+            >
+              {showAll ? 'Show fewer' : `Show all ${sources.length} sources`}
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
   );
@@ -412,6 +517,8 @@ export default function PromptDetailPage() {
           icon={Quote}
         />
       </div>
+
+      {data.topSources.length > 0 && <TopSourcesCard sources={data.topSources} />}
 
       <Card>
         <CardHeader className="pb-3">

--- a/web/src/components/citations/source-cells.tsx
+++ b/web/src/components/citations/source-cells.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+/**
+ * Shared presentational cells for citation-source tables. Used by the
+ * citations page and the prompt detail Top Sources card so a domain renders
+ * identically (favicon, category badge, platform dots) everywhere.
+ */
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { Globe } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { getFaviconUrl } from '@/lib/favicon';
+import { SOURCE_CATEGORY_LABELS, type SourceCategory } from '@/lib/citations/classify';
+import {
+  AIProviderAvatar,
+  resolveAIProvider,
+  type AIProviderKey,
+} from '@/components/ai-provider-avatar';
+
+export const CATEGORY_BADGE_CLASSES: Record<SourceCategory, string> = {
+  you: 'border-indigo-500/30 bg-indigo-500/10 text-indigo-700 dark:text-indigo-300',
+  competitor: 'border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300',
+  editorial: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300',
+  forum: 'border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300',
+  social: 'border-purple-500/30 bg-purple-500/10 text-purple-700 dark:text-purple-300',
+  review: 'border-yellow-500/30 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300',
+  institutional: 'border-teal-500/30 bg-teal-500/10 text-teal-700 dark:text-teal-300',
+  other: 'border-slate-400/30 bg-slate-400/10 text-slate-700 dark:text-slate-300',
+};
+
+export function CategoryBadge({ category }: { category: SourceCategory }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'text-[10px] font-medium capitalize whitespace-nowrap',
+        CATEGORY_BADGE_CLASSES[category],
+      )}
+    >
+      {SOURCE_CATEGORY_LABELS[category]}
+    </Badge>
+  );
+}
+
+function ProviderDot({ provider }: { provider: AIProviderKey }) {
+  return <AIProviderAvatar provider={provider} />;
+}
+
+/**
+ * Collapse model identifiers down to their underlying provider so the column
+ * shows at most one dot per platform (ChatGPT, Claude, Gemini, ...). There
+ * are only 7 known providers, so the row width stays stable regardless of
+ * how many raw models fed into the domain.
+ */
+export function PlatformsCell({ models }: { models: string[] }) {
+  if (models.length === 0) {
+    return <span className="text-xs text-muted-foreground">—</span>;
+  }
+  const providers = Array.from(new Set(models.map((m) => resolveAIProvider(m)))).sort();
+  return (
+    <div className="flex items-center gap-1">
+      {providers.map((p) => (
+        <ProviderDot key={p} provider={p} />
+      ))}
+    </div>
+  );
+}
+
+export function UsageBar({ pct }: { pct: number }) {
+  const clamped = Math.min(100, Math.max(0, pct));
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-20 rounded-full bg-muted overflow-hidden">
+        <div className="h-full rounded-full bg-primary" style={{ width: `${clamped}%` }} />
+      </div>
+      <span className="text-xs tabular-nums text-foreground">{pct.toFixed(1)}%</span>
+    </div>
+  );
+}
+
+export function DomainFavicon({ domain }: { domain: string }) {
+  const [errored, setErrored] = useState(false);
+  if (errored) {
+    return (
+      <div className="flex h-6 w-6 items-center justify-center rounded border bg-muted">
+        <Globe className="h-3 w-3 text-muted-foreground" />
+      </div>
+    );
+  }
+  return (
+    <Image
+      src={getFaviconUrl(domain, 64)}
+      alt=""
+      width={20}
+      height={20}
+      unoptimized
+      className="h-5 w-5 rounded-sm border bg-white object-contain"
+      onError={() => setErrored(true)}
+    />
+  );
+}

--- a/web/src/components/table-pager.tsx
+++ b/web/src/components/table-pager.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+/**
+ * Client-side table pagination shared by the citations page and the prompt
+ * detail Top Sources card: a fixed page size, a state hook that resets on
+ * filter changes, and the Previous/Next footer row.
+ */
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export const PAGE_SIZE = 100;
+
+/**
+ * Per-table pagination state.
+ * resetKey — pass a JSON.stringify of the active filters so the pager
+ * automatically jumps back to page 0 whenever any filter changes.
+ */
+export function usePagination(totalRows: number, resetKey: unknown) {
+  const [page, setPage] = useState(0);
+
+  // Adjust-state-during-render pattern: jump back to page 0 when the key changes.
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (prevResetKey !== resetKey) {
+    setPrevResetKey(resetKey);
+    setPage(0);
+  }
+
+  const totalPages = Math.max(1, Math.ceil(totalRows / PAGE_SIZE));
+  const clampedPage = Math.min(page, totalPages - 1);
+
+  return {
+    page: clampedPage,
+    setPage,
+    totalPages,
+    start: clampedPage * PAGE_SIZE,
+    end: Math.min((clampedPage + 1) * PAGE_SIZE, totalRows),
+  };
+}
+
+export function TablePager({
+  page,
+  totalPages,
+  total,
+  start,
+  end,
+  onPage,
+}: {
+  page: number;
+  totalPages: number;
+  total: number;
+  start: number;
+  end: number;
+  onPage: (p: number) => void;
+}) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-between border-t px-4 py-3">
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {start + 1}–{end} of {total}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 px-3 text-xs"
+          disabled={page === 0}
+          onClick={() => onPage(page - 1)}
+        >
+          Previous
+        </Button>
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {page + 1} / {totalPages}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 px-3 text-xs"
+          disabled={page >= totalPages - 1}
+          onClick={() => onPage(page + 1)}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -87,6 +87,18 @@ export interface PromptTopSource {
   usagePct: number;
 }
 
+/** One URL row of the prompt detail "Top Sources" card — mirrors CitationUrlRow. */
+export interface PromptTopSourceUrl {
+  url: string;
+  domain: string;
+  category: SourceCategory;
+  title: string;
+  models: string[];
+  totalCitations: number;
+  resultsCiting: number;
+  usagePct: number;
+}
+
 export interface PromptDetailData {
   prompt: {
     id: string;
@@ -107,6 +119,7 @@ export interface PromptDetailData {
   };
   results: PromptResultWithText[];
   topSources: PromptTopSource[];
+  topSourceUrls: PromptTopSourceUrl[];
 }
 
 export interface InsightsSummary {
@@ -878,15 +891,22 @@ export async function getPromptDetail(
     resultsCiting: Set<string>;
     models: Set<string>;
   }
+  interface UrlAgg extends SourceAgg {
+    url: string;
+    title: string;
+  }
   const sourceMap = new Map<string, SourceAgg>();
+  const urlMap = new Map<string, UrlAgg>();
   for (const result of results) {
     const modelKey = result.modelUsed || result.platform || '';
     for (const cite of result.citations) {
       const host = extractHostname(cite.url);
       if (!host) continue;
+      const category = sourceMap.get(host)?.category ?? classifyDomain(host, classifyCtx);
+
       const agg = sourceMap.get(host) ?? {
         domain: host,
-        category: classifyDomain(host, classifyCtx),
+        category,
         totalCitations: 0,
         resultsCiting: new Set<string>(),
         models: new Set<string>(),
@@ -895,8 +915,36 @@ export async function getPromptDetail(
       agg.resultsCiting.add(result.id);
       if (modelKey) agg.models.add(modelKey);
       sourceMap.set(host, agg);
+
+      // URL aggregation (strip query/fragment and trailing slash for dedupe,
+      // same as getCitationsOverview).
+      let normalizedUrl = cite.url;
+      try {
+        const parsed = new URL(cite.url);
+        parsed.search = '';
+        parsed.hash = '';
+        normalizedUrl = parsed.toString().replace(/\/$/, '');
+      } catch {
+        // leave as-is
+      }
+      const urlAgg = urlMap.get(normalizedUrl) ?? {
+        url: normalizedUrl,
+        domain: host,
+        category,
+        title: cite.title || '',
+        totalCitations: 0,
+        resultsCiting: new Set<string>(),
+        models: new Set<string>(),
+      };
+      urlAgg.totalCitations += 1;
+      urlAgg.resultsCiting.add(result.id);
+      if (modelKey) urlAgg.models.add(modelKey);
+      if (!urlAgg.title && cite.title) urlAgg.title = cite.title;
+      urlMap.set(normalizedUrl, urlAgg);
     }
   }
+  const usagePctOf = (resultsCiting: number) =>
+    totalResults > 0 ? Math.round((resultsCiting / totalResults) * 1000) / 10 : 0;
   const topSources: PromptTopSource[] = Array.from(sourceMap.values())
     .map((agg) => ({
       domain: agg.domain,
@@ -904,10 +952,21 @@ export async function getPromptDetail(
       models: Array.from(agg.models).sort(),
       totalCitations: agg.totalCitations,
       resultsCiting: agg.resultsCiting.size,
-      usagePct:
-        totalResults > 0 ? Math.round((agg.resultsCiting.size / totalResults) * 1000) / 10 : 0,
+      usagePct: usagePctOf(agg.resultsCiting.size),
     }))
     .sort((a, b) => b.totalCitations - a.totalCitations || a.domain.localeCompare(b.domain));
+  const topSourceUrls: PromptTopSourceUrl[] = Array.from(urlMap.values())
+    .map((agg) => ({
+      url: agg.url,
+      domain: agg.domain,
+      category: agg.category,
+      title: agg.title,
+      models: Array.from(agg.models).sort(),
+      totalCitations: agg.totalCitations,
+      resultsCiting: agg.resultsCiting.size,
+      usagePct: usagePctOf(agg.resultsCiting.size),
+    }))
+    .sort((a, b) => b.totalCitations - a.totalCitations || a.url.localeCompare(b.url));
 
   return {
     prompt: {
@@ -929,6 +988,7 @@ export async function getPromptDetail(
     },
     results,
     topSources,
+    topSourceUrls,
   };
 }
 

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -12,6 +12,12 @@ import type {
   ObservedSearchQuery,
 } from '@/types';
 import { API_BASE_URL } from '@/config/api';
+import {
+  classifyDomain,
+  extractHostname,
+  normalizeDomain,
+  type SourceCategory,
+} from '@/lib/citations/classify';
 import { getTopicById } from '@/lib/actions/topic';
 import { getOrgPlan } from '@/lib/guards/plan-guard';
 import { getPromptVolumes } from '@/lib/actions/volumes';
@@ -71,6 +77,16 @@ export interface PromptResultWithText extends PromptResult {
   topicName?: string;
 }
 
+/** One row of the prompt detail "Top Sources" card — mirrors CitationDomainRow. */
+export interface PromptTopSource {
+  domain: string;
+  category: SourceCategory;
+  models: string[];
+  totalCitations: number;
+  resultsCiting: number;
+  usagePct: number;
+}
+
 export interface PromptDetailData {
   prompt: {
     id: string;
@@ -90,6 +106,7 @@ export interface PromptDetailData {
     lastCheckedAt: string | null;
   };
   results: PromptResultWithText[];
+  topSources: PromptTopSource[];
 }
 
 export interface InsightsSummary {
@@ -799,6 +816,20 @@ export async function getPromptDetail(
 
   const brandId = (promptSetData?.brand_id as string | undefined) ?? '';
 
+  // Brand + competitor domains feed classifyDomain, same as the citations page.
+  const [{ data: brandDomainRows }, { data: competitorRows }] = await Promise.all([
+    supabase.from('brand_domains').select('domain').eq('brand_id', brandId),
+    supabase.from('competitors').select('domain').eq('brand_id', brandId),
+  ]);
+  const classifyCtx = {
+    brandDomains: (brandDomainRows ?? [])
+      .map((r) => normalizeDomain((r as { domain: string }).domain))
+      .filter(Boolean),
+    competitorDomains: (competitorRows ?? [])
+      .map((r) => normalizeDomain((r as { domain: string }).domain))
+      .filter(Boolean),
+  };
+
   let topicName: string | undefined;
   if (prompt.topic_id) {
     const { data: topic } = await supabase
@@ -838,6 +869,46 @@ export async function getPromptDetail(
       ? Math.round(results.reduce((sum, row) => sum + row.visibilityScore, 0) / totalResults)
       : 0;
 
+  // Aggregate citations by domain — same shape and rounding as getCitationsOverview,
+  // but scoped to this prompt's already-loaded results.
+  interface SourceAgg {
+    domain: string;
+    category: SourceCategory;
+    totalCitations: number;
+    resultsCiting: Set<string>;
+    models: Set<string>;
+  }
+  const sourceMap = new Map<string, SourceAgg>();
+  for (const result of results) {
+    const modelKey = result.modelUsed || result.platform || '';
+    for (const cite of result.citations) {
+      const host = extractHostname(cite.url);
+      if (!host) continue;
+      const agg = sourceMap.get(host) ?? {
+        domain: host,
+        category: classifyDomain(host, classifyCtx),
+        totalCitations: 0,
+        resultsCiting: new Set<string>(),
+        models: new Set<string>(),
+      };
+      agg.totalCitations += 1;
+      agg.resultsCiting.add(result.id);
+      if (modelKey) agg.models.add(modelKey);
+      sourceMap.set(host, agg);
+    }
+  }
+  const topSources: PromptTopSource[] = Array.from(sourceMap.values())
+    .map((agg) => ({
+      domain: agg.domain,
+      category: agg.category,
+      models: Array.from(agg.models).sort(),
+      totalCitations: agg.totalCitations,
+      resultsCiting: agg.resultsCiting.size,
+      usagePct:
+        totalResults > 0 ? Math.round((agg.resultsCiting.size / totalResults) * 1000) / 10 : 0,
+    }))
+    .sort((a, b) => b.totalCitations - a.totalCitations || a.domain.localeCompare(b.domain));
+
   return {
     prompt: {
       id: prompt.id as string,
@@ -857,6 +928,7 @@ export async function getPromptDetail(
       lastCheckedAt: results[0]?.createdAt ?? null,
     },
     results,
+    topSources,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a **Top Sources** card to the prompt detail page (`/dashboard/prompts/[id]`), answering "which sources do AI platforms cite when answering this prompt?" — the per-prompt counterpart of the citations page.

- `getPromptDetail` now aggregates the prompt's already-loaded results by cited domain **and** by normalized URL (query/fragment and trailing slash stripped), using the same `classifyDomain` / `extractHostname` helpers, rounding, and row shape as `getCitationsOverview`, so both pages always agree on a domain's name, category, and usage. Adds two additive fields to `PromptDetailData`: `topSources` and `topSourceUrls`.
- The card sits at the end of the page, below Platform Results, with **Domains (N) / URLs (N)** tabs styled like the citations Sources card: favicon, category badge (you / competitor / editorial / ...), per-provider dots, usage bar, citation count, and the citations-style pager (100 rows per page, continuous rank). Hidden when the prompt has no citations.
- Shared extraction, no behavior change on the citations page:
  - `DomainFavicon`, `CategoryBadge`, `PlatformsCell`, `UsageBar` → `components/citations/source-cells.tsx`
  - `TablePager`, `usePagination`, `PAGE_SIZE` → `components/table-pager.tsx` (the reset-on-filter-change logic now uses the adjust-state-during-render pattern instead of a ref write, which the `react-hooks/refs` lint rule rejects)

## Related issue

—

## Type of change

- [x] `feat` — New feature

## How to test

1. Open a prompt detail page (`/dashboard/prompts/<id>`) for a prompt with tracking results.
2. Scroll below Platform Results — the Top Sources card shows the Domains tab: rank, favicon, domain, category badge, provider dots, usage %, citation count.
3. Switch to the URLs tab — rows show the page title linking to the URL, with domain + category badge beneath, deduped by normalized URL.
4. With more than 100 rows, the pager appears (Previous/Next, continuous rank across pages).
5. Cross-check a domain against `/dashboard/citations` (same period ≈ all time): category and look should match.
6. A prompt with no citations shows no card; the citations page itself is unchanged.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR