### PR TITLE
feat(web): show engine icons in the fan-out queries table

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -10,8 +10,8 @@ import {
   type QueryFanoutData,
   type FanoutSubQuery,
 } from '@/lib/actions/fanout';
-import { PLATFORM_LABELS } from '@/config/platform-labels';
 import { INTENT_LABELS, INTENT_COLORS } from '@/config/intent-labels';
+import { PlatformsCell } from '@/components/citations/source-cells';
 import { cn } from '@/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -27,10 +27,6 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Check, ChevronRight, Plus, Loader2, Search } from 'lucide-react';
-
-function platformLabel(slug: string): string {
-  return PLATFORM_LABELS[slug] ?? slug;
-}
 
 type View = 'frequency' | 'by-prompt';
 
@@ -353,7 +349,7 @@ function HighFrequencyView({
               <TableRow key={key}>
                 <TableCell className="font-medium">{sq.query}</TableCell>
                 <TableCell>
-                  <EngineBadges engines={sq.engines} />
+                  <PlatformsCell models={sq.engines} />
                 </TableCell>
                 <TableCell className="text-right tabular-nums">{sq.timesSearched}</TableCell>
                 <TableCell>
@@ -518,7 +514,7 @@ function ByPromptView({
                                       {sq.query}
                                     </TableCell>
                                     <TableCell className="align-middle">
-                                      <EngineBadges engines={sq.engines} />
+                                      <PlatformsCell models={sq.engines} />
                                     </TableCell>
                                     <TableCell className="align-middle text-right tabular-nums">
                                       {sq.timesSearched}
@@ -548,18 +544,6 @@ function ByPromptView({
           </TableBody>
         </Table>
       )}
-    </div>
-  );
-}
-
-function EngineBadges({ engines }: { engines: string[] }) {
-  return (
-    <div className="flex flex-wrap gap-1">
-      {engines.map((e) => (
-        <Badge key={e} variant="secondary" className="text-[10px]">
-          {platformLabel(e)}
-        </Badge>
-      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

On **Prompts → Fan-out**, the Engine column rendered engines as plain text badges while the Citations page (and the prompt-detail Top Sources card) show provider icons. This swaps the fan-out table (both the frequency view and the by-prompt expanded rows) to the shared `PlatformsCell` from `web/src/components/citations/source-cells.tsx` — `AIProviderAvatar` icons, deduplicated by provider — so engines render identically everywhere.

The engine values are `source_platform` slugs (`chatgpt-web`, `perplexity-web`, `google-aio`, …), all already handled by `resolveAIProvider`. The now-unused local `platformLabel` helper and its `PLATFORM_LABELS` import are removed.

## Related issue

—

## Type of change

- [x] `feat` — New feature

## How to test

1. Open Dashboard → Prompts → **Fan-out** tab (a brand with observed fan-out data).
2. The Engine column shows provider icons (same avatars as the Citations page) instead of text badges, in both the frequency table and the expanded per-prompt rows.
3. Rows with multiple engines from the same provider show a single deduplicated icon.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR