### PR TITLE
fix(prompts): surface savePromptSet failures instead of the masked digest error

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -236,7 +236,7 @@ export default function PromptsPage() {
       let targetSetId = promptSets[0]?.id;
 
       if (!targetSetId) {
-        const newSet = await savePromptSet({
+        const result = await savePromptSet({
           brandId,
           name: 'Prompts',
           prompts: activePrompts.map((p) => ({
@@ -246,7 +246,11 @@ export default function PromptsPage() {
             models: defaultModels,
           })),
         });
-        targetSetId = newSet.id;
+        if ('error' in result) {
+          toast.error(result.error);
+          return;
+        }
+        targetSetId = result.promptSet.id;
       } else {
         await Promise.all(
           activePrompts.map((p) =>
@@ -291,11 +295,15 @@ export default function PromptsPage() {
           ...promptData,
         });
       } else {
-        await savePromptSet({
+        const result = await savePromptSet({
           brandId,
           name: `Prompts`,
           prompts: [promptData],
         });
+        if ('error' in result) {
+          toast.error(result.error);
+          return;
+        }
       }
 
       setManualText('');

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
@@ -1097,10 +1097,7 @@ export default function NewBrandPage() {
 
           <div className="mb-4">
             <p className="text-sm font-medium">Your Prompt List</p>
-            <p className="text-xs text-muted-foreground">
-              {totalPrompts} prompts total
-              {promptLimit !== null ? ` · up to ${promptLimit} included in your plan` : ''}
-            </p>
+            <p className="text-xs text-muted-foreground">{totalPrompts} prompts total</p>
           </div>
 
           <div className="rounded-lg border">

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
@@ -562,11 +562,15 @@ export default function NewBrandPage() {
         return;
       }
 
-      await savePromptSet({
+      const result = await savePromptSet({
         brandId: createdBrand.id,
         name: 'Brand Setup Prompts',
         prompts: allPrompts,
       });
+      if ('error' in result) {
+        toast.error(result.error);
+        return;
+      }
 
       setStep(5);
       fetchCompetitorSuggestions();

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
@@ -6,7 +6,7 @@ import { createClient } from '@/lib/supabase/client';
 import { createBrand, updateBrand } from '@/lib/actions/brand';
 import { syncDomains } from '@/lib/actions/brand-domain';
 import { createTopics } from '@/lib/actions/topic';
-import { savePromptSet } from '@/lib/actions/prompt';
+import { getPromptCapacity, savePromptSet } from '@/lib/actions/prompt';
 import { addCompetitor } from '@/lib/actions/competitor';
 import { triggerTrackingCheck } from '@/lib/actions/tracking';
 import { usePlanContext } from '@/components/providers/plan-provider';
@@ -262,6 +262,11 @@ export default function NewBrandPage() {
   // Step 4
   const [topicPrompts, setTopicPrompts] = useState<TopicPromptsData[]>([]);
   const [loadingPrompts, setLoadingPrompts] = useState(false);
+  const [promptCapacity, setPromptCapacity] = useState<{
+    maxPrompts: number;
+    used: number;
+  } | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // Step 5
   interface CompetitorItem {
@@ -314,6 +319,17 @@ export default function NewBrandPage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step]);
+
+  // Know the plan's prompt cap while reviewing, so the step can warn and
+  // disable Continue instead of failing the save afterwards.
+  useEffect(() => {
+    if (step === 4 && createdBrand && !promptCapacity) {
+      getPromptCapacity(createdBrand.id)
+        .then(setPromptCapacity)
+        .catch(() => {});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, createdBrand]);
 
   // Load current plan from org on mount
   useEffect(() => {
@@ -545,6 +561,7 @@ export default function NewBrandPage() {
   const handleSavePromptsAndContinue = async () => {
     if (!createdBrand) return;
     setIsLoading(true);
+    setSaveError(null);
     try {
       const allPrompts = topicPrompts.flatMap((tp) =>
         tp.prompts.map((text) => ({
@@ -557,7 +574,7 @@ export default function NewBrandPage() {
       );
 
       if (allPrompts.length === 0) {
-        toast.error('Add at least one prompt before continuing');
+        setSaveError('Add at least one prompt before continuing.');
         setIsLoading(false);
         return;
       }
@@ -568,14 +585,20 @@ export default function NewBrandPage() {
         prompts: allPrompts,
       });
       if ('error' in result) {
-        toast.error(result.error);
+        // No technical toasts on this step: actionable failures (plan limit)
+        // show verbatim inline, anything else gets a friendly retry message.
+        setSaveError(
+          result.code === 'plan_limit'
+            ? result.error
+            : "We couldn't save your prompts — please try again.",
+        );
         return;
       }
 
       setStep(5);
       fetchCompetitorSuggestions();
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to save prompts');
+    } catch {
+      setSaveError("We couldn't save your prompts — please try again.");
     } finally {
       setIsLoading(false);
     }
@@ -704,6 +727,13 @@ export default function NewBrandPage() {
   };
 
   const totalPrompts = topicPrompts.reduce((sum, tp) => sum + tp.prompts.length, 0);
+  // Prompts this brand may save before hitting the org's plan cap (null =
+  // unknown or unlimited); over that, Continue is disabled with an inline hint.
+  const promptLimit =
+    promptCapacity && promptCapacity.maxPrompts !== -1
+      ? Math.max(0, promptCapacity.maxPrompts - promptCapacity.used)
+      : null;
+  const excessPrompts = promptLimit !== null ? Math.max(0, totalPrompts - promptLimit) : 0;
 
   // ── Step 1: Brand Info ──
 
@@ -1039,7 +1069,7 @@ export default function NewBrandPage() {
             </div>
             <Button
               onClick={handleSavePromptsAndContinue}
-              disabled={isLoading || totalPrompts === 0}
+              disabled={isLoading || totalPrompts === 0 || excessPrompts > 0}
             >
               {isLoading ? (
                 <>
@@ -1052,9 +1082,25 @@ export default function NewBrandPage() {
             </Button>
           </div>
 
+          {excessPrompts > 0 && (
+            <div className="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
+              Your plan includes up to {promptLimit} prompts for this brand — remove {excessPrompts}{' '}
+              to continue.
+            </div>
+          )}
+
+          {saveError && excessPrompts === 0 && (
+            <div className="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
+              {saveError}
+            </div>
+          )}
+
           <div className="mb-4">
             <p className="text-sm font-medium">Your Prompt List</p>
-            <p className="text-xs text-muted-foreground">{totalPrompts} prompts total</p>
+            <p className="text-xs text-muted-foreground">
+              {totalPrompts} prompts total
+              {promptLimit !== null ? ` · up to ${promptLimit} included in your plan` : ''}
+            </p>
           </div>
 
           <div className="rounded-lg border">

--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -1359,10 +1359,7 @@ export default function OnboardingPage() {
 
           <div className="mb-4">
             <p className="text-sm font-medium">Your Prompt List</p>
-            <p className="text-xs text-muted-foreground">
-              {totalPrompts} prompts total
-              {promptLimit !== null ? ` · up to ${promptLimit} included in your plan` : ''}
-            </p>
+            <p className="text-xs text-muted-foreground">{totalPrompts} prompts total</p>
           </div>
 
           <div className="rounded-lg border">

--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { createBrand } from '@/lib/actions/brand';
 import { createTopics, getTopics } from '@/lib/actions/topic';
-import { savePromptSet } from '@/lib/actions/prompt';
+import { getPromptCapacity, savePromptSet } from '@/lib/actions/prompt';
 import { triggerTrackingCheck } from '@/lib/actions/tracking';
 import { addCompetitor, getCompetitors } from '@/lib/actions/competitor';
 import { getFaviconUrl } from '@/lib/favicon';
@@ -273,6 +273,11 @@ export default function OnboardingPage() {
   const [topicPrompts, setTopicPrompts] = useState<TopicPromptsData[]>([]);
   const [loadingPrompts, setLoadingPrompts] = useState(false);
   const [promptGenError, setPromptGenError] = useState(false);
+  const [promptCapacity, setPromptCapacity] = useState<{
+    maxPrompts: number;
+    used: number;
+  } | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // Step 5
   interface CompetitorItem {
@@ -337,6 +342,17 @@ export default function OnboardingPage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step, initialLoading]);
+
+  // Know the plan's prompt cap while reviewing, so the step can warn and
+  // disable Continue instead of failing the save afterwards.
+  useEffect(() => {
+    if (step === 4 && createdBrand && !promptCapacity) {
+      getPromptCapacity(createdBrand.id)
+        .then(setPromptCapacity)
+        .catch(() => {});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, createdBrand]);
 
   // Resume logic: check existing state on mount
   useEffect(() => {
@@ -704,6 +720,7 @@ export default function OnboardingPage() {
   const handleSavePromptsAndContinue = async () => {
     if (!createdBrand) return;
     setIsLoading(true);
+    setSaveError(null);
     try {
       const allPrompts = topicPrompts.flatMap((tp) =>
         tp.prompts.map((text) => ({
@@ -716,7 +733,7 @@ export default function OnboardingPage() {
       );
 
       if (allPrompts.length === 0) {
-        toast.error('Add at least one prompt before continuing');
+        setSaveError('Add at least one prompt before continuing.');
         setIsLoading(false);
         return;
       }
@@ -727,7 +744,13 @@ export default function OnboardingPage() {
         prompts: allPrompts,
       });
       if ('error' in result) {
-        toast.error(result.error);
+        // No technical toasts on this step: actionable failures (plan limit)
+        // show verbatim inline, anything else gets a friendly retry message.
+        setSaveError(
+          result.code === 'plan_limit'
+            ? result.error
+            : "We couldn't save your prompts — please try again.",
+        );
         return;
       }
       track('onboarding_prompts_saved', { count: allPrompts.length });
@@ -740,8 +763,8 @@ export default function OnboardingPage() {
 
       setStep(5);
       fetchCompetitorSuggestions();
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to save prompts');
+    } catch {
+      setSaveError("We couldn't save your prompts — please try again.");
     } finally {
       setIsLoading(false);
     }
@@ -938,6 +961,13 @@ export default function OnboardingPage() {
   };
 
   const totalPrompts = topicPrompts.reduce((sum, tp) => sum + tp.prompts.length, 0);
+  // Prompts this brand may save before hitting the org's plan cap (null =
+  // unknown or unlimited); over that, Continue is disabled with an inline hint.
+  const promptLimit =
+    promptCapacity && promptCapacity.maxPrompts !== -1
+      ? Math.max(0, promptCapacity.maxPrompts - promptCapacity.used)
+      : null;
+  const excessPrompts = promptLimit !== null ? Math.max(0, totalPrompts - promptLimit) : 0;
 
   // ── Loading state ──
 
@@ -1295,7 +1325,7 @@ export default function OnboardingPage() {
             </div>
             <Button
               onClick={handleSavePromptsAndContinue}
-              disabled={isLoading || totalPrompts === 0}
+              disabled={isLoading || totalPrompts === 0 || excessPrompts > 0}
             >
               {isLoading ? (
                 <>
@@ -1315,9 +1345,24 @@ export default function OnboardingPage() {
             </div>
           )}
 
+          {excessPrompts > 0 && (
+            <div className="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
+              Your plan includes up to {promptLimit} prompts — remove {excessPrompts} to continue.
+            </div>
+          )}
+
+          {saveError && excessPrompts === 0 && (
+            <div className="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
+              {saveError}
+            </div>
+          )}
+
           <div className="mb-4">
             <p className="text-sm font-medium">Your Prompt List</p>
-            <p className="text-xs text-muted-foreground">{totalPrompts} prompts total</p>
+            <p className="text-xs text-muted-foreground">
+              {totalPrompts} prompts total
+              {promptLimit !== null ? ` · up to ${promptLimit} included in your plan` : ''}
+            </p>
           </div>
 
           <div className="rounded-lg border">

--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -721,11 +721,15 @@ export default function OnboardingPage() {
         return;
       }
 
-      await savePromptSet({
+      const result = await savePromptSet({
         brandId: createdBrand.id,
         name: 'Onboarding Prompts',
         prompts: allPrompts,
       });
+      if ('error' in result) {
+        toast.error(result.error);
+        return;
+      }
       track('onboarding_prompts_saved', { count: allPrompts.length });
       track('onboarding_step_completed', {
         step: 4,

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -151,7 +151,15 @@ interface SavePromptSetInput {
   }[];
 }
 
-export async function savePromptSet(input: SavePromptSetInput): Promise<PromptSet> {
+export type SavePromptSetResult = { promptSet: PromptSet } | { error: string };
+
+/**
+ * User-facing failures (plan limit, empty platform selection, DB errors) come
+ * back as a VALUE: production masks every error thrown from a server action,
+ * so a thrown PlanLimitError would reach users as the meaningless digest
+ * message (#427).
+ */
+export async function savePromptSet(input: SavePromptSetInput): Promise<SavePromptSetResult> {
   const supabase = await createClient();
 
   const { organizationId: orgId, region: brandRegion } = await getBrandContext(
@@ -170,7 +178,18 @@ export async function savePromptSet(input: SavePromptSetInput): Promise<PromptSe
     .eq('prompt_sets.brand_id', input.brandId);
 
   const otherPrompts = totalOrgPrompts - (brandPromptCount ?? 0);
-  await enforceLimit(orgId, 'maxPrompts', otherPrompts + input.prompts.length - 1);
+
+  // Inclusive cap: saving exactly maxPrompts is allowed; only reject when the
+  // resulting total would exceed it. Spell out the counts so the user knows
+  // exactly how many prompts to remove (onboarding generates 5 per topic, so
+  // hitting the cap there is a normal, recoverable state).
+  const maxPrompts = plan.limits.maxPrompts;
+  const requestedTotal = otherPrompts + input.prompts.length;
+  if (maxPrompts !== -1 && requestedTotal > maxPrompts) {
+    return {
+      error: `Your ${plan.name} plan allows up to ${maxPrompts} tracked prompts and this would save ${requestedTotal}. Remove ${requestedTotal - maxPrompts} prompt${requestedTotal - maxPrompts === 1 ? '' : 's'} to continue, or upgrade your plan.`,
+    };
+  }
 
   // Delete existing prompt sets for this brand to avoid duplicates
   // (e.g. user navigated back during onboarding and re-submitted)
@@ -196,7 +215,7 @@ export async function savePromptSet(input: SavePromptSetInput): Promise<PromptSe
     .single();
 
   if (setError || !set) {
-    throw new Error(setError?.message ?? 'Failed to create prompt set');
+    return { error: setError?.message ?? 'Failed to create prompt set' };
   }
 
   // Insert prompts
@@ -221,36 +240,37 @@ export async function savePromptSet(input: SavePromptSetInput): Promise<PromptSe
       }),
     );
 
+    const rows = [];
+    for (const p of input.prompts) {
+      const filtered = filterByPlan(plan, p.platforms, p.models ?? []);
+      const platforms = stripShoppingWhenDisabled(filtered.platforms, shoppingEnabled);
+      if (platforms.length === 0 && filtered.models.length === 0) {
+        return { error: 'At least one platform or model must be selected for each prompt.' };
+      }
+      rows.push({
+        prompt_set_id: set.id,
+        text: p.text,
+        category: p.category || null,
+        topic_id: (p.category && topicIdMap.get(p.category)) || null,
+        platforms,
+        regions: [brandRegion],
+        models: filtered.models,
+        is_active: p.isActive ?? true,
+      });
+    }
+
     const { data: prompts, error: promptError } = await supabase
       .from('prompts')
-      .insert(
-        input.prompts.map((p) => {
-          const filtered = filterByPlan(plan, p.platforms, p.models ?? []);
-          const platforms = stripShoppingWhenDisabled(filtered.platforms, shoppingEnabled);
-          if (platforms.length === 0 && filtered.models.length === 0) {
-            throw new Error('At least one platform or model must be selected for each prompt.');
-          }
-          return {
-            prompt_set_id: set.id,
-            text: p.text,
-            category: p.category || null,
-            topic_id: (p.category && topicIdMap.get(p.category)) || null,
-            platforms,
-            regions: [brandRegion],
-            models: filtered.models,
-            is_active: p.isActive ?? true,
-          };
-        }),
-      )
+      .insert(rows)
       .select();
 
-    if (promptError) throw new Error(promptError.message);
+    if (promptError) return { error: promptError.message };
     insertedPrompts = (prompts as Record<string, unknown>[]) ?? [];
   }
 
   revalidatePath('/dashboard/brands');
 
-  return mapPromptSetRow(set as Record<string, unknown>, insertedPrompts);
+  return { promptSet: mapPromptSetRow(set as Record<string, unknown>, insertedPrompts) };
 }
 
 export async function updatePrompt(

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -151,7 +151,31 @@ interface SavePromptSetInput {
   }[];
 }
 
-export type SavePromptSetResult = { promptSet: PromptSet } | { error: string };
+export type SavePromptSetResult = { promptSet: PromptSet } | { error: string; code?: 'plan_limit' };
+
+/**
+ * How many prompts a brand's save may total before hitting the org's plan cap.
+ * `used` counts prompts on the org's OTHER brands only — savePromptSet
+ * replaces this brand's own set, so its current prompts don't count against a
+ * re-save. Lets the setup wizards gate the review step inline (counter +
+ * disabled Continue) instead of failing the save after the fact.
+ */
+export async function getPromptCapacity(
+  brandId: string,
+): Promise<{ maxPrompts: number; used: number }> {
+  const supabase = await createClient();
+  const { organizationId: orgId } = await getBrandContext(supabase, brandId);
+  const plan = await getOrgPlan(orgId);
+  const totalOrgPrompts = await getOrgPromptCount(supabase, orgId);
+  const { count: brandPromptCount } = await supabase
+    .from('prompts')
+    .select('id, prompt_sets!inner(brand_id)', { count: 'exact', head: true })
+    .eq('prompt_sets.brand_id', brandId);
+  return {
+    maxPrompts: plan.limits.maxPrompts,
+    used: totalOrgPrompts - (brandPromptCount ?? 0),
+  };
+}
 
 /**
  * User-facing failures (plan limit, empty platform selection, DB errors) come
@@ -187,6 +211,7 @@ export async function savePromptSet(input: SavePromptSetInput): Promise<SaveProm
   const requestedTotal = otherPrompts + input.prompts.length;
   if (maxPrompts !== -1 && requestedTotal > maxPrompts) {
     return {
+      code: 'plan_limit',
       error: `Your ${plan.name} plan allows up to ${maxPrompts} tracked prompts and this would save ${requestedTotal}. Remove ${requestedTotal - maxPrompts} prompt${requestedTotal - maxPrompts === 1 ? '' : 's'} to continue, or upgrade your plan.`,
     };
   }


### PR DESCRIPTION
## Summary

A new user got stuck on the onboarding prompt-review step: pressing Continue showed the production-masked toast `An error occurred in the Server Components render…` and the prompts were never saved. Supabase API logs show the request chain stopping right at the prompt-limit check — `enforceLimit` threw `PlanLimitError`, and since errors thrown from server actions are masked in production, the user never saw the real reason (over the plan's prompt cap after adding their own prompts on top of the generated ones).

Two layers of fix:

**Server action (`savePromptSet`)**
- Now returns `{ promptSet } | { error, code? }` instead of throwing for user-facing failures (plan limit, empty platform/model selection, DB errors) — same pattern as `addPromptToBrand` (#427). Plan-limit failures carry `code: 'plan_limit'`.
- The prompt cap check is explicit and inclusive: saving exactly `maxPrompts` (e.g. 50 on Starter) passes; only totals **above** the cap are rejected.
- Dropped the duplicate `getOrgPlan` round-trip.
- New `getPromptCapacity(brandId)` action exposes `{ maxPrompts, used }` (used = prompts on the org's *other* brands, since a save replaces the brand's own set).

**Review step UX (onboarding + brand setup wizard) — no error toasts at all**
- The step fetches capacity when it opens and shows `X prompts total · up to N included in your plan`.
- Going over the cap disables Continue and shows an inline amber hint: "Your plan includes up to N prompts — remove X to continue." The user fixes it in place; the save is never even attempted.
- If a save still fails (race/backend), the step renders an inline message instead of a toast: the plan-limit text verbatim (actionable), anything else as a friendly "We couldn't save your prompts — please try again." Raw error strings never reach the user on this step.
- The brand prompts page (dashboard) keeps toasts but now gets the real message instead of the masked digest.

## Related issue

Follow-up to #427 (same masking bug, different action).

## Type of change

- [x] `fix` — Bug fix

## How to test

1. On cloud with a Starter-limited org (or an org still in onboarding), generate prompts on the review step and add manual prompts until the total exceeds 50.
2. The counter reads `51 prompts total · up to 50 included in your plan`, an inline hint says to remove 1, and Continue is disabled — no toast anywhere.
3. Remove the extra prompt(s) so the total is exactly 50 → Continue enables and the wizard advances to competitors.
4. Repeat on Dashboard → Brands → New brand (same wizard, other brands' prompts count against the cap).
5. Brands → \[brand] → Prompts: saving suggestions into a brand with no prompt set and adding a manual prompt still work; over-limit saves toast the real message there.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR