### PR TITLE
feat: add topic creation from topics dashboard

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -169,6 +169,11 @@
     "negative": "Negative"
   },
   "topics": {
+    "addTopic": "Add Topic",
+    "addTopicDescription": "Create a new topic for this brand.",
+    "topicAlreadyExists": "This topic already exists",
+    "topicAdded": "\"{name}\" added. Assign prompts to this topic to start tracking it.",
+    "failedToAddTopic": "Failed to add topic",
     "noBrandTitle": "No brand selected",
     "noBrandBody": "Select a brand from the top switcher to view topic analytics.",
     "title": "Topics",

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
@@ -165,6 +165,7 @@ function KpiCard({
 
 export default function TopicsPage() {
   const t = useTranslations('topics');
+  const common = useTranslations('common');
   const activeBrandId = useBrandStore((s) => s.activeBrandId);
   const activeBrand = useBrandStore(
     (s) => s.brands.find((brand) => brand.id === s.activeBrandId) ?? null,
@@ -279,10 +280,11 @@ export default function TopicsPage() {
   }
 
   const handleAddTopic = async () => {
+    if (isAdding) return;
     const name = newName.trim();
     if (!name) return;
     if (topics.some((t) => t.name.toLowerCase() === name.toLowerCase())) {
-      toast.error('This topic already exists');
+      toast.error(t('topicAlreadyExists'));
       return;
     }
     setIsAdding(true);
@@ -291,9 +293,9 @@ export default function TopicsPage() {
       await loadData();
       setNewName('');
       setOpen(false);
-      toast.success(`"${added.name}" added. Assign prompts to this topic to start tracking it.`);
+      toast.success(t('topicAdded', { name: added.name }));
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to add topic');
+      toast.error(err instanceof Error ? err.message : t('failedToAddTopic'));
     } finally {
       setIsAdding(false);
     }
@@ -332,7 +334,7 @@ export default function TopicsPage() {
             <>
               <Button size="sm" onClick={() => setOpen(true)}>
                 <Plus className="mr-2 h-4 w-4" />
-                Add Topic
+                {t('addTopic')}
               </Button>
               <Dialog
                 open={open}
@@ -345,8 +347,8 @@ export default function TopicsPage() {
               >
                 <DialogContent className="sm:max-w-sm">
                   <DialogHeader>
-                    <DialogTitle>Add Topic</DialogTitle>
-                    <DialogDescription>Create a new topic for this brand.</DialogDescription>
+                    <DialogTitle>{t('addTopic')}</DialogTitle>
+                    <DialogDescription>{t('addTopicDescription')}</DialogDescription>
                   </DialogHeader>
                   <div className="flex gap-2">
                     <Input
@@ -358,7 +360,9 @@ export default function TopicsPage() {
                     />
                   </div>
                   <DialogFooter>
-                    <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+                    <DialogClose render={<Button variant="outline" />}>
+                      {common('cancel')}
+                    </DialogClose>
                     <Button
                       variant="default"
                       onClick={handleAddTopic}
@@ -370,7 +374,7 @@ export default function TopicsPage() {
                       ) : (
                         <Plus className="h-4 w-4" />
                       )}
-                      Add Topic
+                      {t('addTopic')}
                     </Button>
                   </DialogFooter>
                 </DialogContent>
@@ -458,7 +462,7 @@ export default function TopicsPage() {
               {canManage && (
                 <Button className="mt-4" onClick={() => setOpen(true)}>
                   <Plus className="mr-2 h-4 w-4" />
-                  Add Topic
+                  {t('addTopic')}
                 </Button>
               )}
             </div>

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
@@ -8,6 +8,10 @@ import { useUserRole } from '@/hooks/use-user-role';
 import { getTopicsOverview, type TopicOverviewRow } from '@/lib/actions/topic';
 import { TopicSuggestionsCard } from './_suggestions-card';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { createTopic } from '@/lib/actions/topic';
+import { toast } from 'sonner';
+import { Input } from '@/components/ui/input';
+import { Loader2, Plus } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -16,6 +20,15 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
@@ -160,6 +173,9 @@ export default function TopicsPage() {
   const [topics, setTopics] = useState<TopicOverviewRow[]>([]);
   const [unassignedPromptCount, setUnassignedPromptCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [isAdding, setIsAdding] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [open, setOpen] = useState(false);
 
   const loadData = useCallback(async () => {
     if (!activeBrandId) {
@@ -262,6 +278,27 @@ export default function TopicsPage() {
     );
   }
 
+  const handleAddTopic = async () => {
+    const name = newName.trim();
+    if (!name) return;
+    if (topics.some((t) => t.name.toLowerCase() === name.toLowerCase())) {
+      toast.error('This topic already exists');
+      return;
+    }
+    setIsAdding(true);
+    try {
+      const added = await createTopic(activeBrandId, name);
+      await loadData();
+      setNewName('');
+      setOpen(false);
+      toast.success(`"${added.name}" added. Assign prompts to this topic to start tracking it.`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add topic');
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -291,6 +328,55 @@ export default function TopicsPage() {
             <Settings2 className="h-4 w-4" />
             {t('manageTopics')}
           </Link>
+          {canManage && (
+            <>
+              <Button size="sm" onClick={() => setOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Add Topic
+              </Button>
+              <Dialog
+                open={open}
+                onOpenChange={(value) => {
+                  setOpen(value);
+                  if (!value) {
+                    setNewName('');
+                  }
+                }}
+              >
+                <DialogContent className="sm:max-w-sm">
+                  <DialogHeader>
+                    <DialogTitle>Add Topic</DialogTitle>
+                    <DialogDescription>Create a new topic for this brand.</DialogDescription>
+                  </DialogHeader>
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="e.g. Industry, Comparison..."
+                      value={newName}
+                      onChange={(e) => setNewName(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && newName.trim() && handleAddTopic()}
+                      className="flex-1"
+                    />
+                  </div>
+                  <DialogFooter>
+                    <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+                    <Button
+                      variant="default"
+                      onClick={handleAddTopic}
+                      disabled={isAdding || !newName.trim()}
+                      className="gap-1.5 shrink-0"
+                    >
+                      {isAdding ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Plus className="h-4 w-4" />
+                      )}
+                      Add Topic
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </>
+          )}
         </div>
       </div>
 
@@ -369,6 +455,12 @@ export default function TopicsPage() {
               <Tag className="mx-auto h-9 w-9 text-muted-foreground/40" />
               <p className="mt-2">{t('emptyTitle')}</p>
               <p className="text-xs">{t('emptyBody')}</p>
+              {canManage && (
+                <Button className="mt-4" onClick={() => setOpen(true)}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add Topic
+                </Button>
+              )}
             </div>
           ) : (
             <Table>


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

- Added the ability to create topics directly from the Topics dashboard.
- Previously, topic creation was only available under Brand Settings → Topics, making the main Topics page read-only. This PR adds an Add Topic flow directly from the dashboard for users with write access.

Changes:
- Added an **Add Topic** button to the Topics dashboard header.
- Added the same Add Topic action to the empty leaderboard state.
- Added a dialog-based topic creation flow for the active brand.
- Reused the existing `createTopic(brandId, name)` action.
- Added validation for empty topic names and duplicate topic names.
- Refreshes the leaderboard after successful topic creation.
- Added a success toast with guidance to assign prompts for tracking.
- Restricted topic creation based on `canManage` permission.

## Related issue

Closes #462 

## Type of change

<!-- Check all that apply -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR