### PR TITLE
fix(insights): divide Positive Sentiment by brand-mentioning results,…

### DIFF
--- a/supabase/migrations/00033_insights_sentiment_denominator.sql
+++ b/supabase/migrations/00033_insights_sentiment_denominator.sql
@@ -1,0 +1,79 @@
+-- #508 — Positive Sentiment KPI was dividing by total_results, which includes
+-- rows where the brand was never mentioned (sentiment analysis is skipped for
+-- those). Add mentioning_results so the app can divide by brand-mentioning
+-- answers only.
+CREATE OR REPLACE FUNCTION public.insights_aggregates(
+  p_brand_id   uuid,
+  p_platform   text         DEFAULT NULL,
+  p_models     text[]       DEFAULT NULL,
+  p_region     text         DEFAULT NULL,
+  p_date_from  timestamptz  DEFAULT NULL,
+  p_date_to    timestamptz  DEFAULT NULL,
+  p_prompt_id  uuid         DEFAULT NULL,
+  p_topic_id   uuid         DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH filtered AS (
+    SELECT pr.visibility_score, pr.mention_count, pr.citation_count,
+           pr.sentiment, pr.model_used, pr.created_at
+    FROM public.prompt_results pr
+    WHERE pr.brand_id = p_brand_id
+      AND pr.platform <> 'chatgpt-shopping'  -- #155 — isolate from Insights
+      AND (p_platform  IS NULL OR pr.platform    = p_platform)
+      AND (p_models    IS NULL OR pr.model_used  = ANY (p_models))
+      AND (p_region    IS NULL OR pr.region      = p_region)
+      AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR pr.created_at <= p_date_to)
+      AND (p_prompt_id IS NULL OR pr.prompt_id   = p_prompt_id)
+      AND (p_topic_id  IS NULL OR EXISTS (
+             SELECT 1 FROM public.prompts p
+             WHERE p.id = pr.prompt_id AND p.topic_id = p_topic_id))
+  ),
+  totals AS (
+    SELECT
+      COUNT(*)                                                AS total_results,
+      COALESCE(SUM(visibility_score), 0)                      AS sum_visibility,
+      COALESCE(SUM(mention_count), 0)                         AS total_mentions,
+      COALESCE(SUM(citation_count), 0)                        AS total_citations,
+      COUNT(*) FILTER (WHERE sentiment = 'positive')          AS positive_count,
+      COUNT(*) FILTER (WHERE mention_count > 0
+                          OR citation_count > 0)               AS mentioning_results,
+      MAX(created_at)                                         AS last_checked_at
+    FROM filtered
+  ),
+  by_model AS (
+    SELECT
+      COALESCE(model_used, 'unknown') AS model_used,
+      SUM(visibility_score)           AS sum_visibility,
+      COUNT(*)                        AS result_count
+    FROM filtered
+    GROUP BY COALESCE(model_used, 'unknown')
+  )
+  SELECT jsonb_build_object(
+    'total_results',       t.total_results,
+    'sum_visibility',      t.sum_visibility,
+    'total_mentions',      t.total_mentions,
+    'total_citations',     t.total_citations,
+    'positive_count',      t.positive_count,
+    'mentioning_results',  t.mentioning_results,
+    'last_checked_at',     t.last_checked_at,
+    'by_model', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',     bm.model_used,
+                'sum_visibility', bm.sum_visibility,
+                'result_count',   bm.result_count)
+              ORDER BY bm.result_count DESC, bm.model_used)
+       FROM by_model bm),
+      '[]'::jsonb)
+  )
+  FROM totals t;
+$$;
+
+ALTER FUNCTION public.insights_aggregates(
+  uuid, text, text[], text, timestamptz, timestamptz, uuid, uuid
+) SECURITY INVOKER;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3777,3 +3777,86 @@ ALTER TABLE "public"."prompt_target_urls"
   ADD COLUMN IF NOT EXISTS "first_cited_at" timestamp with time zone,
   ADD COLUMN IF NOT EXISTS "last_cited_at" timestamp with time zone;
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00033_insights_sentiment_denominator.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- #508 — Positive Sentiment KPI was dividing by total_results, which includes
+-- rows where the brand was never mentioned (sentiment analysis is skipped for
+-- those). Add mentioning_results so the app can divide by brand-mentioning
+-- answers only.
+CREATE OR REPLACE FUNCTION public.insights_aggregates(
+  p_brand_id   uuid,
+  p_platform   text         DEFAULT NULL,
+  p_models     text[]       DEFAULT NULL,
+  p_region     text         DEFAULT NULL,
+  p_date_from  timestamptz  DEFAULT NULL,
+  p_date_to    timestamptz  DEFAULT NULL,
+  p_prompt_id  uuid         DEFAULT NULL,
+  p_topic_id   uuid         DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH filtered AS (
+    SELECT pr.visibility_score, pr.mention_count, pr.citation_count,
+           pr.sentiment, pr.model_used, pr.created_at
+    FROM public.prompt_results pr
+    WHERE pr.brand_id = p_brand_id
+      AND pr.platform <> 'chatgpt-shopping'  -- #155 — isolate from Insights
+      AND (p_platform  IS NULL OR pr.platform    = p_platform)
+      AND (p_models    IS NULL OR pr.model_used  = ANY (p_models))
+      AND (p_region    IS NULL OR pr.region      = p_region)
+      AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR pr.created_at <= p_date_to)
+      AND (p_prompt_id IS NULL OR pr.prompt_id   = p_prompt_id)
+      AND (p_topic_id  IS NULL OR EXISTS (
+             SELECT 1 FROM public.prompts p
+             WHERE p.id = pr.prompt_id AND p.topic_id = p_topic_id))
+  ),
+  totals AS (
+    SELECT
+      COUNT(*)                                                AS total_results,
+      COALESCE(SUM(visibility_score), 0)                      AS sum_visibility,
+      COALESCE(SUM(mention_count), 0)                         AS total_mentions,
+      COALESCE(SUM(citation_count), 0)                        AS total_citations,
+      COUNT(*) FILTER (WHERE sentiment = 'positive')          AS positive_count,
+      COUNT(*) FILTER (WHERE mention_count > 0
+                          OR citation_count > 0)               AS mentioning_results,
+      MAX(created_at)                                         AS last_checked_at
+    FROM filtered
+  ),
+  by_model AS (
+    SELECT
+      COALESCE(model_used, 'unknown') AS model_used,
+      SUM(visibility_score)           AS sum_visibility,
+      COUNT(*)                        AS result_count
+    FROM filtered
+    GROUP BY COALESCE(model_used, 'unknown')
+  )
+  SELECT jsonb_build_object(
+    'total_results',       t.total_results,
+    'sum_visibility',      t.sum_visibility,
+    'total_mentions',      t.total_mentions,
+    'total_citations',     t.total_citations,
+    'positive_count',      t.positive_count,
+    'mentioning_results',  t.mentioning_results,
+    'last_checked_at',     t.last_checked_at,
+    'by_model', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',     bm.model_used,
+                'sum_visibility', bm.sum_visibility,
+                'result_count',   bm.result_count)
+              ORDER BY bm.result_count DESC, bm.model_used)
+       FROM by_model bm),
+      '[]'::jsonb)
+  )
+  FROM totals t;
+$$;
+
+ALTER FUNCTION public.insights_aggregates(
+  uuid, text, text[], text, timestamptz, timestamptz, uuid, uuid
+) SECURITY INVOKER;
+

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -1453,7 +1453,7 @@ export default function InsightsPage() {
                 />
                 <KpiCard
                   title="Positive Sentiment"
-                  tooltip="Percentage of AI responses that described your brand in a positive context."
+                  tooltip="Percentage of answers that mention your brand and describe it in a positive context."
                   icon={AlertCircle}
                   value={`${summary!.positiveSentimentPct}%`}
                   sub={<DeltaBadge delta={summary!.sentimentChange} suffix=" pts" />}

--- a/web/src/lib/actions/tracking.test.ts
+++ b/web/src/lib/actions/tracking.test.ts
@@ -48,9 +48,26 @@ function fakeQueryBuilder(table: string) {
   return builder;
 }
 
+// #508 — a brand tracked broadly but rarely mentioned: most of the 427 rows
+// never mention the brand (sentiment analysis is skipped for those), but of
+// the 127 that do, 51 are positive.
+const insightsAggregatesRow = {
+  total_results: 427,
+  sum_visibility: 7546,
+  total_mentions: 380,
+  total_citations: 192,
+  positive_count: 51,
+  mentioning_results: 127,
+  last_checked_at: '2026-07-22T16:59:39.570Z',
+  by_model: [],
+};
+
+let rpcMock = vi.fn(async () => ({ data: insightsAggregatesRow, error: null }));
+
 vi.mock('@/lib/supabase/server', () => ({
   createClient: async () => ({
     from: (table: string) => fakeQueryBuilder(table),
+    rpc: () => rpcMock(),
   }),
 }));
 
@@ -66,5 +83,29 @@ describe('getPromptResultById', () => {
       id: 'result-id',
       searchQueries: promptResultRow.search_queries,
     });
+  });
+});
+
+describe('getInsightsSummary', () => {
+  it('divides positive sentiment by brand-mentioning results, not all results (#508)', async () => {
+    rpcMock = vi.fn(async () => ({ data: insightsAggregatesRow, error: null }));
+    const { getInsightsSummary } = await import('./tracking');
+
+    const summary = await getInsightsSummary('brand-id');
+
+    // 51/127 ≈ 40%, not the diluted 51/427 ≈ 12% the old formula produced.
+    expect(summary.positiveSentimentPct).toBe(40);
+  });
+
+  it('renders 0% instead of NaN when the brand is tracked but never mentioned', async () => {
+    rpcMock = vi.fn(async () => ({
+      data: { ...insightsAggregatesRow, positive_count: 0, mentioning_results: 0 },
+      error: null,
+    }));
+    const { getInsightsSummary } = await import('./tracking');
+
+    const summary = await getInsightsSummary('brand-id');
+
+    expect(summary.positiveSentimentPct).toBe(0);
   });
 });

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -162,7 +162,7 @@ function modelFilterArray(model: string | undefined): string[] | null {
   return list.length > 0 ? list : null;
 }
 
