### PR TITLE
fix(onboarding): clarify trial billing and add Stripe trust line on the plan step

### DIFF
--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -1521,7 +1521,8 @@ export default function OnboardingPage() {
         <div className="mb-8 text-center">
           <h1 className="text-2xl font-bold tracking-tight">Choose your plan</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Start with a 14-day free trial. Cancel anytime.
+            Start your 14-day free trial — your card won&apos;t be charged until the trial ends.
+            Cancel anytime in Settings → Billing.
           </p>
         </div>
 
@@ -1636,6 +1637,9 @@ export default function OnboardingPage() {
             Contact sales
           </a>{' '}
           for Enterprise pricing.
+        </p>
+        <p className="mt-2 text-center text-xs text-muted-foreground">
+          Secure payments powered by Stripe.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Conversion-copy improvements on the onboarding plan step (step 6, cloud only):

- The subtitle now answers the card-entry anxiety directly: **"Start your 14-day free trial — your card won't be charged until the trial ends. Cancel anytime in Settings → Billing."** The no-charge claim is accurate — the checkout session sets `trial_period_days: 14` — and pointing at Settings → Billing signals the cancel path isn't hidden. Deliberately phrased *"cancel anytime"* rather than *"before your trial ends"*, so the copy can't be read as if cancelling is only possible during the trial.
- Adds a small **"Secure payments powered by Stripe."** line under the Enterprise contact note. The card form itself lives on Stripe's hosted checkout (where Stripe branding is visible), so this line's job is easing the click on **Start Free Trial**, not the card entry.

## Related issue

—

## Type of change

- [x] `fix` — Bug fix

## How to test

1. Run onboarding on a cloud build up to the plan step.
2. The header subtitle reads the new two-sentence copy; below the plan cards, the Enterprise line is followed by the Stripe line in the same muted style.
3. No layout shift on mobile — both lines wrap within the existing max-width container.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR