### PR TITLE
docs: add a Reports guide (templates, section picker, PDF export)

### DIFF
--- a/docs/guides/reports.mdx
+++ b/docs/guides/reports.mdx
@@ -1,0 +1,52 @@
+---
+title: "Reports"
+description: "Immutable snapshot reports with an AI executive summary, ready-made templates and vector PDF export."
+---
+
+## What a report is
+
+The **Reports** page (`/dashboard/reports`) generates point-in-time snapshots of your brand's AI visibility. Unlike the live dashboards, a report is **immutable**: the numbers are captured at generation time and never change afterwards, even as new tracking results arrive. That makes reports the right tool for anything you need to stand behind later — a monthly review deck, a client deliverable, or a before/after comparison around a campaign.
+
+Every report includes an **AI executive summary** on top of the sections you pick, and compares each metric against the **previous period of equal length** (a 30-day report is compared to the 30 days before it).
+
+## Generating a report
+
+Click **Generate Report** and pick a template. A template is a default section set — you can toggle any section on or off before generating.
+
+| Template | Default sections | Default range |
+|---|---|---|
+| **Weekly Visibility Summary** | KPIs, Trend, Share of Voice | Last 7 days |
+| **Monthly Executive Report** | Every section | Last 30 days |
+| **Competitor Benchmark** | KPIs, Share of Voice, Competitors, Topics | Last 30 days |
+| **Citation & Sources Report** | Citations, Citation Evidence | Last 30 days |
+
+Then set:
+
+- **Report title** — optional; a name for the library list.
+- **Brand** — the brand to snapshot.
+- **Date range** — `7d`, `30d`, `90d` presets or a custom from/to range.
+- **Sections** — the full picker offers: KPIs, Trend, Share of Voice, Competitors, Topics, Prompts, Mention Evidence, Fan-out, AI Traffic, Shopping, Audit Score, Citations and Citation Evidence.
+
+<Note>
+The **Shopping** section only appears for brands with Shopping mode enabled. The AI executive summary is always included — it isn't a pickable section.
+</Note>
+
+Generated reports land in the library list on the same page, newest first.
+
+## Reading a report
+
+Open a report to see:
+
+- **AI executive summary** — a short narrative of what changed versus the previous period: the headline visibility movement, mention/citation growth, sentiment and competitor shifts. It is generated once, from the same frozen snapshot the cards render.
+- **Per-section cards** — one card per section you selected, in a fixed order. Sections you left out are simply absent.
+- **Deltas** — KPI cards carry change badges against the previous period of equal length. Percentage deltas render as `+X%`; percentage-point deltas (visibility, sentiment) as `+X pts`.
+
+Because the snapshot is frozen, a report's numbers can legitimately differ from the live dashboards — the dashboards keep moving, the report doesn't.
+
+## PDF export
+
+**Download PDF** renders the report as a vector PDF — text stays selectable and sharp at any zoom, and the file is small enough to attach to an email. The PDF contains the same sections as the web view, including the executive summary.
+
+<Card title="Continue: Looker Studio" icon="arrow-right" href="/guides/looker-studio">
+  Pull Ansvisor metrics into your own dashboards and reporting stack.
+</Card>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -84,6 +84,7 @@
         "guides/ai-traffic-analytics",
         "guides/competitors",
         "guides/content-optimization",
+        "guides/reports",
         "guides/mcp-server",
         "guides/looker-studio"
       ]


### PR DESCRIPTION
## Summary

Adds the missing Platform Guide for the Reports module: what an immutable snapshot report is, how to generate one (the four templates with their default section sets and date presets, the 13-section picker, the Shopping-mode gating), how to read it (AI executive summary, per-section cards, `+X%` vs `+X pts` deltas), and PDF export. Wired into the Platform Guides nav in `docs/mint.json` between Content Optimization and the integration guides.

Template and section names match the UI copy in `web/messages/en.json` → `reports` exactly; default section sets and presets come from `web/src/lib/reports/templates.ts`.

## Related issue

Closes #438

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [x] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. `cd docs && npx mint dev` — the **Reports** page appears in the Platform Guides nav and `/guides/reports` renders (verified locally: HTTP 200, content renders).
2. Cross-check the template table against the generate dialog on `/dashboard/reports` — names, default sections and default ranges match.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (no web/ changes)
- [x] `yarn typecheck` passes (no web/ changes)
- [x] `yarn format:check` passes (no web/ changes)
- [x] Changes are focused — one concern per PR