### PR TITLE
feat(insights): show no-competitors teaser with path to /dashboard/competitors (#507)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -860,6 +860,35 @@ function TrackingProgressBanner({
   );
 }
 
+// ─── No Competitors Teaser ────────────────────────────────────────────────────
+
+/**
+ * Shown in place of the Competitor Comparison section when the brand has no
+ * tracked competitors yet (#507). Gives users a clear path to
+ * /dashboard/competitors so the head-to-head feature is discoverable even
+ * before any competitors are added.
+ */
+function NoCompetitorsTeaser() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-muted-foreground/30 p-8 text-center">
+      <Users className="h-8 w-8 text-muted-foreground/40" />
+      <div>
+        <p className="text-sm font-medium text-foreground">No competitors tracked yet</p>
+        <p className="mt-0.5 max-w-xs text-xs text-muted-foreground">
+          Add competitors to see how you compare in AI answers.
+        </p>
+      </div>
+      <Link
+        href="/dashboard/competitors"
+        className="inline-flex items-center gap-1.5 text-xs font-medium text-primary underline-offset-2 hover:underline"
+      >
+        Head-to-Head Comparison
+        <ArrowRight className="h-3.5 w-3.5" />
+      </Link>
+    </div>
+  );
+}
+
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function InsightsPage() {
@@ -1406,7 +1435,7 @@ export default function InsightsPage() {
               </div>
 
               {/* Competitor Comparison */}
-              {competitorData && (
+              {competitorData ? (
                 <div className="grid grid-cols-1 gap-4 lg:grid-cols-5">
                   <Card className="lg:col-span-3">
                     <CardHeader className="pb-2">
@@ -1441,6 +1470,8 @@ export default function InsightsPage() {
                     </CardContent>
                   </Card>
                 </div>
+              ) : (
+                <NoCompetitorsTeaser />
               )}
 
               {/* Share of Voice */}


### PR DESCRIPTION
## Problem

#506 removed Competitors from the navigation and made the Insights leaderboard's
Head-to-Head Comparison link the page's entry point. However, `competitorData` is
only set when `brands.length > 1` — so a brand with **zero tracked competitors**
has no Competitor Comparison section at all, and no UI path to
`/dashboard/competitors`. The feature is completely undiscoverable for exactly the
users who haven't set it up yet.

## Solution

When `competitorData` is null and the page is otherwise showing data (not the
loading skeleton or the fully-empty state), render a compact teaser card in place
of the missing section.

## Changes

### `web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx`

**New `NoCompetitorsTeaser` component** — a dashed-border card matching the muted
empty-state style used elsewhere on the page:

- `border-dashed border-muted-foreground/30` border
- `Users` icon at `text-muted-foreground/40`
- Heading: **"No competitors tracked yet"**
- Subtext: "Add competitors to see how you compare in AI answers."
- Link → `/dashboard/competitors` labeled **"Head-to-Head Comparison"** with
  `ArrowRight`, using locale-aware `Link` from `@/i18n/navigation`

**`&&` guard swapped to ternary** so the teaser renders when `competitorData` is
null. The existing leaderboard Head-to-Head Comparison link (added in #506) is
preserved inside the `competitorData ? (...)` branch so users **with** competitors
keep their path too — both coexist.

The teaser is inside the `noResults`-gated block so it is correctly suppressed
during the loading skeleton, the fully-empty state, and the no-data-for-period
state.

## Diff

3 hunks, `page.tsx` only — no other files touched:

1. `NoCompetitorsTeaser` component added before `// ─── Main Page`
2. `{competitorData && (` → `{competitorData ? (`
3. `) : ( <NoCompetitorsTeaser /> )}` closing added

## Acceptance Criteria

- [x] Zero competitors → teaser card shown, clicking lands on `/dashboard/competitors`
- [x] At least one competitor → existing chart + leaderboard renders unchanged,
      Head-to-Head link in the leaderboard header still present
- [x] Teaser not shown during loading skeleton
- [x] Teaser not shown on no-data-at-all empty state
- [x] Teaser not shown when selected period has no results
- [x] `yarn lint`, `yarn typecheck`, `yarn format:check` pass from `web/`

## Related

- Closes #507
- References #506 (added leaderboard link + removed Competitors from nav)