### PR TITLE
fix: centralize platform display labels

### DIFF
--- a/web/src/config/platform-labels.ts
+++ b/web/src/config/platform-labels.ts
@@ -16,9 +16,9 @@ export const PLATFORM_LABELS: Record<string, string> = {
   perplexity: 'Perplexity',
   claude: 'Claude',
   grok: 'Grok',
-  copilot: 'Copilot',
+  copilot: 'Microsoft Copilot',
   'meta-ai': 'Meta AI',
-  'google-ai-overviews': 'Google AI',
+  'google-ai-overviews': 'Google AI Overview',
   'google-ai-mode': 'Google AI Mode',
 
   // Tracked scraper platform slugs, as stored in `prompt_results.platform`.
@@ -68,7 +68,7 @@ export const MODEL_PROVIDER_LABELS: Record<string, string> = {
   'google-aimode': 'Google AI Mode',
   'copilot-web': 'Microsoft Copilot',
   'grok-web': 'Grok',
-  'gemini-web': 'Gemini',
+  'gemini-web': 'Google Gemini',
 };
 
 /**

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -24,6 +24,7 @@ import { getPromptVolumes } from '@/lib/actions/volumes';
 import { getPromptSuggestions } from '@/lib/actions/prompt-suggestions';
 import { aggregatePromptVolumeClusters } from '@/lib/prompt-volume-clusters';
 import { percentageChange } from '@/lib/metrics';
+import { PLATFORM_LABELS } from '@/config/platform-labels';
 
 /** Round to one decimal place (keeps sub-1 averages visible instead of flooring to 0). */
 function roundTo1(n: number): number {
@@ -2121,32 +2122,8 @@ export async function getHeadToHeadComparison(
 
 export type BreakdownMetric = 'mentions' | 'visibility';
 
-/**
- * Human-readable platform/scraper slugs used across the Insights UI.
- * Kept in sync with the mapping in insights/page.tsx so drill-down narratives
- * read like the rest of the dashboard ("Gemini" instead of "gemini-web").
- */
-const BREAKDOWN_PLATFORM_LABELS: Record<string, string> = {
-  chatgpt: 'ChatGPT',
-  'chatgpt-web': 'ChatGPT',
-  gemini: 'Gemini',
-  'gemini-web': 'Google Gemini',
-  perplexity: 'Perplexity',
-  'perplexity-web': 'Perplexity',
-  claude: 'Claude',
-  grok: 'Grok',
-  'grok-web': 'Grok',
-  copilot: 'Copilot',
-  'copilot-web': 'Microsoft Copilot',
-  'meta-ai': 'Meta AI',
-  'google-aio': 'Google AI Overview',
-  'google-ai-overviews': 'Google AI Overview',
-  'google-aimode': 'Google AI Mode',
-  'google-ai-mode': 'Google AI Mode',
-};
-
 function formatPlatformLabel(slug: string): string {
-  return BREAKDOWN_PLATFORM_LABELS[slug] ?? slug;
+  return PLATFORM_LABELS[slug] ?? slug;
 }
 
 export interface BreakdownRow {


### PR DESCRIPTION
## Summary

- remove the duplicated platform label map from the tracking action
- use the canonical `PLATFORM_LABELS` map for Insights breakdown narratives
- standardize the conflicting labels as Google AI Overview, Microsoft Copilot, and Google Gemini

Closes #552

## Validation

- `yarn typecheck`
- `yarn eslint src/config/platform-labels.ts src/lib/actions/tracking.ts`
- `yarn prettier --check src/config/platform-labels.ts src/lib/actions/tracking.ts`
- `yarn test src/lib/actions/tracking.test.ts` (3 tests passed)
- `git diff --check`