### PR TITLE
feat: add 10-per-page pagination and search filter to Top Sources (#530)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -231,8 +231,8 @@ function KpiCard({
   );
 }
 
-function TopSourceDomainsTable({ rows }: { rows: PromptTopSource[] }) {
-  const pager = usePagination(rows.length, rows.length);
+function TopSourceDomainsTable({ rows, filterKey, pageSize }: { rows: PromptTopSource[]; filterKey: string; pageSize?: number }) {
+  const pager = usePagination(rows.length, filterKey, pageSize ?? 10);
   const pageRows = rows.slice(pager.start, pager.end);
 
   return (
@@ -299,8 +299,8 @@ function TopSourceDomainsTable({ rows }: { rows: PromptTopSource[] }) {
   );
 }
 
-function TopSourceUrlsTable({ rows }: { rows: PromptTopSourceUrl[] }) {
-  const pager = usePagination(rows.length, rows.length);
+function TopSourceUrlsTable({ rows, filterKey, pageSize }: { rows: PromptTopSourceUrl[]; filterKey: string; pageSize?: number }) {
+  const pager = usePagination(rows.length, filterKey, pageSize ?? 10);
   const pageRows = rows.slice(pager.start, pager.end);
 
   return (
@@ -376,6 +376,16 @@ function TopSourcesCard({
   sources: PromptTopSource[];
   sourceUrls: PromptTopSourceUrl[];
 }) {
+  const [filter, setFilter] = useState('');
+
+  const q = filter.toLowerCase();
+  const filteredSources = q
+    ? sources.filter((s) => s.domain.toLowerCase().includes(q))
+    : sources;
+  const filteredUrls = q
+    ? sourceUrls.filter((u) => u.url.toLowerCase().includes(q) || (u.title && u.title.toLowerCase().includes(q)))
+    : sourceUrls;
+
   return (
     <Card>
       <CardHeader className="pb-3">
@@ -385,16 +395,22 @@ function TopSourcesCard({
         </p>
       </CardHeader>
       <CardContent>
+        <Input
+          placeholder="Filter by domain, URL or title..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="h-8 text-xs mb-4"
+        />
         <Tabs defaultValue="domains">
           <TabsList>
-            <TabsTrigger value="domains">Domains ({sources.length})</TabsTrigger>
-            <TabsTrigger value="urls">URLs ({sourceUrls.length})</TabsTrigger>
+            <TabsTrigger value="domains">Domains ({filteredSources.length})</TabsTrigger>
+            <TabsTrigger value="urls">URLs ({filteredUrls.length})</TabsTrigger>
           </TabsList>
           <TabsContent value="domains" keepMounted className="mt-4">
-            <TopSourceDomainsTable rows={sources} />
+            <TopSourceDomainsTable rows={filteredSources} filterKey={filter} />
           </TabsContent>
           <TabsContent value="urls" keepMounted className="mt-4">
-            <TopSourceUrlsTable rows={sourceUrls} />
+            <TopSourceUrlsTable rows={filteredUrls} filterKey={filter} />
           </TabsContent>
         </Tabs>
       </CardContent>

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -231,7 +231,15 @@ function KpiCard({
   );
 }
 
-function TopSourceDomainsTable({ rows, filterKey, pageSize }: { rows: PromptTopSource[]; filterKey: string; pageSize?: number }) {
+function TopSourceDomainsTable({
+  rows,
+  filterKey,
+  pageSize,
+}: {
+  rows: PromptTopSource[];
+  filterKey: string;
+  pageSize?: number;
+}) {
   const pager = usePagination(rows.length, filterKey, pageSize ?? 10);
   const pageRows = rows.slice(pager.start, pager.end);
 
@@ -299,7 +307,15 @@ function TopSourceDomainsTable({ rows, filterKey, pageSize }: { rows: PromptTopS
   );
 }
 
-function TopSourceUrlsTable({ rows, filterKey, pageSize }: { rows: PromptTopSourceUrl[]; filterKey: string; pageSize?: number }) {
+function TopSourceUrlsTable({
+  rows,
+  filterKey,
+  pageSize,
+}: {
+  rows: PromptTopSourceUrl[];
+  filterKey: string;
+  pageSize?: number;
+}) {
   const pager = usePagination(rows.length, filterKey, pageSize ?? 10);
   const pageRows = rows.slice(pager.start, pager.end);
 
@@ -379,11 +395,11 @@ function TopSourcesCard({
   const [filter, setFilter] = useState('');
 
   const q = filter.toLowerCase();
-  const filteredSources = q
-    ? sources.filter((s) => s.domain.toLowerCase().includes(q))
-    : sources;
+  const filteredSources = q ? sources.filter((s) => s.domain.toLowerCase().includes(q)) : sources;
   const filteredUrls = q
-    ? sourceUrls.filter((u) => u.url.toLowerCase().includes(q) || (u.title && u.title.toLowerCase().includes(q)))
+    ? sourceUrls.filter(
+        (u) => u.url.toLowerCase().includes(q) || (u.title && u.title.toLowerCase().includes(q)),
+      )
     : sourceUrls;
 
   return (

--- a/web/src/components/table-pager.tsx
+++ b/web/src/components/table-pager.tsx
@@ -16,7 +16,7 @@ export const PAGE_SIZE = 100;
  * resetKey — pass a JSON.stringify of the active filters so the pager
  * automatically jumps back to page 0 whenever any filter changes.
  */
-export function usePagination(totalRows: number, resetKey: unknown) {
+export function usePagination(totalRows: number, resetKey: unknown, pageSize: number = PAGE_SIZE) {
   const [page, setPage] = useState(0);
 
   // Adjust-state-during-render pattern: jump back to page 0 when the key changes.
@@ -26,15 +26,15 @@ export function usePagination(totalRows: number, resetKey: unknown) {
     setPage(0);
   }
 
-  const totalPages = Math.max(1, Math.ceil(totalRows / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(totalRows / pageSize));
   const clampedPage = Math.min(page, totalPages - 1);
 
   return {
     page: clampedPage,
     setPage,
     totalPages,
-    start: clampedPage * PAGE_SIZE,
-    end: Math.min((clampedPage + 1) * PAGE_SIZE, totalRows),
+    start: clampedPage * pageSize,
+    end: Math.min((clampedPage + 1) * pageSize, totalRows),
   };
 }
 


### PR DESCRIPTION
Fixes #530

## Changes

### table-pager.tsx
- Added optional `pageSize` parameter to `usePagination` (default `PAGE_SIZE = 100`)
- All existing callers unaffected (default preserved for citations page)

### Prompt detail page
- **Search filter**: added `<Input>` to `TopSourcesCard` that filters rows by case-insensitive substring match on domain, URL, and title
- **10-per-page pagination**: Top Sources tables now use `pageSize=10` (down from 100)
- Filter resets pager to page 1 via `resetKey`
- Rank numbers stay continuous across filtered pages

## Acceptance criteria
- [x] Both Top Sources tabs page through rows 10 at a time
- [x] Citations page still pages by 100 (unchanged)
- [x] Filter narrows both tabs by domain/URL/title and resets pager
- [x] Rank numbers stay continuous across pages of the filtered list
