### PR TITLE
feat(web): show the prompt-level visibility rate on competitor cards and topic detail

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/competitors/page.tsx
@@ -289,7 +289,14 @@ function CompetitorCard({
   deleting,
 }: {
   competitor: Competitor;
-  stats: { avg: number; mentions: number; citations: number } | null;
+  stats: {
+    rate: number;
+    visiblePrompts: number;
+    promptCount: number;
+    avg: number;
+    mentions: number;
+    citations: number;
+  } | null;
   isSelected: boolean;
   onSelect: () => void;
   onDelete: () => void;
@@ -340,10 +347,13 @@ function CompetitorCard({
 
       <div className="flex items-center gap-3 shrink-0">
         {stats ? (
-          <div className="text-right">
-            <div className="text-sm font-semibold tabular-nums">{stats.avg}%</div>
-            <div className="text-[10px] text-muted-foreground">
-              {stats.mentions}m · {stats.citations}c
+          <div
+            className="text-right"
+            title={`Appeared in ${stats.visiblePrompts} of ${stats.promptCount} prompts · ${stats.mentions} mentions · ${stats.citations} citations · avg score ${stats.avg}%`}
+          >
+            <div className="text-sm font-semibold tabular-nums">{stats.rate}%</div>
+            <div className="text-[10px] text-muted-foreground tabular-nums">
+              {stats.visiblePrompts}/{stats.promptCount} prompts
             </div>
           </div>
         ) : (
@@ -1185,12 +1195,27 @@ export default function CompetitorsPage() {
 
   if (!brand) return <NoBrandSelected />;
 
-  // Build score map from comparison data
-  const scoreMap = new Map<string, { avg: number; mentions: number; citations: number }>();
+  // Build score map from comparison data. The headline number is the
+  // prompt-level visibility rate (#493) — the same metric as the Insights
+  // leaderboard — with the raw score average kept for the tooltip.
+  const scoreMap = new Map<
+    string,
+    {
+      rate: number;
+      visiblePrompts: number;
+      promptCount: number;
+      avg: number;
+      mentions: number;
+      citations: number;
+    }
+  >();
   if (comparisonData) {
     for (const entry of comparisonData.brands) {
       if (!entry.isOwnBrand) {
         scoreMap.set(entry.name, {
+          rate: entry.visibilityRate,
+          visiblePrompts: entry.visiblePrompts,
+          promptCount: entry.promptCount,
           avg: entry.avgVisibilityScore,
           mentions: entry.totalMentions,
           citations: entry.totalCitations,

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
@@ -72,15 +72,17 @@ function KpiCard({
   value,
   change,
   suffix,
+  hint,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   label: string;
   value: string | number;
   change?: number | null;
   suffix?: string;
+  hint?: string;
 }) {
   return (
-    <Card>
+    <Card title={hint}>
       <CardContent className="pt-6 pb-5">
         <div className="flex items-center gap-2 text-xs text-muted-foreground mb-2">
           <Icon className="h-3.5 w-3.5" />
@@ -213,6 +215,12 @@ export default function TopicDetailPage({ params }: { params: Promise<{ id: stri
   const topPrompts = [...promptList].sort((a, b) => b.avg - a.avg).slice(0, 5);
   const weakPrompts = [...promptList].sort((a, b) => a.avg - b.avg).slice(0, 5);
 
+  // Headline metric (#493): the topic-scoped prompt-level visibility rate.
+  // getCompetitorComparison already computes it under the topic filter with
+  // the same-denominator rule, so the own-brand entry carries rate, X/Y
+  // counts and the rate's point change.
+  const ownBrand = competitors?.brands.find((b) => b.isOwnBrand) ?? null;
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -248,10 +256,15 @@ export default function TopicDetailPage({ params }: { params: Promise<{ id: stri
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <KpiCard
             icon={Eye}
-            label="Avg visibility"
-            value={summary.avgVisibilityScore}
-            change={summary.visibilityChange}
+            label="Visibility rate"
+            value={ownBrand?.visibilityRate ?? 0}
+            change={ownBrand?.change ?? null}
             suffix="%"
+            hint={
+              ownBrand
+                ? `Appeared in ${ownBrand.visiblePrompts} of ${ownBrand.promptCount} prompts · avg score ${summary.avgVisibilityScore}%`
+                : undefined
+            }
           />
           <KpiCard
             icon={Zap}
@@ -332,6 +345,7 @@ export default function TopicDetailPage({ params }: { params: Promise<{ id: stri
                       'flex items-center gap-3 py-2',
                       c.isOwnBrand && 'bg-primary/5 -mx-3 px-3 rounded',
                     )}
+                    title={`Appeared in ${c.visiblePrompts} of ${c.promptCount} prompts · avg score ${c.avgVisibilityScore}%`}
                   >
                     <span className="w-5 text-xs text-muted-foreground tabular-nums text-right">
                       {i + 1}
@@ -343,7 +357,7 @@ export default function TopicDetailPage({ params }: { params: Promise<{ id: stri
                       )}
                     </span>
                     <span className="text-sm tabular-nums w-10 text-right">
-                      {c.avgVisibilityScore}%
+                      {c.visibilityRate}%
                     </span>
                     {c.change !== null && (
                       <span


### PR DESCRIPTION
## Summary

Completes the remaining scope of #493 (the Topics overview half shipped in #499). Both surfaces now lead with the prompt-level Visibility Rate — the same metric as the Insights leaderboard — instead of the all-rows score average:

- **Competitors page cards** — the headline is now `visibilityRate` with a `X/Y prompts` sub-line (mirroring the leaderboard's "appeared in X/Y prompts"). The score average, mentions and citations move into the hover tooltip, so no information is lost. Pure UI mapping — `CompetitorComparisonEntry` has carried the rate fields since #490.
- **Topic detail KPI** — "Avg visibility" becomes "Visibility rate", sourced from the own-brand entry of the topic-scoped competitor comparison (already computed with the same-denominator rule under the topic filter). Its change indicator now uses the rate's point change instead of the score change.
- **Topic detail competitor table** — rows show `visibilityRate` instead of `avgVisibilityScore`. This also fixes an existing mismatch: the row's ± change was already rate-based, so it previously sat next to a score-average headline. Score average and X/Y counts are kept in the row tooltip.

No backend changes — `getCompetitorComparison` already returns `visibilityRate`, `visiblePrompts` and `promptCount` scoped to the active filters/topic.

## Related issue

Closes #493

## Type of change

- [x] `feat` — New feature

## How to test

1. Open Insights and note a competitor's leaderboard rate, then open Competitors — the card percentage now matches for the same period (previously it showed the much lower score average).
2. Open a topic's detail page — the first KPI reads "Visibility rate"; a topic whose every prompt surfaced the brand reads 100%.
3. In the topic detail competitor list, brand and competitor percentages share the topic's prompt-count denominator; hover a row to see "appeared in X of Y prompts" plus the old score average.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR