### PR TITLE
refactor(web): centralize the duplicated model display-name maps

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -52,6 +52,7 @@ import {
 import { toCsv } from '@/lib/csv';
 import type { Topic } from '@/types';
 import { SOURCE_CATEGORY_LABELS, type SourceCategory } from '@/lib/citations/classify';
+import { MODEL_PROVIDER_LABELS, PLATFORM_LABELS } from '@/config/platform-labels';
 import {
   CategoryBadge,
   DomainFavicon,
@@ -107,53 +108,9 @@ const CATEGORY_COLORS: Record<SourceCategory, string> = {
   other: '#94a3b8',
 };
 
-// AI platform / model friendly names — kept in sync with the insights page.
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
-  'google-ai-mode': 'Google AI Mode',
-  'chatgpt-web': 'ChatGPT',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'perplexity-web': 'Perplexity',
-  'gemini-web': 'Google Gemini',
-};
-
-const MODEL_DISPLAY_NAME: Record<string, string> = {
-  'gpt-4o': 'GPT-4o',
-  'gpt-4o-mini': 'GPT-4o Mini',
-  'gpt-4.1': 'GPT-4.1',
-  'gpt-4.1-mini': 'GPT-4.1 Mini',
-  'gpt-4.1-nano': 'GPT-4.1 Nano',
-  'gpt-5-chat-latest': 'ChatGPT',
-  'claude-sonnet-5': 'Claude',
-  'claude-sonnet-4-6': 'Claude',
-  'claude-opus-4-6': 'Claude',
-  'claude-haiku-4-5': 'Claude',
-  'gemini-2.5-pro': 'Gemini 2.5 Pro',
-  'gemini-2.5-flash': 'Gemini 2.5 Flash',
-  'grok-3': 'Grok',
-  'grok-4-auto': 'Grok',
-  'chatgpt-web': 'ChatGPT',
-  'perplexity-web': 'Perplexity',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
-};
-
 function getPlatformDisplayLabel(slug: string): string {
   return (
-    MODEL_DISPLAY_NAME[slug] ??
+    MODEL_PROVIDER_LABELS[slug] ??
     PLATFORM_LABELS[slug] ??
     getAIProviderDisplayName(resolveAIProvider(slug))
   );

--- a/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
@@ -15,6 +15,7 @@ import {
   type HeadToHeadPromptRow,
 } from '@/lib/actions/tracking';
 import { getFaviconUrl } from '@/lib/favicon';
+import { MODEL_LABELS } from '@/config/platform-labels';
 import type { Competitor } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -64,38 +65,14 @@ import {
 
 // ─── Shared Visual Components (mirroring Insights) ───────────────────────────
 
-const MODEL_DISPLAY_NAME: Record<string, string> = {
-  'gpt-4o': 'GPT-4o',
-  'gpt-4o-mini': 'GPT-4o Mini',
-  'gpt-4.1': 'GPT-4.1',
-  'gpt-4.1-mini': 'GPT-4.1 Mini',
-  'gpt-4.1-nano': 'GPT-4.1 Nano',
-  'gpt-5-chat-latest': 'ChatGPT',
-  'claude-sonnet-5': 'Claude Sonnet 5',
-  'claude-sonnet-4-6': 'Claude Sonnet',
-  'claude-opus-4-6': 'Claude Opus',
-  'claude-haiku-4-5': 'Claude Haiku',
-  'gemini-2.5-pro': 'Gemini 2.5 Pro',
-  'gemini-2.5-flash': 'Gemini 2.5 Flash',
-  'grok-3': 'Grok',
-  'grok-4-auto': 'Grok',
-  'chatgpt-web': 'ChatGPT',
-  'perplexity-web': 'Perplexity',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
-};
-
 function getModelDisplayName(model: string, platform?: string): string {
   // In h2h data, platform is already resolved (e.g. "ChatGPT", "Perplexity")
   // so use it directly if available
   if (platform) {
-    const modelName = MODEL_DISPLAY_NAME[model];
+    const modelName = MODEL_LABELS[model];
     return modelName && modelName !== platform ? `${platform} · ${modelName}` : platform;
   }
-  return MODEL_DISPLAY_NAME[model] ?? model;
+  return MODEL_LABELS[model] ?? model;
 }
 
 function ModelBadge({ model, platform }: { model: string; platform?: string }) {

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -54,7 +54,7 @@ import {
   type BreakdownMetric,
 } from '@/lib/actions/tracking';
 import { getTopics } from '@/lib/actions/topic';
-import { PLATFORM_LABELS } from '@/config/platform-labels';
+import { MODEL_PROVIDER_LABELS, PLATFORM_LABELS } from '@/config/platform-labels';
 import { formatRegionDisplay } from '@/lib/region';
 import type { Topic } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -190,30 +190,6 @@ function InfoTip({ content }: { content: string }) {
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
-
-const MODEL_DISPLAY_NAME: Record<string, string> = {
-  'gpt-4o': 'GPT-4o',
-  'gpt-4o-mini': 'GPT-4o Mini',
-  'gpt-4.1': 'GPT-4.1',
-  'gpt-4.1-mini': 'GPT-4.1 Mini',
-  'gpt-4.1-nano': 'GPT-4.1 Nano',
-  'gpt-5-chat-latest': 'ChatGPT',
-  'claude-sonnet-5': 'Claude',
-  'claude-sonnet-4-6': 'Claude',
-  'claude-opus-4-6': 'Claude',
-  'claude-haiku-4-5': 'Claude',
-  'gemini-2.5-pro': 'Gemini 2.5 Pro',
-  'gemini-2.5-flash': 'Gemini 2.5 Flash',
-  'grok-3': 'Grok',
-  'grok-4-auto': 'Grok',
-  'chatgpt-web': 'ChatGPT',
-  'perplexity-web': 'Perplexity',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
-};
 
 // ─── Delta Badge ──────────────────────────────────────────────────────────────
 
@@ -559,7 +535,7 @@ function FilterBar({
                 if (!value || value === '__all__') return 'All Platforms';
                 const firstSlug = String(value).split(',')[0];
                 return (
-                  MODEL_DISPLAY_NAME[firstSlug] ??
+                  MODEL_PROVIDER_LABELS[firstSlug] ??
                   PLATFORM_LABELS[firstSlug] ??
                   getAIProviderDisplayName(resolveAIProvider(firstSlug))
                 );
@@ -573,7 +549,7 @@ function FilterBar({
               const firstSlug = m.split(',')[0];
               return (
                 <SelectItem key={m} value={m}>
-                  {MODEL_DISPLAY_NAME[firstSlug] ??
+                  {MODEL_PROVIDER_LABELS[firstSlug] ??
                     PLATFORM_LABELS[firstSlug] ??
                     getAIProviderDisplayName(resolveAIProvider(firstSlug))}
                 </SelectItem>
@@ -955,7 +931,7 @@ export default function InsightsPage() {
         for (const slug of insights.filterOptions.models) {
           if (slugToLabel.has(slug)) continue;
           const label =
-            MODEL_DISPLAY_NAME[slug] ??
+            MODEL_PROVIDER_LABELS[slug] ??
             PLATFORM_LABELS[slug] ??
             getAIProviderDisplayName(resolveAIProvider(slug));
           slugToLabel.set(slug, label);

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -43,50 +43,8 @@ import {
   UsageBar,
 } from '@/components/citations/source-cells';
 import { TablePager, usePagination } from '@/components/table-pager';
+import { MODEL_PROVIDER_LABELS, PLATFORM_LABELS } from '@/config/platform-labels';
 import { groupByPlatform, type PlatformGroup } from './grouping';
-
-const PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  gemini: 'Gemini',
-  perplexity: 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  copilot: 'Copilot',
-  'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
-  'google-ai-mode': 'Google AI Mode',
-  'chatgpt-web': 'ChatGPT',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'perplexity-web': 'Perplexity',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
-};
-
-const MODEL_DISPLAY_NAME: Record<string, string> = {
-  'gpt-4o': 'GPT-4o',
-  'gpt-4o-mini': 'GPT-4o Mini',
-  'gpt-4.1': 'GPT-4.1',
-  'gpt-4.1-mini': 'GPT-4.1 Mini',
-  'gpt-4.1-nano': 'GPT-4.1 Nano',
-  'gpt-5-chat-latest': 'ChatGPT',
-  'claude-sonnet-5': 'Claude',
-  'claude-sonnet-4-6': 'Claude',
-  'claude-opus-4-6': 'Claude',
-  'claude-haiku-4-5': 'Claude',
-  'gemini-2.5-pro': 'Gemini 2.5 Pro',
-  'gemini-2.5-flash': 'Gemini 2.5 Flash',
-  'grok-3': 'Grok',
-  'grok-4-auto': 'Grok',
-  'chatgpt-web': 'ChatGPT',
-  'perplexity-web': 'Perplexity',
-  'google-aio': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'copilot-web': 'Microsoft Copilot',
-  'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
-};
 
 // ─── Date range (kept in sync with the insights page filter bar) ─────────────
 
@@ -177,7 +135,7 @@ function DateRangeBar({
 }
 
 function getModelDisplayName(model?: string, platform?: string): string {
-  if (model && MODEL_DISPLAY_NAME[model]) return MODEL_DISPLAY_NAME[model];
+  if (model && MODEL_PROVIDER_LABELS[model]) return MODEL_PROVIDER_LABELS[model];
   if (platform && PLATFORM_LABELS[platform]) return PLATFORM_LABELS[platform];
   return model ?? platform ?? 'Unknown';
 }

--- a/web/src/config/platform-labels.ts
+++ b/web/src/config/platform-labels.ts
@@ -39,3 +39,48 @@ export const PLATFORM_LABELS: Record<string, string> = {
   'gemini-2.5-pro': 'Gemini 2.5 Pro',
   'gemini-2.5-flash': 'Gemini 2.5 Flash',
 };
+
+/**
+ * Model slug → provider-level display name ("claude-sonnet-5" → "Claude").
+ * Used where rows are grouped per engine and the exact model variant is
+ * noise: insights, citations, prompt detail (#435 — was copy-pasted on each
+ * page). Look up with a fallback chain, e.g.
+ * `MODEL_PROVIDER_LABELS[slug] ?? PLATFORM_LABELS[slug] ?? slug`.
+ */
+export const MODEL_PROVIDER_LABELS: Record<string, string> = {
+  'gpt-4o': 'GPT-4o',
+  'gpt-4o-mini': 'GPT-4o Mini',
+  'gpt-4.1': 'GPT-4.1',
+  'gpt-4.1-mini': 'GPT-4.1 Mini',
+  'gpt-4.1-nano': 'GPT-4.1 Nano',
+  'gpt-5-chat-latest': 'ChatGPT',
+  'claude-sonnet-5': 'Claude',
+  'claude-sonnet-4-6': 'Claude',
+  'claude-opus-4-6': 'Claude',
+  'claude-haiku-4-5': 'Claude',
+  'gemini-2.5-pro': 'Gemini 2.5 Pro',
+  'gemini-2.5-flash': 'Gemini 2.5 Flash',
+  'grok-3': 'Grok',
+  'grok-4-auto': 'Grok',
+  'chatgpt-web': 'ChatGPT',
+  'perplexity-web': 'Perplexity',
+  'google-aio': 'Google AI Overview',
+  'google-aimode': 'Google AI Mode',
+  'copilot-web': 'Microsoft Copilot',
+  'grok-web': 'Grok',
+  'gemini-web': 'Gemini',
+};
+
+/**
+ * Model slug → model-level display name ("claude-sonnet-5" → "Claude Sonnet
+ * 5"). Used where the model variant matters, e.g. the competitors page's
+ * head-to-head badges. Only the Claude entries differ from the
+ * provider-level map today; keep the two in sync when adding slugs.
+ */
+export const MODEL_LABELS: Record<string, string> = {
+  ...MODEL_PROVIDER_LABELS,
+  'claude-sonnet-5': 'Claude Sonnet 5',
+  'claude-sonnet-4-6': 'Claude Sonnet',
+  'claude-opus-4-6': 'Claude Opus',
+  'claude-haiku-4-5': 'Claude Haiku',
+};


### PR DESCRIPTION
## Summary

Closes #435.

The `MODEL_DISPLAY_NAME` map was copy-pasted on four dashboard pages (insights, citations, prompt detail, competitors — the last with model-level Claude labels), so adding a new model slug meant touching every copy and a missed one produced inconsistent labels.

- Two maps now live next to the canonical `PLATFORM_LABELS` in `web/src/config/platform-labels.ts`:
  - **`MODEL_PROVIDER_LABELS`** — provider-level (`claude-sonnet-5` → "Claude"), used by insights, citations, and prompt detail.
  - **`MODEL_LABELS`** — model-level (`claude-sonnet-5` → "Claude Sonnet 5"), spread from the provider map with the four Claude overrides, used by the competitors head-to-head badges.
- All four local `MODEL_DISPLAY_NAME` copies and the citations page's byte-identical `PLATFORM_LABELS` duplicate are deleted; a repo-wide search for `MODEL_DISPLAY_NAME` returns nothing. Net −87 lines.
- **Rendered labels are unchanged.** One nuance, documented in the commit: the prompt-detail page's local `PLATFORM_LABELS` said "Gemini" for `gemini-web` where the canonical map says "Google Gemini" — but that branch is unreachable there (its `ModelBadge` always passes a model slug via `modelUsed ?? platform`, so the model map wins before the platform map is consulted).

Out of scope: `MODEL_TO_PROVIDER` in `tracking.ts` is a provider-routing map, not a display-name map — the issue's acceptance criteria only cover the `MODEL_DISPLAY_NAME` copies.

## Related issue

Closes #435

## Type of change

- [x] `refactor` — Code change that neither fixes a bug nor adds a feature

## How to test

1. `yarn typecheck`, `yarn lint`, `yarn test` from `web/` — all pass.
2. Visual spot-check with seed data (`npm run dev`):
   - **Insights** → AI Model filter dropdown shows "ChatGPT / Claude / Gemini 2.5 Pro …" as before.
   - **Citations** → platform labels in the header select and tables unchanged.
   - **Prompt detail** → platform group badges unchanged ("ChatGPT", "Claude", …).
   - **Competitors** → head-to-head badges keep model-level labels ("Claude Sonnet 5", "Claude Opus").
3. `grep -r MODEL_DISPLAY_NAME web/src` → no matches.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR