### PR TITLE
feat(nav): move Prompts above Topics in the sidebar

### DIFF
--- a/web/src/config/dashboard.ts
+++ b/web/src/config/dashboard.ts
@@ -63,14 +63,14 @@ export const dashboardNav: NavGroup[] = [
         requiredFeature: 'basic_insights',
       },
       {
-        title: 'Topics',
-        href: '/dashboard/topics',
-        icon: Tag,
-      },
-      {
         title: 'Prompts',
         href: '/dashboard/prompts',
         icon: Globe,
+      },
+      {
+        title: 'Topics',
+        href: '/dashboard/topics',
+        icon: Tag,
       },
       {
         title: 'Citations',


### PR DESCRIPTION
## Summary

Reorders the Analytics group in the sidebar so **Prompts** sits above **Topics**. Prompts is the more frequently visited surface (it's where tracking is managed and the work happens), so it earns the higher slot; Topics follows as the aggregation view. Pure config reorder in `web/src/config/dashboard.ts` — no behavior change.

## Related issue

—

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

Open the dashboard: the Analytics group should read Answer Engine Insights → Prompts → Topics → Citations → Shopping. Both links still route correctly.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR