### PR TITLE
feat(topics): switch the Topics overview to prompt-level Visibility Rate

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
@@ -65,7 +65,9 @@ function visibilityTextColor(score: number) {
 const TOPIC_EXPORT_HEADERS = [
   'topic',
   'prompt_count',
-  'avg_visibility_score',
+  'visibility_rate',
+  'visible_prompts',
+  'active_prompts',
   'visibility_change',
   'total_mentions',
   'total_citations',
@@ -182,13 +184,13 @@ export default function TopicsPage() {
   }, [loadData]);
 
   const sortedByVisibility = useMemo(
-    () => [...topics].sort((a, b) => b.avgVisibilityScore - a.avgVisibilityScore),
+    () => [...topics].sort((a, b) => b.visibilityRate - a.visibilityRate),
     [topics],
   );
 
   const kpis = useMemo(() => {
     if (topics.length === 0) return null;
-    const withData = topics.filter((t) => t.avgVisibilityScore > 0);
+    const withData = topics.filter((t) => t.visibilityRate > 0);
     if (withData.length === 0) {
       return {
         total: topics.length,
@@ -197,8 +199,8 @@ export default function TopicsPage() {
         gainer: null as TopicOverviewRow | null,
       };
     }
-    const best = [...withData].sort((a, b) => b.avgVisibilityScore - a.avgVisibilityScore)[0];
-    const weakest = [...withData].sort((a, b) => a.avgVisibilityScore - b.avgVisibilityScore)[0];
+    const best = [...withData].sort((a, b) => b.visibilityRate - a.visibilityRate)[0];
+    const weakest = [...withData].sort((a, b) => a.visibilityRate - b.visibilityRate)[0];
     const withChange = topics.filter((t) => t.visibilityChange !== null);
     const gainer = withChange.length
       ? [...withChange].sort((a, b) => (b.visibilityChange ?? 0) - (a.visibilityChange ?? 0))[0]
@@ -220,7 +222,9 @@ export default function TopicsPage() {
     const rows = topics.map((t) => ({
       topic: t.name,
       prompt_count: t.promptCount,
-      avg_visibility_score: t.avgVisibilityScore,
+      visibility_rate: t.visibilityRate,
+      visible_prompts: t.visiblePrompts,
+      active_prompts: t.activePrompts,
       visibility_change: t.visibilityChange ?? '',
       total_mentions: t.totalMentions,
       total_citations: t.totalCitations,
@@ -316,14 +320,14 @@ export default function TopicsPage() {
           <KpiCard
             icon={Trophy}
             label="Best performer"
-            value={kpis.best ? `${kpis.best.avgVisibilityScore}%` : '—'}
+            value={kpis.best ? `${kpis.best.visibilityRate}%` : '—'}
             sub={kpis.best?.name ?? 'No data yet'}
             tone="positive"
           />
           <KpiCard
             icon={TrendingDown}
             label="Biggest gap"
-            value={kpis.weakest ? `${kpis.weakest.avgVisibilityScore}%` : '—'}
+            value={kpis.weakest ? `${kpis.weakest.visibilityRate}%` : '—'}
             sub={kpis.weakest?.name ?? 'No data yet'}
             tone="warning"
           />
@@ -332,7 +336,7 @@ export default function TopicsPage() {
             label="Top mover (7d)"
             value={
               kpis.gainer && kpis.gainer.visibilityChange !== null
-                ? `${kpis.gainer.visibilityChange > 0 ? '+' : ''}${kpis.gainer.visibilityChange}%`
+                ? `${kpis.gainer.visibilityChange > 0 ? '+' : ''}${kpis.gainer.visibilityChange} pts`
                 : '—'
             }
             sub={kpis.gainer?.name ?? 'Not enough data'}
@@ -400,24 +404,27 @@ export default function TopicsPage() {
                       {t.promptCount}
                     </TableCell>
                     <TableCell className="min-w-[160px]">
-                      {t.avgVisibilityScore > 0 ? (
-                        <div className="flex items-center gap-2">
+                      {t.activePrompts > 0 ? (
+                        <div
+                          className="flex items-center gap-2"
+                          title={`Appeared in ${t.visiblePrompts} of ${t.activePrompts} prompts`}
+                        >
                           <span
                             className={cn(
-                              'text-sm font-semibold tabular-nums w-8',
-                              visibilityTextColor(t.avgVisibilityScore),
+                              'text-sm font-semibold tabular-nums w-11',
+                              visibilityTextColor(t.visibilityRate),
                             )}
                           >
-                            {t.avgVisibilityScore}
+                            {t.visibilityRate}%
                           </span>
                           <div className="h-1.5 flex-1 max-w-[90px] rounded-full bg-muted overflow-hidden">
                             <div
                               className={cn(
                                 'h-full rounded-full',
-                                visibilityBarColor(t.avgVisibilityScore),
+                                visibilityBarColor(t.visibilityRate),
                               )}
                               style={{
-                                width: `${Math.min(100, t.avgVisibilityScore)}%`,
+                                width: `${Math.min(100, t.visibilityRate)}%`,
                               }}
                             />
                           </div>
@@ -453,7 +460,7 @@ export default function TopicsPage() {
                               ) : (
                                 <TrendingDown className="h-3 w-3 inline mr-0.5" />
                               )}
-                              {Math.abs(t.visibilityChange).toFixed(1)}%
+                              {Math.abs(t.visibilityChange).toFixed(1)} pts
                             </span>
                           )}
                           {t.visibilityChange === 0 && (

--- a/web/src/lib/actions/topic.ts
+++ b/web/src/lib/actions/topic.ts
@@ -118,7 +118,13 @@ export interface TopicOverviewRow {
   id: string;
   name: string;
   promptCount: number;
-  avgVisibilityScore: number;
+  /** % of the topic's prompts with results where the brand appeared at least once (#490 semantics). */
+  visibilityRate: number;
+  /** Distinct prompts with ≥1 mention/citation in the window (rate numerator). */
+  visiblePrompts: number;
+  /** Distinct prompts that produced results in the window (rate denominator). */
+  activePrompts: number;
+  /** Rate difference in points: (current 7d) − (previous 7d). */
   visibilityChange: number | null;
   totalMentions: number;
   totalCitations: number;
@@ -135,12 +141,14 @@ export interface TopicOverviewSummary {
 
 /**
  * Aggregate per-topic analytics for a brand.
- * Looks at last 30 days of prompt_results and derives visibility, mentions,
- * citations, SoV, top competitor and a short sparkline per topic.
- * Change is computed as (current 7d avg) - (previous 7d avg) to mirror
- * the logic used by Insights KPI cards. Like every analytical surface,
- * chatgpt-shopping rows are excluded (#155) — totals here must agree with
- * the Insights KPIs on the same 30d window (#464).
+ * Looks at last 30 days of prompt_results and derives visibility rate,
+ * mentions, citations, SoV, top competitor and a short sparkline per topic.
+ * Visibility uses the prompt-level rate from #490 (prompts appeared in ÷
+ * prompts with results), NOT the raw score average — the Topics page must
+ * read on the same scale as the Insights headline (#493). Change is
+ * (current 7d rate) − (previous 7d rate) in points. Like every analytical
+ * surface, chatgpt-shopping rows are excluded (#155) — totals here must
+ * agree with the Insights KPIs on the same 30d window (#464).
  */
 /**
  * PostgREST silently caps un-paginated selects at 1000 rows, which sampled the
@@ -204,27 +212,29 @@ export async function getTopicsOverview(brandId: string): Promise<TopicOverviewS
   for (const p of prompts) promptTopicMap.set(p.id, p.topic_id);
 
   interface Agg {
-    curScoreSum: number;
-    curCount: number;
-    prevScoreSum: number;
-    prevCount: number;
-    allScoreSum: number;
-    allCount: number;
+    // Prompt-level visibility (#490): distinct prompts with results vs
+    // distinct prompts where the brand appeared, per window.
+    allPrompts: Set<string>;
+    visiblePrompts: Set<string>;
+    curPrompts: Set<string>;
+    curVisiblePrompts: Set<string>;
+    prevPrompts: Set<string>;
+    prevVisiblePrompts: Set<string>;
     totalMentions: number;
     totalCitations: number;
     brandMentions: number;
     compMentions: number;
     lastRunAt: number;
     competitors: Map<string, { name: string; sov: number }>;
-    daily: Map<string, { sum: number; count: number }>;
+    daily: Map<string, { visible: number; count: number }>;
   }
   const emptyAgg = (): Agg => ({
-    curScoreSum: 0,
-    curCount: 0,
-    prevScoreSum: 0,
-    prevCount: 0,
-    allScoreSum: 0,
-    allCount: 0,
+    allPrompts: new Set(),
+    visiblePrompts: new Set(),
+    curPrompts: new Set(),
+    curVisiblePrompts: new Set(),
+    prevPrompts: new Set(),
+    prevVisiblePrompts: new Set(),
     totalMentions: 0,
     totalCitations: 0,
     brandMentions: 0,
@@ -260,28 +270,29 @@ export async function getTopicsOverview(brandId: string): Promise<TopicOverviewS
 
     const createdAt = row.created_at as string;
     const ts = new Date(createdAt).getTime();
-    const score = (row.visibility_score as number) ?? 0;
     const mentions = (row.mention_count as number) ?? 0;
     const citations = (row.citation_count as number) ?? 0;
+    // Same "appeared" rule as the Insights rate (#490).
+    const visible = mentions > 0 || citations > 0;
 
-    agg.allScoreSum += score;
-    agg.allCount += 1;
+    agg.allPrompts.add(promptId);
+    if (visible) agg.visiblePrompts.add(promptId);
     agg.totalMentions += mentions;
     agg.totalCitations += citations;
     agg.brandMentions += mentions;
     if (ts > agg.lastRunAt) agg.lastRunAt = ts;
 
     if (ts >= curFrom) {
-      agg.curScoreSum += score;
-      agg.curCount += 1;
+      agg.curPrompts.add(promptId);
+      if (visible) agg.curVisiblePrompts.add(promptId);
     } else if (ts >= prevFrom) {
-      agg.prevScoreSum += score;
-      agg.prevCount += 1;
+      agg.prevPrompts.add(promptId);
+      if (visible) agg.prevVisiblePrompts.add(promptId);
     }
 
     const day = createdAt.slice(0, 10);
-    const d = agg.daily.get(day) ?? { sum: 0, count: 0 };
-    d.sum += score;
+    const d = agg.daily.get(day) ?? { visible: 0, count: 0 };
+    if (visible) d.visible += 1;
     d.count += 1;
     agg.daily.set(day, d);
 
@@ -329,10 +340,16 @@ export async function getTopicsOverview(brandId: string): Promise<TopicOverviewS
     const agg = aggByTopic.get(t.id) ?? emptyAgg();
     const promptCount = promptCountByTopic.get(t.id) ?? 0;
 
-    const avg = agg.allCount > 0 ? Math.round(agg.allScoreSum / agg.allCount) : 0;
+    const rateOf = (visible: number, total: number) =>
+      total > 0 ? Math.round((visible / total) * 1000) / 10 : 0;
+    const visibilityRate = rateOf(agg.visiblePrompts.size, agg.allPrompts.size);
     const change =
-      agg.curCount > 0 && agg.prevCount > 0
-        ? Math.round((agg.curScoreSum / agg.curCount - agg.prevScoreSum / agg.prevCount) * 10) / 10
+      agg.curPrompts.size > 0 && agg.prevPrompts.size > 0
+        ? Math.round(
+            (rateOf(agg.curVisiblePrompts.size, agg.curPrompts.size) -
+              rateOf(agg.prevVisiblePrompts.size, agg.prevPrompts.size)) *
+              10,
+          ) / 10
         : null;
 
     const totalForSov = agg.brandMentions + agg.compMentions;
@@ -349,20 +366,26 @@ export async function getTopicsOverview(brandId: string): Promise<TopicOverviewS
       topCompetitor = best;
     }
 
+    // Daily visible-answer share (result-level) — a trend proxy for the
+    // prompt-level headline rate; sparklines have no axis, only shape matters.
     const sparklineDays: number[] = [];
     const todayMs = now;
     for (let i = 13; i >= 0; i--) {
       const d = new Date(todayMs - i * 24 * 60 * 60 * 1000);
       const key = d.toISOString().slice(0, 10);
       const bucket = agg.daily.get(key);
-      sparklineDays.push(bucket && bucket.count > 0 ? Math.round(bucket.sum / bucket.count) : 0);
+      sparklineDays.push(
+        bucket && bucket.count > 0 ? Math.round((bucket.visible / bucket.count) * 100) : 0,
+      );
     }
 
     return {
       id: t.id,
       name: t.name,
       promptCount,
-      avgVisibilityScore: avg,
+      visibilityRate,
+      visiblePrompts: agg.visiblePrompts.size,
+      activePrompts: agg.allPrompts.size,
       visibilityChange: change,
       totalMentions: agg.totalMentions,
       totalCitations: agg.totalCitations,


### PR DESCRIPTION
## Summary

Part of #493 — the Topics page must read on the same scale as the Insights headline. The overview's "Visibility (30d)" column previously averaged raw visibility scores across all results, which reads near zero for most brands (every answer without an appearance contributes 0). It now shows the #490 **Visibility Rate**: distinct prompts the brand appeared in ÷ distinct prompts that produced results, same "appeared" rule (≥1 mention or citation) and 30d window as Insights.

- **Leaderboard**: the column keeps its "Visibility (30d)" header but renders the rate as a percentage; the cell tooltip shows "Appeared in X of Y prompts"; sorting follows the rate.
- **KPI cards**: Best performer / Biggest gap show the rate; "Top mover (7d)" is now the rate difference in **pts** (current 7d − previous 7d), matching the Insights leaderboard's delta language — the trend column's inline delta uses pts too.
- **Sparkline**: tracks the daily visible-answer share instead of the daily score average.
- **CSV export**: `avg_visibility_score` → `visibility_rate`, plus new `visible_prompts` / `active_prompts` columns.
- Aggregation stays a paged scan with the same #155 shopping exclusion; the per-window prompt sets are collected in the same pass, so no extra queries.

Verified against production data: rates now spread meaningfully (e.g. 88.2% / 23.5% / 18.2% across topics) instead of clustering near zero.

The topic **detail** page reads from the Insights primitives via a separate action and still shows the score — that remains open under #493 (this PR does not close it).

## Related issue

Part of #493

## Type of change

- [x] `feat` — New feature

## How to test

1. Open `/dashboard/topics` for a brand with tracking history.
2. The Visibility (30d) column shows percentages that match the Insights headline logic — hover a cell to see "Appeared in X of Y prompts", and X/Y ÷ should equal the shown rate.
3. Rows sort by rate; Best performer / Biggest gap KPI values match the top/bottom non-zero rows.
4. Top mover shows a `± N pts` value when a topic has results in both 7d windows; the trend column's delta also reads in pts.
5. Export CSV → `visibility_rate`, `visible_prompts`, `active_prompts` columns are present and consistent with the table.
6. A topic with no results in the last 30 days shows an em dash.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR