### PR TITLE
feat(web): add citations to prompts table

### DIFF
--- a/supabase/migrations/00034_prompt_visibility_summary_citations.sql
+++ b/supabase/migrations/00034_prompt_visibility_summary_citations.sql
@@ -1,0 +1,40 @@
+-- Add citation totals to the All Prompts visibility summary (#529).
+--
+-- The return type changes, so PostgreSQL requires the existing function to
+-- be dropped before it can be recreated with the additional column.
+
+DROP FUNCTION public.prompt_visibility_summaries(uuid, timestamptz);
+
+CREATE FUNCTION public.prompt_visibility_summaries(
+  p_brand_id  uuid,
+  p_date_from timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  prompt_id       uuid,
+  avg_visibility  double precision,
+  total_mentions  bigint,
+  total_citations bigint,
+  runs            bigint,
+  last_run_at     timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT pr.prompt_id,
+         AVG(COALESCE(pr.visibility_score, 0))::double precision AS avg_visibility,
+         COALESCE(SUM(pr.mention_count), 0)::bigint              AS total_mentions,
+         COALESCE(SUM(pr.citation_count), 0)::bigint             AS total_citations,
+         COUNT(*)::bigint                                        AS runs,
+         MAX(pr.created_at)                                      AS last_run_at
+  FROM public.prompt_results pr
+  WHERE pr.brand_id = p_brand_id
+    AND pr.prompt_id IS NOT NULL
+    AND pr.platform <> 'chatgpt-shopping'  -- #155 - isolate from analytics
+    AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+  GROUP BY pr.prompt_id
+$$;
+
+GRANT EXECUTE ON FUNCTION public.prompt_visibility_summaries(uuid, timestamptz)
+  TO authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3860,3 +3860,47 @@ ALTER FUNCTION public.insights_aggregates(
   uuid, text, text[], text, timestamptz, timestamptz, uuid, uuid
 ) SECURITY INVOKER;
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00034_prompt_visibility_summary_citations.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Add citation totals to the All Prompts visibility summary (#529).
+--
+-- The return type changes, so PostgreSQL requires the existing function to
+-- be dropped before it can be recreated with the additional column.
+
+DROP FUNCTION public.prompt_visibility_summaries(uuid, timestamptz);
+
+CREATE FUNCTION public.prompt_visibility_summaries(
+  p_brand_id  uuid,
+  p_date_from timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  prompt_id       uuid,
+  avg_visibility  double precision,
+  total_mentions  bigint,
+  total_citations bigint,
+  runs            bigint,
+  last_run_at     timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT pr.prompt_id,
+         AVG(COALESCE(pr.visibility_score, 0))::double precision AS avg_visibility,
+         COALESCE(SUM(pr.mention_count), 0)::bigint              AS total_mentions,
+         COALESCE(SUM(pr.citation_count), 0)::bigint             AS total_citations,
+         COUNT(*)::bigint                                        AS runs,
+         MAX(pr.created_at)                                      AS last_run_at
+  FROM public.prompt_results pr
+  WHERE pr.brand_id = p_brand_id
+    AND pr.prompt_id IS NOT NULL
+    AND pr.platform <> 'chatgpt-shopping'  -- #155 - isolate from analytics
+    AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+  GROUP BY pr.prompt_id
+$$;
+
+GRANT EXECUTE ON FUNCTION public.prompt_visibility_summaries(uuid, timestamptz)
+  TO authenticated;
+

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -143,9 +143,15 @@ function ColHead({
 
 // ─── Sortable column header (All Prompts) ─────────────────────────────────────
 
-type AllPromptsSortKey = 'visibility' | 'mentions' | 'volume' | 'lastRun';
+type AllPromptsSortKey = 'visibility' | 'mentions' | 'citations' | 'volume' | 'lastRun';
 
-const ALL_PROMPTS_SORT_KEYS: AllPromptsSortKey[] = ['visibility', 'mentions', 'volume', 'lastRun'];
+const ALL_PROMPTS_SORT_KEYS: AllPromptsSortKey[] = [
+  'visibility',
+  'mentions',
+  'citations',
+  'volume',
+  'lastRun',
+];
 
 function isAllPromptsSortKey(value: string | null): value is AllPromptsSortKey {
   return value !== null && (ALL_PROMPTS_SORT_KEYS as string[]).includes(value);
@@ -217,6 +223,7 @@ const PROMPT_EXPORT_HEADERS = [
   'intent',
   'avg_visibility_30d',
   'total_mentions_30d',
+  'total_citations_30d',
   'runs_30d',
   'last_run_at',
 ];
@@ -1120,6 +1127,7 @@ export default function PromptsPage() {
       intent: volumeByPromptId.get(p.id)?.intent ?? '',
       avg_visibility_30d: visibility[p.id]?.avgVisibility ?? '',
       total_mentions_30d: visibility[p.id]?.totalMentions ?? '',
+      total_citations_30d: visibility[p.id]?.totalCitations ?? '',
       runs_30d: visibility[p.id]?.runs ?? '',
       last_run_at: visibility[p.id]?.lastRunAt ?? '',
     }));
@@ -1736,6 +1744,8 @@ function AllPromptsTab({
           return vis ? vis.avgVisibility : null;
         case 'mentions':
           return vis ? vis.totalMentions : null;
+        case 'citations':
+          return vis ? vis.totalCitations : null;
         case 'volume':
           return vol ? vol.estAiVolume : null;
         case 'lastRun':
@@ -1861,6 +1871,16 @@ function AllPromptsTab({
               </SortableHead>
               <SortableHead
                 className="text-right"
+                tooltip="Total times your pages were cited in AI answers for this prompt over the last 30 days."
+                sortKey="citations"
+                activeSort={activeSort}
+                dir={dir}
+                onSort={handleSort}
+              >
+                Citations
+              </SortableHead>
+              <SortableHead
+                className="text-right"
                 tooltip="Estimated monthly AI prompt volume, from keyword analysis. Empty until analysed."
                 sortKey="volume"
                 activeSort={activeSort}
@@ -1971,6 +1991,13 @@ function AllPromptsTab({
                   <TableCell className="text-right tabular-nums text-sm">
                     {vis ? (
                       vis.totalMentions.toLocaleString()
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums text-sm">
+                    {vis ? (
+                      vis.totalCitations.toLocaleString()
                     ) : (
                       <span className="text-xs text-muted-foreground">—</span>
                     )}

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -1309,6 +1309,7 @@ export async function cancelTrackingJob(jobId: string): Promise<void> {
 export interface PromptVisibilitySummary {
   avgVisibility: number;
   totalMentions: number;
+  totalCitations: number;
   runs: number;
   lastRunAt: string;
 }
@@ -1346,6 +1347,7 @@ export async function getPromptVisibilitySummaries(
     result[row.prompt_id] = {
       avgVisibility: row.avg_visibility ?? 0,
       totalMentions: Number(row.total_mentions ?? 0),
+      totalCitations: Number(row.total_citations ?? 0),
       runs: Number(row.runs ?? 0),
       lastRunAt: row.last_run_at,
     };

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -1372,6 +1372,7 @@ export type Database = {
           prompt_id: string;
           avg_visibility: number;
           total_mentions: number;
+          total_citations: number;
           runs: number;
           last_run_at: string;
         }[];


### PR DESCRIPTION
## Summary

Adds citation totals to the All Prompts table and CSV export so prompts that are cited but not directly mentioned are visible.

- Extends `prompt_visibility_summaries` with `total_citations`
- Preserves `SECURITY INVOKER`, the `chatgpt-shopping` exclusion, and existing grants
- Adds `totalCitations` to the prompt visibility loader and Supabase types
- Adds a sortable Citations column beside Mentions
- Displays `—` for prompts without tracking runs
- Adds `total_citations_30d` beside `total_mentions_30d` in CSV exports
- Regenerates `supabase/schema.sql`

## Related issue

Closes #529

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [ ] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

## Testing

- All 47 web tests pass
- All changed TypeScript files pass Prettier
- `git diff --check` passes
- `npm run version:check` passes
- `supabase/schema.sql` regenerates reproducibly from all migrations

The repository-wide formatting check reports existing CRLF differences in untouched files in this Windows checkout. All files modified by this PR pass Prettier individually.