### PR TITLE
fix(tracking): accept the new string-array Perplexity search_model_queries shape

### DIFF
--- a/server/src/lib/cloro-scraper.js
+++ b/server/src/lib/cloro-scraper.js
@@ -90,8 +90,11 @@ function buildRequestBody(promptText, scraperId, region) {
  * Normalize the observed query fan-out from a raw Cloro response into a rich,
  * engine-labelled array: `[{ query, engine?, source_platform }]` (#332).
  *
- * Two provider shapes:
- *  - Perplexity → `search_model_queries: [{ query, engine, limit }]` (keep `engine`)
+ * Provider shapes:
+ *  - Perplexity → `search_model_queries: string[]` since Cloro's 2026-07-23
+ *    update; `[{ query, engine, limit }]` before it (keep `engine`). Both are
+ *    accepted so a potential upstream revert can't silently zero the field
+ *    again.
  *  - Copilot / ChatGPT / Grok / Gemini → `searchQueries: string[]`
  * Anything else (or missing) → `[]`. This is OBSERVED data only — we never
  * synthesize sub-queries.
@@ -102,14 +105,22 @@ function normalizeSearchQueries(result, scraperId) {
   // kept when it's a non-empty string (never a stray non-string value).
   if (Array.isArray(result.search_model_queries)) {
     return result.search_model_queries
-      .filter((q) => typeof q?.query === 'string' && q.query.trim() !== '')
-      .map((q) => ({
-        query: q.query.trim(),
-        ...(typeof q.engine === 'string' && q.engine.trim() !== ''
-          ? { engine: q.engine.trim() }
-          : {}),
-        source_platform: scraperId,
-      }));
+      .map((entry) => {
+        if (typeof entry === 'string') {
+          return { query: entry.trim(), source_platform: scraperId };
+        }
+        if (typeof entry?.query === 'string') {
+          return {
+            query: entry.query.trim(),
+            ...(typeof entry.engine === 'string' && entry.engine.trim() !== ''
+              ? { engine: entry.engine.trim() }
+              : {}),
+            source_platform: scraperId,
+          };
+        }
+        return null;
+      })
+      .filter((item) => item !== null && item.query !== '');
   }
 
   if (Array.isArray(result.searchQueries)) {

--- a/server/src/lib/cloro-scraper.test.js
+++ b/server/src/lib/cloro-scraper.test.js
@@ -184,6 +184,19 @@ describe('cloro-scraper – parseScraperResponse', () => {
       ]);
     });
 
+    it('maps the plain-string Perplexity search_model_queries shape (Cloro 2026-07)', () => {
+      const result = {
+        markdown: 'text',
+        sources: [],
+        search_model_queries: ['best laptops 2026', '  laptop reviews  ', '', '   ', 42, null],
+      };
+      const parsed = parseScraperResponse(result, 'perplexity-web');
+      expect(parsed.search_queries).toEqual([
+        { query: 'best laptops 2026', source_platform: 'perplexity-web' },
+        { query: 'laptop reviews', source_platform: 'perplexity-web' },
+      ]);
+    });
+
     it('preserves the per-item engine label from Perplexity search_model_queries', () => {
       const result = {
         markdown: 'text',


### PR DESCRIPTION
## Summary

Cloro's 2026-07-23 update changed the Perplexity `search_model_queries` field from `[{ query, engine, limit }]` objects to a plain `string[]` (matching how other providers expose fan-out). Our normalizer only handled the object shape — `typeof q?.query === 'string'` is false for a string entry — so every entry was silently filtered out and Perplexity results have been stored with an empty fan-out since the change shipped.

Verified against production data and live API calls:
- `prompt_results` (perplexity-web): ~99% of results had fan-out through Jul 22; **0 of 426** on Jul 23.
- Two live Cloro PERPLEXITY tasks (Jul 24) both returned `search_model_queries` as an array of strings; the current normalizer kept 0 entries from each.

Fix: `normalizeSearchQueries` now accepts both entry shapes — plain strings (new) map to `{ query, source_platform }`, and legacy `{ query, engine }` objects keep their `engine` label — so historical replays and a potential upstream revert both keep working. Stored row shape is unchanged; `engine` was already optional downstream, it's just absent on new rows.

No backfill is possible for Jul 23 rows (we don't store the raw response), but the window is a single day.

## Related issue

—

## Type of change

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [x] `test` — Adding or updating tests

## How to test

1. `cd server && yarn vitest run src/lib/cloro-scraper.test.js` — 22 tests pass, including the new plain-string shape case.
2. After deploy, check a fresh Perplexity result: `prompt_results.search_queries` should be non-empty again and the Query Fan-out card on the prompt detail page should populate for new runs.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `server/`)
- [x] `yarn typecheck` passes (web unchanged)
- [x] `yarn format:check` passes (run from `server/`)
- [x] Changes are focused — one concern per PR