### PR TITLE
feat(prompts): prompt workflow — work status, notes, target URLs with cited tracking

### DIFF
--- a/server/src/lib/cloro-result-handler.js
+++ b/server/src/lib/cloro-result-handler.js
@@ -17,6 +17,7 @@ import supabaseAdmin from '../config/supabase.js';
 import { analyzeSentimentAI } from './ai-tracker.js';
 import { parseResponse, countBrandMentions } from './response-parser.js';
 import { normalizeShoppingCards, matchCardBrand } from './shopping-cards.js';
+import { updateTargetUrlStats } from './target-url-stats.js';
 import { logger } from './logger.js';
 
 /**
@@ -74,6 +75,9 @@ export async function handleScraperResult({
     logger.error({ err: error }, '[cloro-result] failed to insert result');
     throw error;
   }
+
+  // Best-effort: mark target URLs cited by this answer (00032).
+  await updateTargetUrlStats(promptId, aiResponse.citations, new Date().toISOString());
 
   // Best-effort normalization of any shopping cards on this result.
   // Failures here must not abort the result insert — the raw cards are

--- a/server/src/lib/target-url-stats.js
+++ b/server/src/lib/target-url-stats.js
@@ -1,0 +1,61 @@
+import supabaseAdmin from '../config/supabase.js';
+import { logger } from './logger.js';
+
+/**
+ * Closed-loop citation tracking for prompt target URLs (00032).
+ *
+ * Normalization must stay in sync with the web-side matcher in
+ * web/src/lib/actions/prompt-workflow.ts: protocol, www., query, fragment
+ * and trailing slashes are ignored, so "https://www.foo.com/blog/x?a=1" and
+ * "http://foo.com/blog/x/" count as the same page.
+ */
+export function normalizeUrlForMatch(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const u = new URL(raw.trim());
+    const host = u.hostname.toLowerCase().replace(/^www\./, '');
+    const path = u.pathname.replace(/\/+$/, '');
+    return `${host}${path}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update cited stats for a prompt's target URLs against one freshly saved
+ * result's citations. Best-effort by design — a stats failure must never
+ * fail the result insert; callers should not await-and-throw.
+ */
+export async function updateTargetUrlStats(promptId, citations, observedAtIso) {
+  try {
+    if (!Array.isArray(citations) || citations.length === 0) return;
+
+    const { data: targets } = await supabaseAdmin
+      .from('prompt_target_urls')
+      .select('id, url, cited_count, first_cited_at')
+      .eq('prompt_id', promptId);
+    if (!targets || targets.length === 0) return;
+
+    const citedKeys = new Set(citations.map((c) => normalizeUrlForMatch(c?.url)).filter(Boolean));
+    if (citedKeys.size === 0) return;
+
+    const observedAt = observedAtIso || new Date().toISOString();
+    for (const target of targets) {
+      const key = normalizeUrlForMatch(target.url);
+      if (!key || !citedKeys.has(key)) continue;
+      const { error } = await supabaseAdmin
+        .from('prompt_target_urls')
+        .update({
+          cited_count: (target.cited_count || 0) + 1,
+          first_cited_at: target.first_cited_at ?? observedAt,
+          last_cited_at: observedAt,
+        })
+        .eq('id', target.id);
+      if (error) {
+        logger.warn({ err: error, targetId: target.id }, '[target-urls] stats update failed');
+      }
+    }
+  } catch (err) {
+    logger.warn({ err, promptId }, '[target-urls] stats pass failed');
+  }
+}

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -10,6 +10,7 @@ import supabaseAdmin from '../config/supabase.js';
 import { hasFeature, getPlan, isCloud } from '../config/plans.js';
 import { applyPlanOverrides } from '../lib/plan-guard.js';
 import { generateContentOpportunities } from '../lib/opportunity-generator.js';
+import { updateTargetUrlStats } from '../lib/target-url-stats.js';
 import logger from '../lib/logger.js';
 
 function resolveModelPlatform(model) {
@@ -140,6 +141,8 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
       throw error;
     }
     insertedCount++;
+    // Best-effort: mark target URLs cited by this answer (00032).
+    await updateTargetUrlStats(row.prompt_id, row.citations, new Date().toISOString());
   }
 
   // 6. Phase 1: Collect & run all scraper (platform) tasks first

--- a/supabase/migrations/00031_prompt_workflow.sql
+++ b/supabase/migrations/00031_prompt_workflow.sql
@@ -1,0 +1,109 @@
+-- 00031_prompt_workflow.sql
+-- Prompt workflow: per-prompt work status, a notes thread, and multiple
+-- target URLs. Turns the prompts list into a workspace — "which prompts have
+-- we acted on, which still need work, and which URLs are we pushing to get
+-- cited?" Target URLs are structured (not free text inside notes) so a later
+-- iteration can auto-check them against the prompt's citations.
+
+ALTER TABLE "public"."prompts"
+  ADD COLUMN IF NOT EXISTS "work_status" "text",
+  ADD CONSTRAINT "prompts_work_status_check" CHECK (
+    "work_status" IS NULL OR "work_status" = ANY (ARRAY['todo'::"text", 'in_progress'::"text", 'done'::"text"])
+  );
+
+CREATE TABLE IF NOT EXISTS "public"."prompt_notes" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "prompt_id" "uuid" NOT NULL,
+    "author_id" "uuid",
+    "body" "text" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "prompt_notes_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "prompt_notes_prompt_id_fkey" FOREIGN KEY ("prompt_id")
+        REFERENCES "public"."prompts"("id") ON DELETE CASCADE,
+    CONSTRAINT "prompt_notes_author_id_fkey" FOREIGN KEY ("author_id")
+        REFERENCES "public"."profiles"("id") ON DELETE SET NULL
+);
+
+ALTER TABLE "public"."prompt_notes" OWNER TO "postgres";
+
+CREATE INDEX IF NOT EXISTS "idx_prompt_notes_prompt"
+    ON "public"."prompt_notes" ("prompt_id", "created_at");
+
+CREATE TABLE IF NOT EXISTS "public"."prompt_target_urls" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "prompt_id" "uuid" NOT NULL,
+    "url" "text" NOT NULL,
+    "label" "text",
+    "added_by" "uuid",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "prompt_target_urls_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "prompt_target_urls_prompt_id_fkey" FOREIGN KEY ("prompt_id")
+        REFERENCES "public"."prompts"("id") ON DELETE CASCADE,
+    CONSTRAINT "prompt_target_urls_added_by_fkey" FOREIGN KEY ("added_by")
+        REFERENCES "public"."profiles"("id") ON DELETE SET NULL,
+    CONSTRAINT "prompt_target_urls_unique" UNIQUE ("prompt_id", "url")
+);
+
+ALTER TABLE "public"."prompt_target_urls" OWNER TO "postgres";
+
+CREATE INDEX IF NOT EXISTS "idx_prompt_target_urls_prompt"
+    ON "public"."prompt_target_urls" ("prompt_id", "created_at");
+
+ALTER TABLE "public"."prompt_notes" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."prompt_target_urls" ENABLE ROW LEVEL SECURITY;
+
+-- Same org scoping as prompts: members read, admin/manager write.
+CREATE POLICY "prompt_notes: member select" ON "public"."prompt_notes"
+    FOR SELECT USING (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE ("p"."id" = "auth"."uid"()))));
+
+CREATE POLICY "prompt_notes: admin/manager insert" ON "public"."prompt_notes"
+    FOR INSERT WITH CHECK (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE (("p"."id" = "auth"."uid"()) AND ("p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role"]))))));
+
+CREATE POLICY "prompt_notes: admin/manager delete" ON "public"."prompt_notes"
+    FOR DELETE USING (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE (("p"."id" = "auth"."uid"()) AND ("p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role"]))))));
+
+CREATE POLICY "prompt_target_urls: member select" ON "public"."prompt_target_urls"
+    FOR SELECT USING (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE ("p"."id" = "auth"."uid"()))));
+
+CREATE POLICY "prompt_target_urls: admin/manager insert" ON "public"."prompt_target_urls"
+    FOR INSERT WITH CHECK (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE (("p"."id" = "auth"."uid"()) AND ("p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role"]))))));
+
+CREATE POLICY "prompt_target_urls: admin/manager delete" ON "public"."prompt_target_urls"
+    FOR DELETE USING (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE (("p"."id" = "auth"."uid"()) AND ("p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role"]))))));
+
+GRANT ALL ON TABLE "public"."prompt_notes" TO "anon";
+GRANT ALL ON TABLE "public"."prompt_notes" TO "authenticated";
+GRANT ALL ON TABLE "public"."prompt_notes" TO "service_role";
+GRANT ALL ON TABLE "public"."prompt_target_urls" TO "anon";
+GRANT ALL ON TABLE "public"."prompt_target_urls" TO "authenticated";
+GRANT ALL ON TABLE "public"."prompt_target_urls" TO "service_role";

--- a/supabase/migrations/00032_target_url_cited_stats.sql
+++ b/supabase/migrations/00032_target_url_cited_stats.sql
@@ -1,0 +1,11 @@
+-- 00032_target_url_cited_stats.sql
+-- v2 of the prompt workflow (00031): closed-loop citation tracking for
+-- target URLs. Stats are denormalized onto the row so list surfaces read
+-- them without scanning result citations: the tracking pipeline updates
+-- them as new results arrive, and the web action backfills once when a URL
+-- is added.
+
+ALTER TABLE "public"."prompt_target_urls"
+  ADD COLUMN IF NOT EXISTS "cited_count" integer DEFAULT 0 NOT NULL,
+  ADD COLUMN IF NOT EXISTS "first_cited_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "last_cited_at" timestamp with time zone;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3762,3 +3762,18 @@ GRANT ALL ON TABLE "public"."prompt_target_urls" TO "anon";
 GRANT ALL ON TABLE "public"."prompt_target_urls" TO "authenticated";
 GRANT ALL ON TABLE "public"."prompt_target_urls" TO "service_role";
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00032_target_url_cited_stats.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- 00032_target_url_cited_stats.sql
+-- v2 of the prompt workflow (00031): closed-loop citation tracking for
+-- target URLs. Stats are denormalized onto the row so list surfaces read
+-- them without scanning result citations: the tracking pipeline updates
+-- them as new results arrive, and the web action backfills once when a URL
+-- is added.
+
+ALTER TABLE "public"."prompt_target_urls"
+  ADD COLUMN IF NOT EXISTS "cited_count" integer DEFAULT 0 NOT NULL,
+  ADD COLUMN IF NOT EXISTS "first_cited_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "last_cited_at" timestamp with time zone;
+

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3649,3 +3649,116 @@ GRANT ALL ON TABLE "public"."topic_suggestions" TO "anon";
 GRANT ALL ON TABLE "public"."topic_suggestions" TO "authenticated";
 GRANT ALL ON TABLE "public"."topic_suggestions" TO "service_role";
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00031_prompt_workflow.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- 00031_prompt_workflow.sql
+-- Prompt workflow: per-prompt work status, a notes thread, and multiple
+-- target URLs. Turns the prompts list into a workspace — "which prompts have
+-- we acted on, which still need work, and which URLs are we pushing to get
+-- cited?" Target URLs are structured (not free text inside notes) so a later
+-- iteration can auto-check them against the prompt's citations.
+
+ALTER TABLE "public"."prompts"
+  ADD COLUMN IF NOT EXISTS "work_status" "text",
+  ADD CONSTRAINT "prompts_work_status_check" CHECK (
+    "work_status" IS NULL OR "work_status" = ANY (ARRAY['todo'::"text", 'in_progress'::"text", 'done'::"text"])
+  );
+
+CREATE TABLE IF NOT EXISTS "public"."prompt_notes" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "prompt_id" "uuid" NOT NULL,
+    "author_id" "uuid",
+    "body" "text" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "prompt_notes_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "prompt_notes_prompt_id_fkey" FOREIGN KEY ("prompt_id")
+        REFERENCES "public"."prompts"("id") ON DELETE CASCADE,
+    CONSTRAINT "prompt_notes_author_id_fkey" FOREIGN KEY ("author_id")
+        REFERENCES "public"."profiles"("id") ON DELETE SET NULL
+);
+
+ALTER TABLE "public"."prompt_notes" OWNER TO "postgres";
+
+CREATE INDEX IF NOT EXISTS "idx_prompt_notes_prompt"
+    ON "public"."prompt_notes" ("prompt_id", "created_at");
+
+CREATE TABLE IF NOT EXISTS "public"."prompt_target_urls" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "prompt_id" "uuid" NOT NULL,
+    "url" "text" NOT NULL,
+    "label" "text",
+    "added_by" "uuid",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "prompt_target_urls_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "prompt_target_urls_prompt_id_fkey" FOREIGN KEY ("prompt_id")
+        REFERENCES "public"."prompts"("id") ON DELETE CASCADE,
+    CONSTRAINT "prompt_target_urls_added_by_fkey" FOREIGN KEY ("added_by")
+        REFERENCES "public"."profiles"("id") ON DELETE SET NULL,
+    CONSTRAINT "prompt_target_urls_unique" UNIQUE ("prompt_id", "url")
+);
+
+ALTER TABLE "public"."prompt_target_urls" OWNER TO "postgres";
+
+CREATE INDEX IF NOT EXISTS "idx_prompt_target_urls_prompt"
+    ON "public"."prompt_target_urls" ("prompt_id", "created_at");
+
+ALTER TABLE "public"."prompt_notes" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."prompt_target_urls" ENABLE ROW LEVEL SECURITY;
+
+-- Same org scoping as prompts: members read, admin/manager write.
+CREATE POLICY "prompt_notes: member select" ON "public"."prompt_notes"
+    FOR SELECT USING (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE ("p"."id" = "auth"."uid"()))));
+
+CREATE POLICY "prompt_notes: admin/manager insert" ON "public"."prompt_notes"
+    FOR INSERT WITH CHECK (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE (("p"."id" = "auth"."uid"()) AND ("p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role"]))))));
+
+CREATE POLICY "prompt_notes: admin/manager delete" ON "public"."prompt_notes"
+    FOR DELETE USING (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE (("p"."id" = "auth"."uid"()) AND ("p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role"]))))));
+
+CREATE POLICY "prompt_target_urls: member select" ON "public"."prompt_target_urls"
+    FOR SELECT USING (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE ("p"."id" = "auth"."uid"()))));
+
+CREATE POLICY "prompt_target_urls: admin/manager insert" ON "public"."prompt_target_urls"
+    FOR INSERT WITH CHECK (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE (("p"."id" = "auth"."uid"()) AND ("p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role"]))))));
+
+CREATE POLICY "prompt_target_urls: admin/manager delete" ON "public"."prompt_target_urls"
+    FOR DELETE USING (("prompt_id" IN ( SELECT "pr"."id"
+        FROM ((("public"."prompts" "pr"
+          JOIN "public"."prompt_sets" "ps" ON (("ps"."id" = "pr"."prompt_set_id")))
+          JOIN "public"."brands" "b" ON (("b"."id" = "ps"."brand_id")))
+          JOIN "public"."profiles" "p" ON (("p"."organization_id" = "b"."organization_id")))
+        WHERE (("p"."id" = "auth"."uid"()) AND ("p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role"]))))));
+
+GRANT ALL ON TABLE "public"."prompt_notes" TO "anon";
+GRANT ALL ON TABLE "public"."prompt_notes" TO "authenticated";
+GRANT ALL ON TABLE "public"."prompt_notes" TO "service_role";
+GRANT ALL ON TABLE "public"."prompt_target_urls" TO "anon";
+GRANT ALL ON TABLE "public"."prompt_target_urls" TO "authenticated";
+GRANT ALL ON TABLE "public"."prompt_target_urls" TO "service_role";
+

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/_workflow-cards.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/_workflow-cards.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+/**
+ * Prompt workflow section on the prompt detail page: a notes thread and the
+ * target URLs list. The work-status picker lives in the page header (next to
+ * the Active badge); these two cards carry the collaboration surface.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { ExternalLink, Link2, Loader2, MessageSquare, Plus, Send, X } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  addPromptNote,
+  addPromptTargetUrl,
+  deletePromptNote,
+  deletePromptTargetUrl,
+  type PromptNote,
+  type PromptTargetUrl,
+} from '@/lib/actions/prompt-workflow';
+
+function formatNoteDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export function NotesCard({
+  promptId,
+  notes,
+  onNotesChange,
+  canManage,
+}: {
+  promptId: string;
+  notes: PromptNote[];
+  onNotesChange: (notes: PromptNote[]) => void;
+  canManage: boolean;
+}) {
+  const [draft, setDraft] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleAdd = useCallback(async () => {
+    const body = draft.trim();
+    if (!body) return;
+    setSaving(true);
+    try {
+      const note = await addPromptNote(promptId, body);
+      onNotesChange([note, ...notes]);
+      setDraft('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add note');
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, promptId, notes, onNotesChange]);
+
+  const handleDelete = (note: PromptNote) => {
+    onNotesChange(notes.filter((n) => n.id !== note.id));
+    deletePromptNote(note.id).catch(() => {
+      onNotesChange(notes);
+      toast.error('Failed to delete note');
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <MessageSquare className="h-4 w-4" />
+          Notes
+          {notes.length > 0 && (
+            <Badge variant="secondary" className="text-xs tabular-nums">
+              {notes.length}
+            </Badge>
+          )}
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Keep track of the work behind this prompt — what was published, planned or decided.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {canManage && (
+          <div className="space-y-2">
+            <Textarea
+              placeholder="e.g. Published a comparison blog post targeting this prompt…"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={2}
+              className="text-sm"
+            />
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                className="gap-2"
+                onClick={handleAdd}
+                disabled={saving || !draft.trim()}
+              >
+                {saving ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Send className="h-3.5 w-3.5" />
+                )}
+                Add note
+              </Button>
+            </div>
+          </div>
+        )}
+        {notes.length === 0 ? (
+          <p className="py-4 text-center text-xs text-muted-foreground">
+            No notes yet{canManage ? ' — add the first one above.' : '.'}
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {notes.map((note) => (
+              <li key={note.id} className="group rounded-lg border bg-muted/20 p-3">
+                <p className="whitespace-pre-wrap text-sm leading-relaxed">{note.body}</p>
+                <div className="mt-1.5 flex items-center justify-between gap-2">
+                  <p className="text-[11px] text-muted-foreground">
+                    {note.authorName ?? 'Unknown'} · {formatNoteDate(note.createdAt)}
+                  </p>
+                  {canManage && (
+                    <button
+                      type="button"
+                      className="text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+                      onClick={() => handleDelete(note)}
+                      aria-label="Delete note"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function TargetUrlsCard({
+  promptId,
+  urls,
+  onUrlsChange,
+  canManage,
+}: {
+  promptId: string;
+  urls: PromptTargetUrl[];
+  onUrlsChange: (urls: PromptTargetUrl[]) => void;
+  canManage: boolean;
+}) {
+  const [draft, setDraft] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleAdd = useCallback(async () => {
+    const value = draft.trim();
+    if (!value) return;
+    setSaving(true);
+    try {
+      const added = await addPromptTargetUrl(promptId, value);
+      onUrlsChange([...urls, added]);
+      setDraft('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add URL');
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, promptId, urls, onUrlsChange]);
+
+  const handleDelete = (target: PromptTargetUrl) => {
+    onUrlsChange(urls.filter((u) => u.id !== target.id));
+    deletePromptTargetUrl(target.id).catch(() => {
+      onUrlsChange(urls);
+      toast.error('Failed to remove URL');
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <Link2 className="h-4 w-4" />
+          Target URLs
+          {urls.length > 0 && (
+            <Badge variant="secondary" className="text-xs tabular-nums">
+              {urls.length}
+            </Badge>
+          )}
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Pages you want AI answers to cite for this prompt.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {canManage && (
+          <div className="flex items-center gap-2">
+            <Input
+              placeholder="https://example.com/blog/comparison-post"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAdd();
+                }
+              }}
+              className="h-8 text-xs"
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 gap-1.5"
+              onClick={handleAdd}
+              disabled={saving || !draft.trim()}
+            >
+              {saving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Plus className="h-3.5 w-3.5" />
+              )}
+              Add
+            </Button>
+          </div>
+        )}
+        {urls.length === 0 ? (
+          <p className="py-4 text-center text-xs text-muted-foreground">
+            No target URLs yet{canManage ? ' — add the pages you want cited.' : '.'}
+          </p>
+        ) : (
+          <ul className="space-y-1.5">
+            {urls.map((target) => (
+              <li
+                key={target.id}
+                className="group flex items-center gap-2 rounded-lg border bg-muted/20 px-3 py-2"
+              >
+                <a
+                  href={target.url}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex min-w-0 flex-1 items-center gap-1.5 text-sm hover:underline"
+                  title={target.url}
+                >
+                  <span className="truncate">{target.url.replace(/^https?:\/\//, '')}</span>
+                  <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
+                </a>
+                {canManage && (
+                  <button
+                    type="button"
+                    className="text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+                    onClick={() => handleDelete(target)}
+                    aria-label="Remove target URL"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/_workflow-cards.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/_workflow-cards.tsx
@@ -6,13 +6,23 @@
  * the Active badge); these two cards carry the collaboration surface.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { ExternalLink, Link2, Loader2, MessageSquare, Plus, Send, X } from 'lucide-react';
+import {
+  CheckCircle2,
+  ExternalLink,
+  Link2,
+  Loader2,
+  MessageSquare,
+  Plus,
+  Send,
+  X,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import {
   addPromptNote,
@@ -22,6 +32,52 @@ import {
   type PromptNote,
   type PromptTargetUrl,
 } from '@/lib/actions/prompt-workflow';
+
+function formatShortDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Cited-status badge for a target URL. Distinguishes "cited after we started
+ * targeting it" (the win) from "was already cited before targeting".
+ */
+function CitedBadge({ target }: { target: PromptTargetUrl }) {
+  if (target.citedCount === 0) {
+    return (
+      <Badge
+        variant="outline"
+        className="shrink-0 border-dashed border-muted-foreground/30 text-[10px] text-muted-foreground whitespace-nowrap"
+      >
+        Not cited yet
+      </Badge>
+    );
+  }
+  const alreadyCited =
+    target.firstCitedAt !== null && new Date(target.firstCitedAt) < new Date(target.createdAt);
+  const tooltip = [
+    `Cited in ${target.citedCount} answer${target.citedCount !== 1 ? 's' : ''}`,
+    target.firstCitedAt ? `first ${formatShortDate(target.firstCitedAt)}` : null,
+    target.lastCitedAt ? `last ${formatShortDate(target.lastCitedAt)}` : null,
+    alreadyCited ? 'was already cited before targeting' : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return (
+    <Badge
+      variant="outline"
+      title={tooltip}
+      className={cn(
+        'shrink-0 gap-1 text-[10px] whitespace-nowrap',
+        'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+      )}
+    >
+      <CheckCircle2 className="h-3 w-3" />
+      Cited ×{target.citedCount}
+    </Badge>
+  );
+}
 
 function formatNoteDate(iso: string): string {
   const date = new Date(iso);
@@ -198,7 +254,8 @@ export function TargetUrlsCard({
           )}
         </CardTitle>
         <p className="text-xs text-muted-foreground">
-          Pages you want AI answers to cite for this prompt.
+          Pages you want AI answers to cite for this prompt. Citation status updates automatically
+          as new tracking results arrive.
         </p>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -253,6 +310,7 @@ export function TargetUrlsCard({
                   <span className="truncate">{target.url.replace(/^https?:\/\//, '')}</span>
                   <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
                 </a>
+                <CitedBadge target={target} />
                 {canManage && (
                   <button
                     type="button"

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -35,7 +35,18 @@ import {
   Quote,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
+import { useUserRole } from '@/hooks/use-user-role';
 import { AIProviderAvatar, resolveAIProvider } from '@/components/ai-provider-avatar';
+import { WorkStatusBadge } from '@/components/prompts/work-status';
+import {
+  getPromptWorkflow,
+  setPromptWorkStatus,
+  type PromptNote,
+  type PromptTargetUrl,
+  type PromptWorkStatus,
+} from '@/lib/actions/prompt-workflow';
+import { NotesCard, TargetUrlsCard } from './_workflow-cards';
 import {
   CategoryBadge,
   DomainFavicon,
@@ -533,6 +544,8 @@ export default function PromptDetailPage() {
   const router = useRouter();
   const promptId = params.id as string;
 
+  const { canManage } = useUserRole();
+
   const [data, setData] = useState<PromptDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
@@ -540,6 +553,35 @@ export default function PromptDetailPage() {
   const [datePreset, setDatePreset] = useState<DatePreset>('30d');
   const [customFrom, setCustomFrom] = useState('');
   const [customTo, setCustomTo] = useState('');
+  const [workStatus, setWorkStatus] = useState<PromptWorkStatus | null>(null);
+  const [notes, setNotes] = useState<PromptNote[]>([]);
+  const [targetUrls, setTargetUrls] = useState<PromptTargetUrl[]>([]);
+
+  // Workflow data is independent of the date window — load it once per
+  // prompt, outside the main load cycle, so date changes don't refetch it.
+  useEffect(() => {
+    let cancelled = false;
+    getPromptWorkflow(promptId)
+      .then((wf) => {
+        if (cancelled) return;
+        setWorkStatus(wf.workStatus);
+        setNotes(wf.notes);
+        setTargetUrls(wf.targetUrls);
+      })
+      .catch((err) => console.error('Failed to load prompt workflow:', err));
+    return () => {
+      cancelled = true;
+    };
+  }, [promptId]);
+
+  const handleStatusChange = (status: PromptWorkStatus | null) => {
+    const previous = workStatus;
+    setWorkStatus(status);
+    setPromptWorkStatus(promptId, status).catch(() => {
+      setWorkStatus(previous);
+      toast.error('Failed to update status');
+    });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -646,6 +688,10 @@ export default function PromptDetailPage() {
               Last run: {formatTimestamp(data.summary.lastCheckedAt)}
             </Badge>
           )}
+          <WorkStatusBadge
+            status={workStatus}
+            onChange={canManage ? handleStatusChange : undefined}
+          />
         </div>
       </div>
 
@@ -733,6 +779,23 @@ export default function PromptDetailPage() {
             <TopSourcesCard sources={data.topSources} sourceUrls={data.topSourceUrls} />
           )}
         </div>
+      </div>
+
+      {/* Workflow — outside the refetch overlay: notes and target URLs are
+          date-window independent. */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <NotesCard
+          promptId={promptId}
+          notes={notes}
+          onNotesChange={setNotes}
+          canManage={canManage}
+        />
+        <TargetUrlsCard
+          promptId={promptId}
+          urls={targetUrls}
+          onUrlsChange={setTargetUrls}
+          canManage={canManage}
+        />
       </div>
     </div>
   );

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -1632,6 +1632,14 @@ export default function PromptsPage() {
 
 // ─── All Prompts Tab ──────────────────────────────────────────────────────────
 
+const WORK_FILTER_LABELS: Record<string, string> = {
+  all: 'All work',
+  todo: 'To do',
+  in_progress: 'In progress',
+  done: 'Done',
+  none: 'No status',
+};
+
 function AllPromptsTab({
   loading,
   prompts,
@@ -1794,7 +1802,9 @@ function AllPromptsTab({
               onValueChange={(v) => setWorkFilter((v as typeof workFilter) ?? 'all')}
             >
               <SelectTrigger className="h-8 w-32 text-xs">
-                <SelectValue placeholder="All work" />
+                <SelectValue placeholder="All work">
+                  {(value) => WORK_FILTER_LABELS[(value as string) ?? 'all'] ?? 'All work'}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All work</SelectItem>

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -43,6 +43,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { CompetitionBars } from '@/components/ui/competition-bars';
+import { WorkStatusBadge } from '@/components/prompts/work-status';
+import { setPromptWorkStatus, type PromptWorkStatus } from '@/lib/actions/prompt-workflow';
 import {
   TrendingUp,
   Search,
@@ -1650,7 +1652,33 @@ function AllPromptsTab({
   onEditPrompt?: (prompt: Prompt) => void;
 }) {
   const [search, setSearch] = useState('');
+  const [workFilter, setWorkFilter] = useState<'all' | 'none' | PromptWorkStatus>('all');
+  // Optimistic per-row status overrides — the prompts prop belongs to the
+  // parent's load cycle; a full reload for a one-column change would flash
+  // the whole table.
+  const [statusOverrides, setStatusOverrides] = useState<Map<string, PromptWorkStatus | null>>(
+    new Map(),
+  );
   const searchParams = useSearchParams();
+
+  const statusOf = useCallback(
+    (p: Prompt) => (statusOverrides.has(p.id) ? statusOverrides.get(p.id)! : p.workStatus),
+    [statusOverrides],
+  );
+
+  const handleStatusChange = useCallback(
+    (prompt: Prompt, status: PromptWorkStatus | null) => {
+      const previous = statusOverrides.has(prompt.id)
+        ? statusOverrides.get(prompt.id)!
+        : prompt.workStatus;
+      setStatusOverrides((prev) => new Map(prev).set(prompt.id, status));
+      setPromptWorkStatus(prompt.id, status).catch(() => {
+        setStatusOverrides((prev) => new Map(prev).set(prompt.id, previous));
+        toast.error('Failed to update status');
+      });
+    },
+    [statusOverrides],
+  );
 
   const rawSort = searchParams.get('sort');
   const activeSort: AllPromptsSortKey | null = isAllPromptsSortKey(rawSort) ? rawSort : null;
@@ -1681,6 +1709,11 @@ function AllPromptsTab({
         (p) => p.text.toLowerCase().includes(q) || (p.category ?? '').toLowerCase().includes(q),
       );
     }
+    if (workFilter !== 'all') {
+      list = list.filter((p) =>
+        workFilter === 'none' ? statusOf(p) === null : statusOf(p) === workFilter,
+      );
+    }
 
     if (!activeSort) {
       // Default ordering: newest first.
@@ -1703,7 +1736,7 @@ function AllPromptsTab({
     };
 
     return list.sort((a, b) => compareNullsLast(valueOf(a), valueOf(b), dir));
-  }, [prompts, search, activeSort, dir, visibility, volumeByPromptId]);
+  }, [prompts, search, workFilter, statusOf, activeSort, dir, visibility, volumeByPromptId]);
 
   if (loading) {
     return (
@@ -1755,14 +1788,31 @@ function AllPromptsTab({
                 : 'Read-only overview of every tracked prompt for this brand'}
             </p>
           </div>
-          <div className="relative w-60">
-            <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
-            <Input
-              placeholder="Search prompts…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-8 h-8 text-xs"
-            />
+          <div className="flex items-center gap-2">
+            <Select
+              value={workFilter}
+              onValueChange={(v) => setWorkFilter((v as typeof workFilter) ?? 'all')}
+            >
+              <SelectTrigger className="h-8 w-32 text-xs">
+                <SelectValue placeholder="All work" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All work</SelectItem>
+                <SelectItem value="todo">To do</SelectItem>
+                <SelectItem value="in_progress">In progress</SelectItem>
+                <SelectItem value="done">Done</SelectItem>
+                <SelectItem value="none">No status</SelectItem>
+              </SelectContent>
+            </Select>
+            <div className="relative w-60">
+              <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+              <Input
+                placeholder="Search prompts…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-8 h-8 text-xs"
+              />
+            </div>
           </div>
         </div>
       </CardHeader>
@@ -1773,6 +1823,12 @@ function AllPromptsTab({
               <TableHead className="pl-6">Prompt</TableHead>
               <TableHead>Topic</TableHead>
               <TableHead className="text-center">Status</TableHead>
+              <ColHead
+                className="text-center"
+                tooltip="Your workflow state for this prompt — has content work been done for it yet?"
+              >
+                Work
+              </ColHead>
               <SortableHead
                 className="text-right"
                 tooltip="Average brand visibility score in AI answers for this prompt over the last 30 days."
@@ -1853,6 +1909,12 @@ function AllPromptsTab({
                     >
                       {p.isActive ? 'Active' : 'Paused'}
                     </Badge>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <WorkStatusBadge
+                      status={statusOf(p)}
+                      onChange={onEditPrompt ? (s) => handleStatusChange(p, s) : undefined}
+                    />
                   </TableCell>
                   <TableCell className="text-right">
                     {vis ? (

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -1921,10 +1921,25 @@ function AllPromptsTab({
                     </Badge>
                   </TableCell>
                   <TableCell className="text-center">
-                    <WorkStatusBadge
-                      status={statusOf(p)}
-                      onChange={onEditPrompt ? (s) => handleStatusChange(p, s) : undefined}
-                    />
+                    <div className="inline-flex flex-col items-center gap-0.5">
+                      <WorkStatusBadge
+                        status={statusOf(p)}
+                        onChange={onEditPrompt ? (s) => handleStatusChange(p, s) : undefined}
+                      />
+                      {p.targetUrlCount > 0 && (
+                        <span
+                          className={cn(
+                            'text-[10px] tabular-nums',
+                            p.citedUrlCount > 0
+                              ? 'text-emerald-600 dark:text-emerald-400'
+                              : 'text-muted-foreground',
+                          )}
+                          title={`${p.citedUrlCount} of ${p.targetUrlCount} target URLs cited in AI answers`}
+                        >
+                          {p.citedUrlCount}/{p.targetUrlCount} cited
+                        </span>
+                      )}
+                    </div>
                   </TableCell>
                   <TableCell className="text-right">
                     {vis ? (

--- a/web/src/components/prompts/work-status.tsx
+++ b/web/src/components/prompts/work-status.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+/**
+ * Prompt workflow status badge + picker. One visual definition shared by the
+ * All Prompts table and the prompt detail page so a status always renders
+ * identically.
+ */
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Badge } from '@/components/ui/badge';
+import { Check, ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { PromptWorkStatus } from '@/lib/actions/prompt-workflow';
+
+export const WORK_STATUS_META: Record<PromptWorkStatus, { label: string; className: string }> = {
+  todo: {
+    label: 'To do',
+    className: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  },
+  in_progress: {
+    label: 'In progress',
+    className: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
+  },
+  done: {
+    label: 'Done',
+    className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  },
+};
+
+export const WORK_STATUS_ORDER: PromptWorkStatus[] = ['todo', 'in_progress', 'done'];
+
+function badgeClasses(status: PromptWorkStatus | null) {
+  return status
+    ? WORK_STATUS_META[status].className
+    : 'border-dashed border-muted-foreground/30 text-muted-foreground';
+}
+
+/**
+ * Read-only badge, or a dropdown picker when `onChange` is provided
+ * (admin/manager). `null` renders a dashed "Set status" affordance in edit
+ * mode and an em dash in read mode.
+ */
+export function WorkStatusBadge({
+  status,
+  onChange,
+}: {
+  status: PromptWorkStatus | null;
+  onChange?: (status: PromptWorkStatus | null) => void;
+}) {
+  if (!onChange) {
+    if (!status) return <span className="text-xs text-muted-foreground">—</span>;
+    return (
+      <Badge variant="outline" className={cn('text-xs whitespace-nowrap', badgeClasses(status))}>
+        {WORK_STATUS_META[status].label}
+      </Badge>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className={cn(
+          'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold whitespace-nowrap transition-colors',
+          badgeClasses(status),
+        )}
+        aria-label="Set work status"
+      >
+        {status ? WORK_STATUS_META[status].label : 'Set status'}
+        <ChevronDown className="h-3 w-3" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {WORK_STATUS_ORDER.map((s) => (
+          <DropdownMenuItem key={s} className="gap-2 text-xs" onClick={() => onChange(s)}>
+            <Check className={cn('h-3.5 w-3.5', status === s ? 'opacity-100' : 'opacity-0')} />
+            {WORK_STATUS_META[s].label}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuItem className="gap-2 text-xs" onClick={() => onChange(null)}>
+          <Check className={cn('h-3.5 w-3.5', status === null ? 'opacity-100' : 'opacity-0')} />
+          No status
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web/src/lib/actions/prompt-workflow.ts
+++ b/web/src/lib/actions/prompt-workflow.ts
@@ -25,12 +25,29 @@ export interface PromptTargetUrl {
   url: string;
   label: string | null;
   createdAt: string;
+  /** Answers for this prompt that cited the URL (backfill + live tracking). */
+  citedCount: number;
+  firstCitedAt: string | null;
+  lastCitedAt: string | null;
 }
 
 export interface PromptWorkflowData {
   workStatus: PromptWorkStatus | null;
   notes: PromptNote[];
   targetUrls: PromptTargetUrl[];
+}
+
+function mapTargetUrlRow(r: Record<string, unknown>): PromptTargetUrl {
+  return {
+    id: r.id as string,
+    promptId: r.prompt_id as string,
+    url: r.url as string,
+    label: (r.label as string | null) ?? null,
+    createdAt: r.created_at as string,
+    citedCount: (r.cited_count as number) ?? 0,
+    firstCitedAt: (r.first_cited_at as string | null) ?? null,
+    lastCitedAt: (r.last_cited_at as string | null) ?? null,
+  };
 }
 
 export async function getPromptWorkflow(promptId: string): Promise<PromptWorkflowData> {
@@ -45,7 +62,7 @@ export async function getPromptWorkflow(promptId: string): Promise<PromptWorkflo
       .order('created_at', { ascending: false }),
     supabase
       .from('prompt_target_urls')
-      .select('id, prompt_id, url, label, created_at')
+      .select('id, prompt_id, url, label, created_at, cited_count, first_cited_at, last_cited_at')
       .eq('prompt_id', promptId)
       .order('created_at', { ascending: true }),
   ]);
@@ -65,16 +82,9 @@ export async function getPromptWorkflow(promptId: string): Promise<PromptWorkflo
     };
   });
 
-  const targetUrls: PromptTargetUrl[] = (urlsRes.data ?? []).map((row) => {
-    const r = row as unknown as Record<string, unknown>;
-    return {
-      id: r.id as string,
-      promptId: r.prompt_id as string,
-      url: r.url as string,
-      label: (r.label as string | null) ?? null,
-      createdAt: r.created_at as string,
-    };
-  });
+  const targetUrls: PromptTargetUrl[] = (urlsRes.data ?? []).map((row) =>
+    mapTargetUrlRow(row as unknown as Record<string, unknown>),
+  );
 
   return {
     workStatus: (promptRes.data?.work_status as PromptWorkStatus | null) ?? null,
@@ -140,6 +150,88 @@ function normalizeTargetUrl(raw: string): string {
   return parsed.toString();
 }
 
+/**
+ * Match key for citation comparison — must stay in sync with the server-side
+ * matcher in server/src/lib/target-url-stats.js: protocol, www., query,
+ * fragment and trailing slashes are ignored.
+ */
+function urlMatchKey(raw: string): string | null {
+  try {
+    const u = new URL(raw.trim());
+    const host = u.hostname.toLowerCase().replace(/^www\./, '');
+    const path = u.pathname.replace(/\/+$/, '');
+    return `${host}${path}`;
+  } catch {
+    return null;
+  }
+}
+
+const BACKFILL_PAGE_SIZE = 1000;
+const BACKFILL_MAX_ROWS = 5000;
+
+/**
+ * One-time backfill when a target URL is added: scan the prompt's existing
+ * results so citations that predate the URL still count. Live tracking keeps
+ * the stats current from here on (server/src/lib/target-url-stats.js).
+ * Best-effort — a scan failure leaves the row at zero, which live tracking
+ * corrects over time.
+ */
+async function backfillCitedStats(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  promptId: string,
+  targetId: string,
+  targetUrl: string,
+): Promise<{ citedCount: number; firstCitedAt: string | null; lastCitedAt: string | null }> {
+  const key = urlMatchKey(targetUrl);
+  const empty = { citedCount: 0, firstCitedAt: null, lastCitedAt: null };
+  if (!key) return empty;
+
+  let citedCount = 0;
+  let firstCitedAt: string | null = null;
+  let lastCitedAt: string | null = null;
+
+  try {
+    for (let from = 0; from < BACKFILL_MAX_ROWS; from += BACKFILL_PAGE_SIZE) {
+      const { data, error } = await supabase
+        .from('prompt_results')
+        .select('citations, created_at')
+        .eq('prompt_id', promptId)
+        .neq('platform', 'chatgpt-shopping')
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true })
+        .range(from, from + BACKFILL_PAGE_SIZE - 1);
+      if (error) throw new Error(error.message);
+
+      const batch = (data ?? []) as { citations: { url?: string }[] | null; created_at: string }[];
+      for (const row of batch) {
+        const cites = Array.isArray(row.citations) ? row.citations : [];
+        if (cites.some((c) => urlMatchKey(c?.url ?? '') === key)) {
+          citedCount += 1;
+          if (!firstCitedAt) firstCitedAt = row.created_at;
+          lastCitedAt = row.created_at;
+        }
+      }
+      if (batch.length < BACKFILL_PAGE_SIZE) break;
+    }
+
+    if (citedCount > 0) {
+      await supabase
+        .from('prompt_target_urls')
+        .update({
+          cited_count: citedCount,
+          first_cited_at: firstCitedAt,
+          last_cited_at: lastCitedAt,
+        })
+        .eq('id', targetId);
+    }
+  } catch (err) {
+    console.error('[prompt-workflow] cited backfill failed:', err);
+    return empty;
+  }
+
+  return { citedCount, firstCitedAt, lastCitedAt };
+}
+
 export async function addPromptTargetUrl(
   promptId: string,
   url: string,
@@ -165,21 +257,16 @@ export async function addPromptTargetUrl(
       label: label?.trim() || null,
       added_by: user?.id ?? null,
     })
-    .select('id, prompt_id, url, label, created_at')
+    .select('id, prompt_id, url, label, created_at, cited_count, first_cited_at, last_cited_at')
     .single();
   if (error) {
     if (error.code === '23505') throw new Error('This URL is already targeted for this prompt');
     throw new Error(error.message);
   }
 
-  const r = data as unknown as Record<string, unknown>;
-  return {
-    id: r.id as string,
-    promptId: r.prompt_id as string,
-    url: r.url as string,
-    label: (r.label as string | null) ?? null,
-    createdAt: r.created_at as string,
-  };
+  const mapped = mapTargetUrlRow(data as unknown as Record<string, unknown>);
+  const stats = await backfillCitedStats(supabase, promptId, mapped.id, mapped.url);
+  return { ...mapped, ...stats };
 }
 
 export async function deletePromptTargetUrl(id: string): Promise<void> {

--- a/web/src/lib/actions/prompt-workflow.ts
+++ b/web/src/lib/actions/prompt-workflow.ts
@@ -1,0 +1,189 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * Prompt workflow (v1): per-prompt work status, a notes thread, and target
+ * URLs. All access control lives in RLS (00031): members read, admin/manager
+ * write, everything scoped to the caller's org through
+ * prompts → prompt_sets → brands.
+ */
+
+export type PromptWorkStatus = 'todo' | 'in_progress' | 'done';
+
+export interface PromptNote {
+  id: string;
+  promptId: string;
+  body: string;
+  authorName: string | null;
+  createdAt: string;
+}
+
+export interface PromptTargetUrl {
+  id: string;
+  promptId: string;
+  url: string;
+  label: string | null;
+  createdAt: string;
+}
+
+export interface PromptWorkflowData {
+  workStatus: PromptWorkStatus | null;
+  notes: PromptNote[];
+  targetUrls: PromptTargetUrl[];
+}
+
+export async function getPromptWorkflow(promptId: string): Promise<PromptWorkflowData> {
+  const supabase = await createClient();
+
+  const [promptRes, notesRes, urlsRes] = await Promise.all([
+    supabase.from('prompts').select('work_status').eq('id', promptId).maybeSingle(),
+    supabase
+      .from('prompt_notes')
+      .select('id, prompt_id, body, created_at, profiles(full_name)')
+      .eq('prompt_id', promptId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('prompt_target_urls')
+      .select('id, prompt_id, url, label, created_at')
+      .eq('prompt_id', promptId)
+      .order('created_at', { ascending: true }),
+  ]);
+
+  if (notesRes.error) throw new Error(notesRes.error.message);
+  if (urlsRes.error) throw new Error(urlsRes.error.message);
+
+  const notes: PromptNote[] = (notesRes.data ?? []).map((row) => {
+    const r = row as unknown as Record<string, unknown>;
+    const profile = r.profiles as { full_name: string | null } | null;
+    return {
+      id: r.id as string,
+      promptId: r.prompt_id as string,
+      body: r.body as string,
+      authorName: profile?.full_name ?? null,
+      createdAt: r.created_at as string,
+    };
+  });
+
+  const targetUrls: PromptTargetUrl[] = (urlsRes.data ?? []).map((row) => {
+    const r = row as unknown as Record<string, unknown>;
+    return {
+      id: r.id as string,
+      promptId: r.prompt_id as string,
+      url: r.url as string,
+      label: (r.label as string | null) ?? null,
+      createdAt: r.created_at as string,
+    };
+  });
+
+  return {
+    workStatus: (promptRes.data?.work_status as PromptWorkStatus | null) ?? null,
+    notes,
+    targetUrls,
+  };
+}
+
+export async function setPromptWorkStatus(
+  promptId: string,
+  status: PromptWorkStatus | null,
+): Promise<void> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from('prompts')
+    .update({ work_status: status })
+    .eq('id', promptId);
+  if (error) throw new Error(error.message);
+}
+
+export async function addPromptNote(promptId: string, body: string): Promise<PromptNote> {
+  const trimmed = body.trim();
+  if (!trimmed) throw new Error('Note cannot be empty');
+  if (trimmed.length > 2000) throw new Error('Note is too long (max 2000 characters)');
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data, error } = await supabase
+    .from('prompt_notes')
+    .insert({ prompt_id: promptId, body: trimmed, author_id: user?.id ?? null })
+    .select('id, prompt_id, body, created_at, profiles(full_name)')
+    .single();
+  if (error) throw new Error(error.message);
+
+  const r = data as unknown as Record<string, unknown>;
+  const profile = r.profiles as { full_name: string | null } | null;
+  return {
+    id: r.id as string,
+    promptId: r.prompt_id as string,
+    body: r.body as string,
+    authorName: profile?.full_name ?? null,
+    createdAt: r.created_at as string,
+  };
+}
+
+export async function deletePromptNote(noteId: string): Promise<void> {
+  const supabase = await createClient();
+  const { error } = await supabase.from('prompt_notes').delete().eq('id', noteId);
+  if (error) throw new Error(error.message);
+}
+
+/** Basic sanity check — the value must parse as an http(s) URL. */
+function normalizeTargetUrl(raw: string): string {
+  const trimmed = raw.trim();
+  const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  const parsed = new URL(candidate);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Only http(s) URLs are supported');
+  }
+  return parsed.toString();
+}
+
+export async function addPromptTargetUrl(
+  promptId: string,
+  url: string,
+  label?: string,
+): Promise<PromptTargetUrl> {
+  let normalized: string;
+  try {
+    normalized = normalizeTargetUrl(url);
+  } catch {
+    throw new Error('Enter a valid URL');
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data, error } = await supabase
+    .from('prompt_target_urls')
+    .insert({
+      prompt_id: promptId,
+      url: normalized,
+      label: label?.trim() || null,
+      added_by: user?.id ?? null,
+    })
+    .select('id, prompt_id, url, label, created_at')
+    .single();
+  if (error) {
+    if (error.code === '23505') throw new Error('This URL is already targeted for this prompt');
+    throw new Error(error.message);
+  }
+
+  const r = data as unknown as Record<string, unknown>;
+  return {
+    id: r.id as string,
+    promptId: r.prompt_id as string,
+    url: r.url as string,
+    label: (r.label as string | null) ?? null,
+    createdAt: r.created_at as string,
+  };
+}
+
+export async function deletePromptTargetUrl(id: string): Promise<void> {
+  const supabase = await createClient();
+  const { error } = await supabase.from('prompt_target_urls').delete().eq('id', id);
+  if (error) throw new Error(error.message);
+}

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -49,6 +49,7 @@ function mapPromptRow(row: Record<string, unknown>): Prompt {
     regions: (row.regions as string[]) ?? [],
     models: (row.models as string[]) ?? [],
     isActive: row.is_active as boolean,
+    workStatus: (row.work_status as Prompt['workStatus']) ?? null,
     createdAt: row.created_at as string,
   };
 }

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -50,6 +50,11 @@ function mapPromptRow(row: Record<string, unknown>): Prompt {
     models: (row.models as string[]) ?? [],
     isActive: row.is_active as boolean,
     workStatus: (row.work_status as Prompt['workStatus']) ?? null,
+    targetUrlCount: Array.isArray(row.prompt_target_urls) ? row.prompt_target_urls.length : 0,
+    citedUrlCount: Array.isArray(row.prompt_target_urls)
+      ? (row.prompt_target_urls as { cited_count: number }[]).filter((t) => t.cited_count > 0)
+          .length
+      : 0,
     createdAt: row.created_at as string,
   };
 }
@@ -123,7 +128,7 @@ export async function getPromptSets(brandId: string): Promise<PromptSet[]> {
 
   const { data, error } = await supabase
     .from('prompt_sets')
-    .select('*, prompts(*)')
+    .select('*, prompts(*, prompt_target_urls(cited_count))')
     .eq('brand_id', brandId)
     .order('created_at', { ascending: false });
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -58,6 +58,10 @@ export interface Prompt {
   isActive: boolean;
   /** Workflow state (#463 follow-up): null = no status set. */
   workStatus: 'todo' | 'in_progress' | 'done' | null;
+  /** Target URLs attached to this prompt (0 when the embed isn't selected). */
+  targetUrlCount: number;
+  /** Target URLs cited by at least one answer. */
+  citedUrlCount: number;
   createdAt: string;
 }
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -56,6 +56,8 @@ export interface Prompt {
   regions: string[];
   models: string[];
   isActive: boolean;
+  /** Workflow state (#463 follow-up): null = no status set. */
+  workStatus: 'todo' | 'in_progress' | 'done' | null;
   createdAt: string;
 }
 

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -930,25 +930,34 @@ export type Database = {
       prompt_target_urls: {
         Row: {
           added_by: string | null;
+          cited_count: number;
           created_at: string;
+          first_cited_at: string | null;
           id: string;
           label: string | null;
+          last_cited_at: string | null;
           prompt_id: string;
           url: string;
         };
         Insert: {
           added_by?: string | null;
+          cited_count?: number;
           created_at?: string;
+          first_cited_at?: string | null;
           id?: string;
           label?: string | null;
+          last_cited_at?: string | null;
           prompt_id: string;
           url: string;
         };
         Update: {
           added_by?: string | null;
+          cited_count?: number;
           created_at?: string;
+          first_cited_at?: string | null;
           id?: string;
           label?: string | null;
+          last_cited_at?: string | null;
           prompt_id?: string;
           url?: string;
         };

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -649,6 +649,45 @@ export type Database = {
           },
         ];
       };
+      prompt_notes: {
+        Row: {
+          author_id: string | null;
+          body: string;
+          created_at: string;
+          id: string;
+          prompt_id: string;
+        };
+        Insert: {
+          author_id?: string | null;
+          body: string;
+          created_at?: string;
+          id?: string;
+          prompt_id: string;
+        };
+        Update: {
+          author_id?: string | null;
+          body?: string;
+          created_at?: string;
+          id?: string;
+          prompt_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'prompt_notes_author_id_fkey';
+            columns: ['author_id'];
+            isOneToOne: false;
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'prompt_notes_prompt_id_fkey';
+            columns: ['prompt_id'];
+            isOneToOne: false;
+            referencedRelation: 'prompts';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       prompt_results: {
         Row: {
           brand_id: string;
@@ -888,6 +927,48 @@ export type Database = {
           },
         ];
       };
+      prompt_target_urls: {
+        Row: {
+          added_by: string | null;
+          created_at: string;
+          id: string;
+          label: string | null;
+          prompt_id: string;
+          url: string;
+        };
+        Insert: {
+          added_by?: string | null;
+          created_at?: string;
+          id?: string;
+          label?: string | null;
+          prompt_id: string;
+          url: string;
+        };
+        Update: {
+          added_by?: string | null;
+          created_at?: string;
+          id?: string;
+          label?: string | null;
+          prompt_id?: string;
+          url?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'prompt_target_urls_added_by_fkey';
+            columns: ['added_by'];
+            isOneToOne: false;
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'prompt_target_urls_prompt_id_fkey';
+            columns: ['prompt_id'];
+            isOneToOne: false;
+            referencedRelation: 'prompts';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       prompts: {
         Row: {
           category: string | null;
@@ -900,6 +981,7 @@ export type Database = {
           regions: string[];
           text: string;
           topic_id: string | null;
+          work_status: string | null;
         };
         Insert: {
           category?: string | null;
@@ -911,6 +993,7 @@ export type Database = {
           prompt_set_id: string;
           regions?: string[];
           text: string;
+          work_status?: string | null;
         };
         Update: {
           category?: string | null;
@@ -922,6 +1005,7 @@ export type Database = {
           prompt_set_id?: string;
           regions?: string[];
           text?: string;
+          work_status?: string | null;
         };
         Relationships: [
           {


### PR DESCRIPTION
## Summary

The prompts list only measured; the *act* side of the AEO loop (which prompts got content work, which are queued, which URLs we're pushing to get cited) lived outside the product. This adds the prompt workflow, v1 + v2:

**Data** (`00031` + `00032`, applied to the hosted project)
- `prompts.work_status` — `todo / in_progress / done`, nullable.
- `prompt_notes` — author + timestamped notes thread per prompt.
- `prompt_target_urls` — multiple URLs per prompt (unique per URL), with denormalized `cited_count` / `first_cited_at` / `last_cited_at` so list surfaces read citation status without scanning results.
- RLS mirrors the prompts policies: members read, admin/manager write.

**All Prompts**
- New **Work** column: shared `WorkStatusBadge` — dropdown picker for admin/manager (optimistic update with rollback), read-only badge for members — plus an **"X/Y cited"** line (green once any target URL is cited) via a cheap `prompt_target_urls(cited_count)` embed, so "work done but nothing cited yet" rows stand out.
- Work-status filter (All / To do / In progress / Done / No status) next to the search box, labels rendered through the base-ui SelectValue render-function pattern.

**Prompt detail**
- Status picker in the header next to the Active badge.
- **Notes** card: free-form thread ("published a comparison post targeting this prompt…") with author + timestamp; **Target URLs** card: add/remove (normalized + validated), each URL opens in a new tab. Both sit outside the date-range refetch overlay — they're window-independent.

**Closed-loop citation tracking (v2)**
- Server: `updateTargetUrlStats` matches each freshly saved result's citations against the prompt's target URLs (protocol / www / query / fragment / trailing-slash insensitive) and bumps the stats. Hooked into both insert paths — the Cloro result handler and the tracking worker's API-model path — as a best-effort step that can never fail the result insert.
- Web: adding a URL backfills its stats from the prompt's existing results (paged, capped at 5,000 rows), so pre-existing citations count from day one.
- UI: **"Cited ×N"** badge per URL with first/last dates in the tooltip and a "was already cited before targeting" nuance; dashed "Not cited yet" otherwise.

The URL matcher is intentionally duplicated web (TS) / server (JS) with stay-in-sync notes on both sides.

## Related issue

—

## Type of change

- [x] `feat` — New feature

## How to test

1. **Status**: on All Prompts (admin/manager), click a Work badge → pick "In progress" → survives reload; the filter narrows rows; as a member the badge is read-only and shows the label, not the raw value.
2. **Notes**: on a prompt detail page add a note → appears with your name + timestamp, survives reload; delete rolls back on failure.
3. **Target URLs**: add a URL that is already cited in this prompt's answers → backfill shows "Cited ×N" immediately with plausible first/last dates; add an uncited URL → "Not cited yet". Duplicate URL add is rejected with a clear message.
4. **Live update**: run a tracking check for the prompt; when a new answer cites a target URL, its count increments without re-adding.
5. **Table indicator**: prompts with targets show "X/Y cited" under the Work badge — green when ≥1 cited.
6. Member role sees everything read-only (no add/delete/status controls).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR