### PR TITLE
fix: unify Prompts page pagination with shared TablePager (closes #544)

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -27,6 +27,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Check, ChevronRight, Plus, Loader2, Search } from 'lucide-react';
+import { usePagination, TablePager } from '@/components/table-pager';
 
 type View = 'frequency' | 'by-prompt';
 
@@ -48,6 +49,8 @@ type QueryFanoutTabProps = {
  * queries ≈ 40s+, aborted, badges never arrived that session).
  */
 const INTENT_CHUNK_SIZE = 20;
+
+const FANOUT_PAGE_SIZE = 10;
 
 /**
  * Server-action failures reach the client with Next's production-masked
@@ -72,16 +75,22 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
   const [addingKey, setAddingKey] = useState<string | null>(null);
   // Intent is keyed by the lower-cased sub-query (matches the server cache key).
   const [intents, setIntents] = useState<Record<string, string>>({});
-  const [page, setPage] = useState(1);
   const [view, setView] = useState<View>('by-prompt');
   const [searchText, setSearchText] = useState('');
-  const PAGE_SIZE = 10;
 
   // Mirror of `intents` for the async classification chain (avoids stale
   // closures), plus a run counter so a reload/brand switch/unmount cancels
   // the previous chain instead of racing it.
   const intentsRef = useRef<Record<string, string>>({});
   const intentRunRef = useRef(0);
+
+  // Shared pager for the HighFrequencyView — reset whenever brandId or view changes.
+  const pager = usePagination(
+    data?.subQueries.length ?? 0,
+    // resetKey: changing brand or switching away from/back to frequency view resets to page 0
+    `${brandId}::${view}`,
+    FANOUT_PAGE_SIZE,
+  );
 
   /**
    * Classify intents progressively (#431): the visible page's queries first
@@ -94,10 +103,11 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
     const pending = queries.filter((q) => !(q.toLowerCase() in intentsRef.current));
     if (pending.length === 0) return;
 
-    const chunks: string[][] = [pending.slice(0, PAGE_SIZE)];
-    for (let i = PAGE_SIZE; i < pending.length; i += INTENT_CHUNK_SIZE) {
+    const chunks: string[][] = [pending.slice(0, FANOUT_PAGE_SIZE)];
+    for (let i = FANOUT_PAGE_SIZE; i < pending.length; i += INTENT_CHUNK_SIZE) {
       chunks.push(pending.slice(i, i + INTENT_CHUNK_SIZE));
     }
+
     for (const chunk of chunks) {
       if (intentRunRef.current !== run) return;
       try {
@@ -134,6 +144,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
     },
     [brandId, classifyProgressively],
   );
+
   useEffect(() => {
     load();
     // Cancel the in-flight classification chain on unmount/brand switch.
@@ -143,7 +154,6 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
   }, [load]);
 
   useEffect(() => {
-    setPage(1);
     setSearchText('');
   }, [brandId]);
 
@@ -261,9 +271,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
             subQueries={data.subQueries}
             intents={intents}
             addingKey={addingKey}
-            page={page}
-            pageSize={PAGE_SIZE}
-            onPageChange={setPage}
+            pager={pager}
             onTrack={handleTrack}
           />
         ) : (
@@ -295,39 +303,20 @@ function EmptyState() {
   );
 }
 
-function getPagerItems(page: number, totalPages: number): (number | '...')[] {
-  if (totalPages <= 7) {
-    return Array.from({ length: totalPages }, (_, i) => i + 1);
-  }
-  const items: (number | '...')[] = [1];
-  if (page > 3) items.push('...');
-  for (let p = Math.max(2, page - 1); p <= Math.min(totalPages - 1, page + 1); p++) {
-    items.push(p);
-  }
-  if (page < totalPages - 2) items.push('...');
-  items.push(totalPages);
-  return items;
-}
-
 function HighFrequencyView({
   subQueries,
   intents,
   addingKey,
-  page,
-  pageSize,
-  onPageChange,
+  pager,
   onTrack,
 }: {
   subQueries: FanoutSubQuery[];
   intents: Record<string, string>;
   addingKey: string | null;
-  page: number;
-  pageSize: number;
-  onPageChange: (p: number) => void;
+  pager: ReturnType<typeof usePagination>;
   onTrack: (query: string) => void;
 }) {
-  const totalPages = Math.ceil(subQueries.length / pageSize);
-  const pageRows = subQueries.slice((page - 1) * pageSize, page * pageSize);
+  const pageRows = subQueries.slice(pager.start, pager.end);
 
   return (
     <>
@@ -366,48 +355,14 @@ function HighFrequencyView({
           })}
         </TableBody>
       </Table>
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-1 pt-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0 text-xs"
-            onClick={() => onPageChange(page - 1)}
-            disabled={page === 1}
-          >
-            ‹
-          </Button>
-          {getPagerItems(page, totalPages).map((item, idx) =>
-            item === '...' ? (
-              <span
-                key={`ellipsis-${idx}`}
-                className="flex h-7 w-7 items-center justify-center text-xs text-muted-foreground"
-              >
-                …
-              </span>
-            ) : (
-              <Button
-                key={item}
-                variant={page === item ? 'default' : 'ghost'}
-                size="sm"
-                className="h-7 w-7 p-0 text-xs"
-                onClick={() => onPageChange(item as number)}
-              >
-                {item}
-              </Button>
-            ),
-          )}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0 text-xs"
-            onClick={() => onPageChange(page + 1)}
-            disabled={page === totalPages}
-          >
-            ›
-          </Button>
-        </div>
-      )}
+      <TablePager
+        page={pager.page}
+        totalPages={pager.totalPages}
+        total={subQueries.length}
+        start={pager.start}
+        end={pager.end}
+        onPage={pager.setPage}
+      />
     </>
   );
 }
@@ -449,7 +404,6 @@ function ByPromptView({
           className="pl-8 h-8 text-xs"
         />
       </div>
-
       {groups.length === 0 ? (
         <div className="flex flex-col items-center gap-2 py-12 text-center">
           <Search className="h-8 w-8 text-muted-foreground/50" />
@@ -573,6 +527,7 @@ function TrackCell({
       </Badge>
     );
   }
+
   return (
     <Button
       variant="ghost"
@@ -624,6 +579,7 @@ function IntentBadge({ intent }: { intent?: string }) {
   // Intents load on-demand (async, cached server-side); show a placeholder
   // until this row's classification resolves.
   if (!intent) return <span className="text-xs text-muted-foreground">—</span>;
+
   return (
     <Badge
       variant="outline"

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -86,6 +86,7 @@ import { toast } from 'sonner';
 import { toCsv } from '@/lib/csv';
 import { compareNullsLast, type SortDir } from './prompt-sort';
 import { formatCompactNumber } from '@/lib/format';
+import { usePagination, TablePager } from '@/components/table-pager';
 
 // ─── Info Tooltip ─────────────────────────────────────────────────────────────
 
@@ -1756,6 +1757,13 @@ function AllPromptsTab({
     return list.sort((a, b) => compareNullsLast(valueOf(a), valueOf(b), dir));
   }, [prompts, search, workFilter, statusOf, activeSort, dir, visibility, volumeByPromptId]);
 
+  // Pagination for the main prompt list.  resetKey encodes every variable that
+  // changes the visible row set (search text, sort column, sort direction, work
+  // status filter) so usePagination jumps back to page 0 automatically when
+  // any filter or sort changes — satisfying the issue's acceptance criteria.
+  const promptsResetKey = `${search}::${workFilter}::${activeSort ?? ''}::${dir}`;
+  const promptsPager = usePagination(filtered.length, promptsResetKey);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-10">
@@ -1909,7 +1917,7 @@ function AllPromptsTab({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {filtered.map((p) => {
+            {filtered.slice(promptsPager.start, promptsPager.end).map((p) => {
               const vol = volumeByPromptId.get(p.id);
               const vis = visibility[p.id];
               return (
@@ -2038,6 +2046,14 @@ function AllPromptsTab({
             })}
           </TableBody>
         </Table>
+        <TablePager
+          page={promptsPager.page}
+          totalPages={promptsPager.totalPages}
+          total={filtered.length}
+          start={promptsPager.start}
+          end={promptsPager.end}
+          onPage={promptsPager.setPage}
+        />
         {filtered.length === 0 && (
           <div className="py-10 text-center text-sm text-muted-foreground">
             No prompts match your search.


### PR DESCRIPTION
## Summary

Fixes the pagination inconsistency on the Prompts page described in #544.
Both affected views now use the same `TablePager` + `usePagination` that
the Citations page and prompt-detail Top Sources card already use.

## Changes

### `_fanout-tab.tsx` — Fan-out tab (High frequency view)
- Replaced the bespoke `getPagerItems` numbered pager (`1 2 … 9` buttons)
  with the shared `<TablePager>` component
- `usePagination` (pageSize = 10) is now called in `QueryFanoutTab` and
  passed down to `HighFrequencyView` via a single `pager` prop
- Deleted `getPagerItems` entirely — no remaining usages anywhere
- `ByPromptView` is unchanged

### `page.tsx` — Main prompt list (All Prompts tab)
- Added `usePagination(filtered.length, resetKey)` + `<TablePager>` below
  the table (PAGE_SIZE = 100, matching the shared default)
- `resetKey` encodes search text + work status filter + sort column + sort
  direction, so changing any filter or sort automatically returns to page 1
- `filtered.map(...)` → `filtered.slice(pager.start, pager.end).map(...)`
- All other logic (sorting, filtering, row rendering, dialogs) untouched

## Acceptance criteria (from issue)

- [x] Prompts main list shows at most one page of rows with the shared
      pager below the table; filter/sort changes reset to page 1
- [x] Fan-out tab High frequency view uses the same `TablePager` UI as
      Citations
- [x] No remaining usages of `getPagerItems`
- [x] `format:check`, `lint`, `typecheck`, and `test` all pass (47/47)

## Testing

```bash
cd web
npm run format:check   # ✅ All matched files use Prettier code style!
npm run lint           # ✅ No issues
npm run typecheck      # ✅ No errors
npm run test           # ✅ 47/47 tests passed
```

Manually verified on `npm run dev`:
- All Prompts tab: Previous/Next pager appears below the table, page
  resets to 1 when search or sort changes
- Fan-out → High frequency: Previous/Next pager replaces the old numbered
  buttons, styling matches Citations page exactly