-// ── RPC return shapes (mirror supabase/migrations/00006_insights_aggregates.sql) ─
+// ── RPC return shapes (mirror supabase/migrations/00031_insights_sentiment_denominator.sql) ─
 
 interface InsightsAggregates {
   total_results: number;
@@ -170,6 +170,7 @@ interface InsightsAggregates {
   total_mentions: number;
   total_citations: number;
   positive_count: number;
+  mentioning_results: number;
   last_checked_at: string | null;
   by_model: Array<{
     model_used: string;
@@ -1078,7 +1079,14 @@ export async function getInsightsSummary(
   const avgVisibilityScore = roundTo1(cur.sum_visibility / totalResults);
   const totalMentions = cur.total_mentions;
   const totalCitations = cur.total_citations;
-  const positiveSentimentPct = Math.round((cur.positive_count / totalResults) * 100);
+  // Denominator is answers that mention/cite the brand, not all results —
+  // sentiment analysis is skipped entirely for brand-absent answers, so
+  // dividing by totalResults dilutes the score with rows that can never
+  // be positive (#508).
+  const positiveSentimentPct =
+    cur.mentioning_results > 0
+      ? Math.round((cur.positive_count / cur.mentioning_results) * 100)
+      : 0;
   const lastCheckedAt = cur.last_checked_at;
 
   const platformBreakdown = cur.by_model.map((m) => ({
@@ -1139,12 +1147,18 @@ export async function getInsightsSummary(
       const curAvgVis = roundTo1(curWin.sum_visibility / curWin.total_results);
       const curMentions = curWin.total_mentions;
       const curCitations = curWin.total_citations;
-      const curSentimentPct = Math.round((curWin.positive_count / curWin.total_results) * 100);
+      const curSentimentPct =
+        curWin.mentioning_results > 0
+          ? Math.round((curWin.positive_count / curWin.mentioning_results) * 100)
+          : 0;
 
       const prevAvgVis = roundTo1(prevWin.sum_visibility / prevWin.total_results);
       prevMentions = prevWin.total_mentions;
       prevCitations = prevWin.total_citations;
-      const prevSentimentPct = Math.round((prevWin.positive_count / prevWin.total_results) * 100);
+      const prevSentimentPct =
+        prevWin.mentioning_results > 0
+          ? Math.round((prevWin.positive_count / prevWin.mentioning_results) * 100)
+          : 0;
 
       visibilityChange = roundTo1(curAvgVis - prevAvgVis);
       mentionsChange = percentageChange(curMentions, prevMentions);


### PR DESCRIPTION
## Summary

The "Positive Sentiment" KPI on the Insights dashboard divided `positive_count`
by `total_results` — but sentiment analysis is skipped entirely for answers
that never mention the brand, so those rows sit in the denominator and can
never be positive. On brands with low mention volume this collapses the
score toward zero (e.g. a real 43% positive rate among brand-mentioning
answers displayed as ~1% once 13,002 brand-absent rows were mixed in).

This adds `mentioning_results` (`mention_count > 0 OR citation_count > 0`) to
the `insights_aggregates()` RPC and divides by that instead, with an explicit
zero-guard for brands that are tracked but never mentioned in the selected
window. Same fix covers the Insights dashboard, the Topics detail page, and
Reports (PDF + web), since they all read from `getInsightsSummary()`.

## Related issue

Closes #508

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR