### PR TITLE
fix(server): key the API rate limiter by auth token instead of IP

### DIFF
--- a/server/src/middleware/index.js
+++ b/server/src/middleware/index.js
@@ -1,5 +1,6 @@
 import supabaseAdmin from '../config/supabase.js';
 import logger from '../lib/logger.js';
+import { markTokenVerified } from './verified-tokens.js';
 
 class Middleware {
   async decodeTokenForSocket(socket, next) {
@@ -44,6 +45,9 @@ class Middleware {
       if (error || !user) {
         return res.status(401).json({ message: 'Unauthorized API Request' });
       }
+
+      // Promote this token to a per-user rate-limit bucket (see rate-limiter.js)
+      markTokenVerified(req.headers.authorization, user.id);
 
       req.user = user;
       return next();

--- a/server/src/middleware/rate-limiter.js
+++ b/server/src/middleware/rate-limiter.js
@@ -1,9 +1,49 @@
 import rateLimit from 'express-rate-limit';
+import { createHash } from 'node:crypto';
 
-// General API rate limit: 100 requests per 15 minutes
+/**
+ * Anonymous bucket key. IPv4 (including v4-mapped IPv6) keys on the exact
+ * address; plain IPv6 collapses to the /64 prefix so one caller can't dodge
+ * the limit by rotating through their subnet's practically unlimited
+ * addresses.
+ */
+export function anonymousIpKey(ip) {
+  if (!ip) return 'ip:unknown';
+  if (!ip.includes(':') || ip.includes('.')) return 'ip:' + ip;
+  const [head, tail = ''] = ip.split('::');
+  const headGroups = head ? head.split(':') : [];
+  const tailGroups = tail ? tail.split(':') : [];
+  const zeros = Array(Math.max(0, 8 - headGroups.length - tailGroups.length)).fill('0');
+  const prefix = [...headGroups, ...zeros, ...tailGroups].slice(0, 4).join(':');
+  return 'ip:' + prefix + '::/64';
+}
+
+/**
+ * Key authenticated dashboard traffic by bearer token, not by IP. The web
+ * app's server actions all egress through Vercel's small shared IP pool, so an
+ * IP-keyed limiter lumps every user's server-side traffic (volume analyses,
+ * tracking-status polls, page loads…) into a handful of buckets and 429s
+ * legitimate users while browser-direct calls sail through. The token is
+ * hashed so raw JWTs never sit in the limiter's store, and it doesn't need to
+ * be verified here — a forged token just earns its own bucket. Anonymous
+ * requests still fall back to the caller IP.
+ */
+export function apiLimiterKey(req) {
+  const auth = req.headers.authorization;
+  if (auth) {
+    return 'token:' + createHash('sha256').update(auth).digest('hex').slice(0, 32);
+  }
+  return anonymousIpKey(req.ip);
+}
+
+// General API rate limit, per user token (per IP when unauthenticated)
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 250,
+  // Authenticated buckets are per user, so the ceiling only needs to absorb a
+  // single user's own burst (several tabs polling tracking status every 15s
+  // plus normal navigation). Anonymous traffic keeps the tighter IP limit.
+  max: (req) => (req.headers.authorization ? 1000 : 250),
+  keyGenerator: apiLimiterKey,
   standardHeaders: true,
   legacyHeaders: false,
   message: {

--- a/server/src/middleware/rate-limiter.js
+++ b/server/src/middleware/rate-limiter.js
@@ -1,5 +1,5 @@
 import rateLimit from 'express-rate-limit';
-import { createHash } from 'node:crypto';
+import { verifiedUserId } from './verified-tokens.js';
 
 /**
  * Anonymous bucket key. IPv4 (including v4-mapped IPv6) keys on the exact
@@ -19,30 +19,33 @@ export function anonymousIpKey(ip) {
 }
 
 /**
- * Key authenticated dashboard traffic by bearer token, not by IP. The web
- * app's server actions all egress through Vercel's small shared IP pool, so an
+ * Key dashboard traffic by VERIFIED user, falling back to IP. The web app's
+ * server actions all egress through Vercel's small shared IP pool, so a purely
  * IP-keyed limiter lumps every user's server-side traffic (volume analyses,
  * tracking-status polls, page loads…) into a handful of buckets and 429s
- * legitimate users while browser-direct calls sail through. The token is
- * hashed so raw JWTs never sit in the limiter's store, and it doesn't need to
- * be verified here — a forged token just earns its own bucket. Anonymous
- * requests still fall back to the caller IP.
+ * legitimate users while browser-direct calls sail through.
+ *
+ * The per-user bucket is granted only to tokens decodeToken has already
+ * verified (see verified-tokens.js): merely ATTACHING an Authorization header
+ * earns nothing, so an attacker spamming forged tokens stays pinned to their
+ * IP bucket. A legit token's first-ever request counts against the IP bucket
+ * too (it isn't verified yet) — one request per token per half hour, noise.
+ * Rotating IPs to evade the anonymous limit remains an infra-level concern
+ * (WAF/CDN), same as before this limiter existed.
  */
 export function apiLimiterKey(req) {
-  const auth = req.headers.authorization;
-  if (auth) {
-    return 'token:' + createHash('sha256').update(auth).digest('hex').slice(0, 32);
-  }
+  const userId = verifiedUserId(req.headers.authorization);
+  if (userId) return 'user:' + userId;
   return anonymousIpKey(req.ip);
 }
 
-// General API rate limit, per user token (per IP when unauthenticated)
+// General API rate limit, per verified user (per IP otherwise)
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  // Authenticated buckets are per user, so the ceiling only needs to absorb a
-  // single user's own burst (several tabs polling tracking status every 15s
-  // plus normal navigation). Anonymous traffic keeps the tighter IP limit.
-  max: (req) => (req.headers.authorization ? 1000 : 250),
+  // A verified user's bucket only needs to absorb their own burst (several
+  // tabs polling tracking status every 15s plus normal navigation).
+  // Unverified traffic keeps the tighter IP limit.
+  max: (req) => (verifiedUserId(req.headers.authorization) ? 1000 : 250),
   keyGenerator: apiLimiterKey,
   standardHeaders: true,
   legacyHeaders: false,

--- a/server/src/middleware/rate-limiter.test.js
+++ b/server/src/middleware/rate-limiter.test.js
@@ -1,27 +1,44 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { apiLimiterKey } from './rate-limiter.js';
+import { markTokenVerified, clearVerifiedTokens } from './verified-tokens.js';
 
 function reqWith({ authorization, ip = '203.0.113.7' } = {}) {
   return { headers: authorization ? { authorization } : {}, ip };
 }
 
 describe('rate-limiter – apiLimiterKey', () => {
-  it('buckets authenticated requests by token, not by IP', () => {
-    const sameTokenA = apiLimiterKey(reqWith({ authorization: 'Bearer tok-1', ip: '1.1.1.1' }));
-    const sameTokenB = apiLimiterKey(reqWith({ authorization: 'Bearer tok-1', ip: '2.2.2.2' }));
-    expect(sameTokenA).toBe(sameTokenB);
-    expect(sameTokenA.startsWith('token:')).toBe(true);
+  beforeEach(() => clearVerifiedTokens());
+
+  it('keeps unverified Authorization headers in the caller IP bucket', () => {
+    const forged = apiLimiterKey(reqWith({ authorization: 'Bearer forged-1', ip: '1.1.1.1' }));
+    const forged2 = apiLimiterKey(reqWith({ authorization: 'Bearer forged-2', ip: '1.1.1.1' }));
+    const anonymous = apiLimiterKey(reqWith({ ip: '1.1.1.1' }));
+    expect(forged).toBe(anonymous);
+    expect(forged2).toBe(anonymous);
   });
 
-  it('gives different tokens different buckets even from the same IP', () => {
+  it('buckets verified tokens by user across IPs', () => {
+    markTokenVerified('Bearer tok-1', 'user-a');
+    const a = apiLimiterKey(reqWith({ authorization: 'Bearer tok-1', ip: '1.1.1.1' }));
+    const b = apiLimiterKey(reqWith({ authorization: 'Bearer tok-1', ip: '2.2.2.2' }));
+    expect(a).toBe('user:user-a');
+    expect(b).toBe('user:user-a');
+  });
+
+  it('maps a refreshed token for the same user to the same bucket', () => {
+    markTokenVerified('Bearer tok-old', 'user-a');
+    markTokenVerified('Bearer tok-new', 'user-a');
+    const oldKey = apiLimiterKey(reqWith({ authorization: 'Bearer tok-old' }));
+    const newKey = apiLimiterKey(reqWith({ authorization: 'Bearer tok-new' }));
+    expect(oldKey).toBe(newKey);
+  });
+
+  it('gives different verified users different buckets', () => {
+    markTokenVerified('Bearer tok-1', 'user-a');
+    markTokenVerified('Bearer tok-2', 'user-b');
     const a = apiLimiterKey(reqWith({ authorization: 'Bearer tok-1' }));
     const b = apiLimiterKey(reqWith({ authorization: 'Bearer tok-2' }));
     expect(a).not.toBe(b);
-  });
-
-  it('never stores the raw token in the key', () => {
-    const key = apiLimiterKey(reqWith({ authorization: 'Bearer super-secret-jwt' }));
-    expect(key).not.toContain('super-secret-jwt');
   });
 
   it('falls back to the caller IP for anonymous requests', () => {

--- a/server/src/middleware/rate-limiter.test.js
+++ b/server/src/middleware/rate-limiter.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { apiLimiterKey } from './rate-limiter.js';
+
+function reqWith({ authorization, ip = '203.0.113.7' } = {}) {
+  return { headers: authorization ? { authorization } : {}, ip };
+}
+
+describe('rate-limiter – apiLimiterKey', () => {
+  it('buckets authenticated requests by token, not by IP', () => {
+    const sameTokenA = apiLimiterKey(reqWith({ authorization: 'Bearer tok-1', ip: '1.1.1.1' }));
+    const sameTokenB = apiLimiterKey(reqWith({ authorization: 'Bearer tok-1', ip: '2.2.2.2' }));
+    expect(sameTokenA).toBe(sameTokenB);
+    expect(sameTokenA.startsWith('token:')).toBe(true);
+  });
+
+  it('gives different tokens different buckets even from the same IP', () => {
+    const a = apiLimiterKey(reqWith({ authorization: 'Bearer tok-1' }));
+    const b = apiLimiterKey(reqWith({ authorization: 'Bearer tok-2' }));
+    expect(a).not.toBe(b);
+  });
+
+  it('never stores the raw token in the key', () => {
+    const key = apiLimiterKey(reqWith({ authorization: 'Bearer super-secret-jwt' }));
+    expect(key).not.toContain('super-secret-jwt');
+  });
+
+  it('falls back to the caller IP for anonymous requests', () => {
+    const a = apiLimiterKey(reqWith({ ip: '1.1.1.1' }));
+    const b = apiLimiterKey(reqWith({ ip: '2.2.2.2' }));
+    expect(a).not.toBe(b);
+    expect(a).toContain('1.1.1.1');
+  });
+
+  it('collapses an IPv6 subnet into one anonymous bucket', () => {
+    const a = apiLimiterKey(reqWith({ ip: '2001:db8:abcd:12::1' }));
+    const b = apiLimiterKey(reqWith({ ip: '2001:db8:abcd:12::2' }));
+    expect(a).toBe(b);
+  });
+
+  it('keeps v4-mapped IPv6 addresses distinct per IPv4 address', () => {
+    const a = apiLimiterKey(reqWith({ ip: '::ffff:1.1.1.1' }));
+    const b = apiLimiterKey(reqWith({ ip: '::ffff:2.2.2.2' }));
+    expect(a).not.toBe(b);
+  });
+});

--- a/server/src/middleware/verified-tokens.js
+++ b/server/src/middleware/verified-tokens.js
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Short-lived cache of Authorization headers that decodeToken has already
+ * verified against Supabase Auth, mapped to their user id. The rate limiter
+ * consults it to give real users per-user buckets WITHOUT trusting the header
+ * blindly: a forged or garbage token never gets verified, so it never earns a
+ * bucket of its own and keeps counting against the caller's IP limit.
+ *
+ * Only the SHA-256 of the header is stored, never the raw JWT. Entries expire
+ * after 30 minutes (well under the token's own lifetime) and the map is
+ * capped, evicting oldest-inserted first, so it can't grow unbounded.
+ */
+const TTL_MS = 30 * 60 * 1000;
+const MAX_ENTRIES = 5000;
+const cache = new Map();
+
+function hashAuthHeader(authorizationHeader) {
+  return createHash('sha256').update(authorizationHeader).digest('hex').slice(0, 32);
+}
+
+export function markTokenVerified(authorizationHeader, userId) {
+  if (!authorizationHeader || !userId) return;
+  if (cache.size >= MAX_ENTRIES) {
+    cache.delete(cache.keys().next().value);
+  }
+  cache.set(hashAuthHeader(authorizationHeader), {
+    userId,
+    expiresAt: Date.now() + TTL_MS,
+  });
+}
+
+export function verifiedUserId(authorizationHeader) {
+  if (!authorizationHeader) return null;
+  const key = hashAuthHeader(authorizationHeader);
+  const hit = cache.get(key);
+  if (!hit) return null;
+  if (hit.expiresAt < Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+  return hit.userId;
+}
+
+// Test hook — the limiter's behavior depends on cache state.
+export function clearVerifiedTokens() {
+  cache.clear();
+}


### PR DESCRIPTION
## Summary

A user pressing **Analyze Prompts** got a bare `Volume analysis failed` toast. Vercel runtime logs show the real cause: the Express API answered **429 Too Many Requests** (`Error: Server error: 429` on `POST /dashboard/prompts`, repeatedly).

The dashboard API limiter (`app.use('/api', apiLimiter)`) allows 250 requests / 15 min **per IP**. But every web-app server action (volume analyses, `getPromptVolumes` page loads, tracking-status polls every 15s per open tab…) reaches the Express server from **Vercel's small shared egress IP pool** — so the whole platform's server-side traffic competes for a handful of IP buckets and legitimate users get 429s, while browser-direct calls (user's own IP) sail through. That's why only server-action-backed features appeared broken.

Fix — per-user buckets, but only for **verified** users:

- `decodeToken` already verifies every token against Supabase Auth; on success it now records the token (SHA-256 hash only, never the raw JWT) in a short-lived capped cache (`verified-tokens.js`, 30 min TTL, 5k entries, oldest-first eviction).
- `apiLimiter` keys requests whose token is in that cache as `user:<id>` with a 1000/15min ceiling (sized for one user's own burst: several tabs polling every 15s plus navigation).
- Everything else — anonymous traffic AND forged/garbage Authorization headers — stays pinned to the caller's 250/15min IP bucket, so spamming random tokens cannot mint fresh buckets. A legit token's first-ever request counts against the IP bucket once (it isn't verified yet); after that it rides its user bucket. A refreshed token maps to the same user bucket.
- Anonymous IPv6 collapses to its /64 prefix so a caller can't rotate through a subnet; IPv4 and v4-mapped IPv6 stay per-address. IP *rotation* at scale remains an infra concern (WAF/CDN) — same as before this change.
- `publicLimiter`, `trafficLimiter`, `authLimiter` are unchanged (they guard unauthenticated surfaces where IP keying is correct).

## Related issue

—

## Type of change

- [x] `fix` — Bug fix

## How to test

1. `cd server && yarn test` — `rate-limiter.test.js` covers: unverified/forged headers share the IP bucket, verified tokens bucket per user across IPs, refreshed token ⇒ same user bucket, distinct users ⇒ distinct buckets, anonymous per-IP fallback, IPv6 /64 collapsing, v4-mapped IPv6 per-address.
2. Manually: authenticated `/api` traffic no longer 429s at 250/15min per shared IP; requests with a made-up bearer token still 429 at the IP limit.
3. In production: **Analyze Prompts** on a brand with many prompts completes instead of failing instantly.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] Server test suite passes (`cd server && yarn test`)
- [x] Prettier passes on changed files
- [x] Changes are focused — one concern per PR