### PR TITLE
fix: resolve all ESLint warnings in web/ (issue #437)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from '@/i18n/navigation';
-import { createPortal } from 'react-dom';
 import { useTranslations } from 'next-intl';
 import { useBrandStore } from '@/stores/use-brand-store';
 import { useFeatureGate } from '@/hooks/use-feature-gate';
@@ -60,7 +59,6 @@ import {
   ShieldAlert,
   ChevronDown,
   Eye,
-  HelpCircle,
 } from 'lucide-react';
 
 // ─── Shared Visual Components (mirroring Insights) ───────────────────────────
@@ -101,76 +99,6 @@ function SentimentBadge({ sentiment }: { sentiment: 'positive' | 'neutral' | 'ne
     >
       {sentiment}
     </Badge>
-  );
-}
-
-function VisibilityBar({ score, max = 100 }: { score: number; max?: number }) {
-  const pct = Math.round((score / max) * 100);
-  return (
-    <div className="flex items-center gap-2">
-      <div className="h-1.5 w-24 rounded-full bg-muted overflow-hidden">
-        <div
-          className={cn(
-            'h-full rounded-full transition-all',
-            score >= 60 ? 'bg-green-500' : score >= 40 ? 'bg-yellow-500' : 'bg-red-500',
-          )}
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <span className="text-sm font-medium tabular-nums">{Math.round(score)}</span>
-    </div>
-  );
-}
-
-function InfoTip({ content }: { content: string }) {
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
-  const ref = useRef<HTMLSpanElement>(null);
-
-  function show() {
-    const r = ref.current?.getBoundingClientRect();
-    if (r) setPos({ x: r.left + r.width / 2, y: r.bottom + 6 });
-  }
-
-  return (
-    <>
-      <span
-        ref={ref}
-        onMouseEnter={show}
-        onMouseLeave={() => setPos(null)}
-        className="inline-flex items-center cursor-help"
-      >
-        <HelpCircle className="h-3 w-3 text-muted-foreground/60 hover:text-muted-foreground transition-colors" />
-      </span>
-      {pos &&
-        createPortal(
-          <div
-            style={{ left: pos.x, top: pos.y, transform: 'translateX(-50%)' }}
-            className="pointer-events-none fixed z-[9999] w-56 rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md"
-          >
-            {content}
-          </div>,
-          document.body,
-        )}
-    </>
-  );
-}
-
-function ColHead({
-  children,
-  tooltip,
-  className,
-}: {
-  children: React.ReactNode;
-  tooltip?: string;
-  className?: string;
-}) {
-  return (
-    <TableHead className={className}>
-      <span className="inline-flex items-center gap-1">
-        {children}
-        {tooltip && <InfoTip content={tooltip} />}
-      </span>
-    </TableHead>
   );
 }
 

--- a/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/shopping/page.tsx
@@ -690,6 +690,7 @@ function PromptsTabContent({
                             className="flex gap-3 rounded-md border bg-muted/10 p-2 text-xs"
                           >
                             {card.imageUrl ? (
+                              // eslint-disable-next-line @next/next/no-img-element -- product images come from arbitrary merchant domains; next/image remotePatterns would need an open-ended wildcard
                               <img
                                 src={card.imageUrl}
                                 alt=""

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -135,7 +135,6 @@ function DeltaBadge({ current, previous }: { current: number; previous: number }
 
 function SnippetBanner({ trackingCode }: { trackingCode?: string }) {
   const [copied, setCopied] = useState(false);
-  const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
   const apiUrl = getPublicApiBaseUrl();
   const snippet = `<script src="${apiUrl}/t.js" data-t="${trackingCode || 'YOUR_TRACKING_CODE'}" defer></script>`;
 

--- a/web/src/app/opengraph-image.tsx
+++ b/web/src/app/opengraph-image.tsx
@@ -44,7 +44,6 @@ export default async function OpengraphImage() {
         }}
       />
 
-      {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={logoSrc} alt="" width={360} height={360} style={{ width: 360, height: 360 }} />
     </div>,
     { ...size },

--- a/web/src/components/ai-provider-avatar.tsx
+++ b/web/src/components/ai-provider-avatar.tsx
@@ -165,6 +165,7 @@ export function AIProviderAvatar({
         className,
       )}
     >
+      {/* eslint-disable-next-line @next/next/no-img-element -- AI provider favicon URLs come from arbitrary remote domains; next/image remotePatterns would need an open-ended wildcard */}
       <img src={meta.icon} alt="" className="h-full w-full object-cover" aria-hidden="true" />
     </span>
   );

--- a/web/src/components/auth/sign-in-form.tsx
+++ b/web/src/components/auth/sign-in-form.tsx
@@ -30,7 +30,7 @@ export function SignInForm() {
 
     const supabase = createClient();
 
-    const { data, error } = await supabase.auth.signInWithPassword({
+    const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
     });

--- a/web/src/components/auth/sign-up-form.tsx
+++ b/web/src/components/auth/sign-up-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
-import { useRouter, Link } from '@/i18n/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';


### PR DESCRIPTION
## Summary

Fixes #437

Eliminates all 8 ESLint warnings from `npx eslint src` with 0 regressions
(`npx tsc --noEmit` and `✓ Compiled successfully` both pass clean).

---

## Changes

### `competitors/page.tsx` — Remove 3 unused components + orphaned imports

`VisibilityBar` and `ColHead` were defined but never referenced in JSX.
Deleting `ColHead` exposed `InfoTip` as also orphaned (it was only used
by `ColHead`), so that was removed too. Their imports were then cleaned up:

- Removed `useRef` from the `react` import
- Removed `import { createPortal } from 'react-dom'`
- Removed `HelpCircle` from the `lucide-react` import block

### `shopping/page.tsx` — Suppress `no-img-element` with reason comment

The `<img>` tag at line 693 loads product images from arbitrary merchant
domains. Migrating to `next/image` would require adding an open-ended
wildcard to `remotePatterns` in `next.config.ts`, which is a broader
change outside the scope of this issue. Added a scoped
`eslint-disable-next-line` comment with an explanation.

### `traffic/page.tsx` — Remove unused variable `isCloud`

`const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true'` was
assigned at line 138 but never read anywhere in the file. Deleted.

### `opengraph-image.tsx` — Remove stale `eslint-disable` directive

The `{/* eslint-disable-next-line @next/next/no-img-element */}` comment
was flagged as unused because ESLint's `no-img-element` rule does not
fire inside Next.js `ImageResponse` JSX. The directive was suppressing
nothing, so it was removed. The `<img>` tag itself is untouched.

### `ai-provider-avatar.tsx` — Suppress `no-img-element` with reason comment

The `<img>` tag at line 168 loads AI provider favicon icons from
arbitrary remote domains. Same reasoning as `shopping/page.tsx` — an
open-ended `remotePatterns` wildcard would be needed for `next/image`,
which is out of scope here. Added a scoped `eslint-disable-next-line`
comment with an explanation.

### `sign-in-form.tsx` — Remove unused destructured variable `data`

`const { data, error }` at line 33 — `data` was destructured from the
Supabase `signInWithPassword` response but never used. Changed to
`const { error }`.

### `sign-up-form.tsx` — Remove unused import `Link`

`Link` was imported from `@/i18n/navigation` at line 6 but not used
anywhere in the component. Removed from the import.

---

## Testing

```bash
npx eslint src     # 0 warnings, 0 errors
npx tsc --noEmit   # 0 errors

```