### PR TITLE
chore(ci): run Next.js production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,15 @@ jobs:
         run: yarn typecheck
       - name: Vitest tests
         run: yarn test
+      - name: Next.js production build
+        run: yarn build
+        env:
+          # next build evaluates modules that initialize Supabase and Stripe
+          # clients; fake values keep CI independent of deployment secrets.
+          NEXT_PUBLIC_SUPABASE_URL: https://ci-placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder-anon-key
+          SUPABASE_SERVICE_ROLE_KEY: ci-placeholder-service-role-key
+          STRIPE_SECRET_KEY: sk_test_ci_placeholder
   server:
     name: server — lint, format & test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- run the Next.js production build after Vitest in the existing web CI job
- provide clearly fake Supabase and Stripe values for SDK clients initialized during build-time page-data collection
- keep deployment secrets out of CI while catching Next.js-only server/client boundary and route compilation failures

The production build completes in about 19 seconds locally, so this change does not add `.next/cache` caching.

## Related issue

Closes #523

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Validation

- `yarn format:check`
- `yarn lint`
- `yarn typecheck`
- `yarn test` (47 tests)
- `yarn build` with the workflow's placeholder environment
- temporarily exported a synchronous function from a `'use server'` module and confirmed `next build` fails with `Server Actions must be async functions`

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
