### PR TITLE
feat(web): add head-to-head link to insights leaderboard

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -77,6 +77,7 @@ import {
   PieChart,
   Users,
   StopCircle,
+  ArrowRight,
   ArrowUpRight,
   Download,
   Layers,
@@ -1424,7 +1425,16 @@ export default function InsightsPage() {
 
                   <Card className="lg:col-span-2">
                     <CardHeader className="pb-2">
-                      <CardTitle className="text-sm font-medium">Leaderboard</CardTitle>
+                      <div className="flex items-center justify-between gap-3">
+                        <CardTitle className="text-sm font-medium">Leaderboard</CardTitle>
+                        <Link
+                          href="/dashboard/competitors"
+                          className="flex shrink-0 items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                        >
+                          Head-to-Head Comparison
+                          <ArrowRight className="h-3 w-3" />
+                        </Link>
+                      </div>
                     </CardHeader>
                     <CardContent>
                       <CompetitorLeaderboard data={competitorData.brands} />

--- a/web/src/components/layout/mobile-nav.tsx
+++ b/web/src/components/layout/mobile-nav.tsx
@@ -48,7 +48,6 @@ export function MobileNav() {
       'AI Traffic Analytics': t('traffic'),
       Prompts: t('prompts'),
       'Content Optimization': t('content'),
-      Competitors: t('competitors'),
       Citations: t('citations'),
       Reports: t('reports'),
       Settings: t('settings'),

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -61,7 +61,6 @@ export function Sidebar() {
     Topics: () => t('topics'),
     'Content Optimization': () => t('content'),
     'Site Audit': () => t('audit'),
-    Competitors: () => t('competitors'),
     Citations: () => t('citations'),
     Shopping: () => t('shopping'),
     Reports: () => t('reports'),

--- a/web/src/config/dashboard.ts
+++ b/web/src/config/dashboard.ts
@@ -9,7 +9,6 @@ import {
   ShoppingBag,
   Sparkles,
   Tag,
-  Users,
 } from 'lucide-react';
 import type { Feature } from '@/config/plans';
 
@@ -90,12 +89,6 @@ export const dashboardNav: NavGroup[] = [
         href: '/dashboard/traffic',
         icon: LineChart,
         requiredFeature: 'advanced_analytics',
-      },
-      {
-        title: 'Competitors',
-        href: '/dashboard/competitors',
-        icon: Users,
-        requiredFeature: 'competitor_tracking',
       },
     ],
   },


### PR DESCRIPTION
## Summary

Moves the Competitors entry point from the navigation to the Insights leaderboard.

- Removes Competitors from the desktop sidebar and mobile navigation
- Adds a locale-aware “Head-to-Head Comparison” link to the Leaderboard card
- Keeps the existing `/dashboard/competitors` route and plan gate unchanged

## Related issue

Closes #504

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [ ] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

## Testing

- All 43 tests pass across 10 test files
- All changed files pass Prettier
- The repository-wide formatting check reports pre-existing CRLF formatting differences in this Windows checkout