### PR TITLE
fix(db): drop deleted competitors from competitor_aggregates

### DIFF
--- a/supabase/migrations/00035_competitor_aggregates_live_only.sql
+++ b/supabase/migrations/00035_competitor_aggregates_live_only.sql
@@ -1,0 +1,172 @@
+-- ── Only aggregate mentions of competitors that still exist ──────────────────
+--
+-- Deleting a competitor stops future tracking runs from scoring it, but the
+-- Insights leaderboard, the provider breakdown and the Competitors comparison
+-- kept showing it until the selected date window aged past its last scraped
+-- result: competitor_aggregates reads the historical competitor_mentions JSON
+-- on prompt_results and never checked the live competitors table.
+--
+-- mentions_flat now keeps only rows whose competitor_id resolves to a live
+-- competitor of the same brand, so removed competitors drop out of every
+-- competitor-side CTE at once. The brand-side numbers come from the filtered
+-- CTE and each remaining competitor's rate uses its own visible_prompts over
+-- the shared brand_prompt_count, so neither changes.
+--
+-- Function body otherwise identical to 00029. Return type is unchanged, so
+-- CREATE OR REPLACE suffices (grants from 00006 carry over).
+-- SECURITY INVOKER kept from 00014.
+
+CREATE OR REPLACE FUNCTION public.competitor_aggregates(
+  p_brand_id   uuid,
+  p_platform   text         DEFAULT NULL,
+  p_models     text[]       DEFAULT NULL,
+  p_region     text         DEFAULT NULL,
+  p_date_from  timestamptz  DEFAULT NULL,
+  p_date_to    timestamptz  DEFAULT NULL,
+  p_prompt_id  uuid         DEFAULT NULL,
+  p_topic_id   uuid         DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH filtered AS (
+    SELECT pr.prompt_id, pr.visibility_score, pr.mention_count, pr.citation_count,
+           pr.model_used, pr.platform, pr.competitor_mentions
+    FROM public.prompt_results pr
+    WHERE pr.brand_id = p_brand_id
+      AND pr.platform <> 'chatgpt-shopping'  -- #155 — isolate from Insights
+      AND (p_platform  IS NULL OR pr.platform    = p_platform)
+      AND (p_models    IS NULL OR pr.model_used  = ANY (p_models))
+      AND (p_region    IS NULL OR pr.region      = p_region)
+      AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR pr.created_at <= p_date_to)
+      AND (p_prompt_id IS NULL OR pr.prompt_id   = p_prompt_id)
+      AND (p_topic_id  IS NULL OR EXISTS (
+             SELECT 1 FROM public.prompts p
+             WHERE p.id = pr.prompt_id AND p.topic_id = p_topic_id))
+  ),
+  brand_totals AS (
+    SELECT
+      COUNT(*)                                          AS row_count,
+      COALESCE(SUM(visibility_score), 0)                AS sum_visibility,
+      COALESCE(SUM(mention_count), 0)::bigint           AS total_mentions,
+      COALESCE(SUM(citation_count), 0)::bigint          AS total_citations,
+      COUNT(DISTINCT prompt_id)                         AS prompt_count,
+      COUNT(DISTINCT prompt_id)
+        FILTER (WHERE mention_count > 0 OR citation_count > 0)
+                                                        AS visible_prompts
+    FROM filtered
+  ),
+  by_brand_provider AS (
+    SELECT
+      model_used,
+      platform,
+      SUM(visibility_score)  AS sum_visibility,
+      COUNT(*)               AS row_count,
+      COUNT(DISTINCT prompt_id) AS prompt_count,
+      COUNT(DISTINCT prompt_id)
+        FILTER (WHERE mention_count > 0 OR citation_count > 0)
+                             AS visible_prompts
+    FROM filtered
+    GROUP BY model_used, platform
+  ),
+  mentions_flat AS (
+    SELECT
+      f.prompt_id,
+      f.model_used,
+      f.platform,
+      cm.value->>'competitor_id'                       AS competitor_id,
+      cm.value->>'name'                                AS competitor_name,
+      (cm.value->>'visibility_score')::numeric         AS cm_visibility,
+      COALESCE((cm.value->>'mention_count')::int, 0)   AS cm_mention_count,
+      COALESCE((cm.value->>'citation_count')::int, 0)  AS cm_citation_count
+    FROM filtered f,
+         LATERAL jsonb_array_elements(
+           COALESCE(f.competitor_mentions, '[]'::jsonb)) cm
+    WHERE cm.value ? 'competitor_id'
+      AND EXISTS (
+        SELECT 1 FROM public.competitors c
+        WHERE c.id::text = cm.value->>'competitor_id'
+          AND c.brand_id = p_brand_id
+      )
+  ),
+  by_competitor AS (
+    SELECT
+      competitor_id,
+      MAX(competitor_name)                  AS name,
+      SUM(cm_visibility)                    AS sum_visibility,
+      COUNT(*)                              AS row_count,
+      SUM(cm_mention_count)::bigint         AS total_mentions,
+      SUM(cm_citation_count)::bigint        AS total_citations,
+      COUNT(DISTINCT prompt_id)
+        FILTER (WHERE cm_mention_count > 0
+                   OR cm_citation_count > 0
+                   OR COALESCE(cm_visibility, 0) > 0)
+                                            AS visible_prompts
+    FROM mentions_flat
+    GROUP BY competitor_id
+  ),
+  by_competitor_provider AS (
+    SELECT
+      model_used,
+      platform,
+      competitor_id,
+      MAX(competitor_name)   AS competitor_name,
+      SUM(cm_visibility)     AS sum_visibility,
+      COUNT(*)               AS row_count,
+      COUNT(DISTINCT prompt_id)
+        FILTER (WHERE cm_mention_count > 0
+                   OR cm_citation_count > 0
+                   OR COALESCE(cm_visibility, 0) > 0)
+                             AS visible_prompts
+    FROM mentions_flat
+    GROUP BY model_used, platform, competitor_id
+  )
+  SELECT jsonb_build_object(
+    'brand_row_count',       b.row_count,
+    'brand_sum_visibility',  b.sum_visibility,
+    'brand_total_mentions',  b.total_mentions,
+    'brand_total_citations', b.total_citations,
+    'brand_prompt_count',    b.prompt_count,
+    'brand_visible_prompts', b.visible_prompts,
+    'by_competitor', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'competitor_id',    bc.competitor_id,
+                'name',             bc.name,
+                'sum_visibility',   bc.sum_visibility,
+                'row_count',        bc.row_count,
+                'total_mentions',   bc.total_mentions,
+                'total_citations',  bc.total_citations,
+                'visible_prompts',  bc.visible_prompts)
+              ORDER BY bc.row_count DESC, bc.competitor_id)
+       FROM by_competitor bc),
+      '[]'::jsonb),
+    'by_brand_provider', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',       bbp.model_used,
+                'platform',         bbp.platform,
+                'sum_visibility',   bbp.sum_visibility,
+                'row_count',        bbp.row_count,
+                'prompt_count',     bbp.prompt_count,
+                'visible_prompts',  bbp.visible_prompts)
+              ORDER BY bbp.platform NULLS LAST, bbp.model_used NULLS LAST)
+       FROM by_brand_provider bbp),
+      '[]'::jsonb),
+    'by_competitor_provider', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',       bcp.model_used,
+                'platform',         bcp.platform,
+                'competitor_id',    bcp.competitor_id,
+                'competitor_name',  bcp.competitor_name,
+                'sum_visibility',   bcp.sum_visibility,
+                'row_count',        bcp.row_count,
+                'visible_prompts',  bcp.visible_prompts)
+              ORDER BY bcp.platform NULLS LAST, bcp.model_used NULLS LAST, bcp.competitor_id)
+       FROM by_competitor_provider bcp),
+      '[]'::jsonb)
+  )
+  FROM brand_totals b;
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3904,3 +3904,179 @@ $$;
 GRANT EXECUTE ON FUNCTION public.prompt_visibility_summaries(uuid, timestamptz)
   TO authenticated;
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00035_competitor_aggregates_live_only.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- ── Only aggregate mentions of competitors that still exist ──────────────────
+--
+-- Deleting a competitor stops future tracking runs from scoring it, but the
+-- Insights leaderboard, the provider breakdown and the Competitors comparison
+-- kept showing it until the selected date window aged past its last scraped
+-- result: competitor_aggregates reads the historical competitor_mentions JSON
+-- on prompt_results and never checked the live competitors table.
+--
+-- mentions_flat now keeps only rows whose competitor_id resolves to a live
+-- competitor of the same brand, so removed competitors drop out of every
+-- competitor-side CTE at once. The brand-side numbers come from the filtered
+-- CTE and each remaining competitor's rate uses its own visible_prompts over
+-- the shared brand_prompt_count, so neither changes.
+--
+-- Function body otherwise identical to 00029. Return type is unchanged, so
+-- CREATE OR REPLACE suffices (grants from 00006 carry over).
+-- SECURITY INVOKER kept from 00014.
+
+CREATE OR REPLACE FUNCTION public.competitor_aggregates(
+  p_brand_id   uuid,
+  p_platform   text         DEFAULT NULL,
+  p_models     text[]       DEFAULT NULL,
+  p_region     text         DEFAULT NULL,
+  p_date_from  timestamptz  DEFAULT NULL,
+  p_date_to    timestamptz  DEFAULT NULL,
+  p_prompt_id  uuid         DEFAULT NULL,
+  p_topic_id   uuid         DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH filtered AS (
+    SELECT pr.prompt_id, pr.visibility_score, pr.mention_count, pr.citation_count,
+           pr.model_used, pr.platform, pr.competitor_mentions
+    FROM public.prompt_results pr
+    WHERE pr.brand_id = p_brand_id
+      AND pr.platform <> 'chatgpt-shopping'  -- #155 — isolate from Insights
+      AND (p_platform  IS NULL OR pr.platform    = p_platform)
+      AND (p_models    IS NULL OR pr.model_used  = ANY (p_models))
+      AND (p_region    IS NULL OR pr.region      = p_region)
+      AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR pr.created_at <= p_date_to)
+      AND (p_prompt_id IS NULL OR pr.prompt_id   = p_prompt_id)
+      AND (p_topic_id  IS NULL OR EXISTS (
+             SELECT 1 FROM public.prompts p
+             WHERE p.id = pr.prompt_id AND p.topic_id = p_topic_id))
+  ),
+  brand_totals AS (
+    SELECT
+      COUNT(*)                                          AS row_count,
+      COALESCE(SUM(visibility_score), 0)                AS sum_visibility,
+      COALESCE(SUM(mention_count), 0)::bigint           AS total_mentions,
+      COALESCE(SUM(citation_count), 0)::bigint          AS total_citations,
+      COUNT(DISTINCT prompt_id)                         AS prompt_count,
+      COUNT(DISTINCT prompt_id)
+        FILTER (WHERE mention_count > 0 OR citation_count > 0)
+                                                        AS visible_prompts
+    FROM filtered
+  ),
+  by_brand_provider AS (
+    SELECT
+      model_used,
+      platform,
+      SUM(visibility_score)  AS sum_visibility,
+      COUNT(*)               AS row_count,
+      COUNT(DISTINCT prompt_id) AS prompt_count,
+      COUNT(DISTINCT prompt_id)
+        FILTER (WHERE mention_count > 0 OR citation_count > 0)
+                             AS visible_prompts
+    FROM filtered
+    GROUP BY model_used, platform
+  ),
+  mentions_flat AS (
+    SELECT
+      f.prompt_id,
+      f.model_used,
+      f.platform,
+      cm.value->>'competitor_id'                       AS competitor_id,
+      cm.value->>'name'                                AS competitor_name,
+      (cm.value->>'visibility_score')::numeric         AS cm_visibility,
+      COALESCE((cm.value->>'mention_count')::int, 0)   AS cm_mention_count,
+      COALESCE((cm.value->>'citation_count')::int, 0)  AS cm_citation_count
+    FROM filtered f,
+         LATERAL jsonb_array_elements(
+           COALESCE(f.competitor_mentions, '[]'::jsonb)) cm
+    WHERE cm.value ? 'competitor_id'
+      AND EXISTS (
+        SELECT 1 FROM public.competitors c
+        WHERE c.id::text = cm.value->>'competitor_id'
+          AND c.brand_id = p_brand_id
+      )
+  ),
+  by_competitor AS (
+    SELECT
+      competitor_id,
+      MAX(competitor_name)                  AS name,
+      SUM(cm_visibility)                    AS sum_visibility,
+      COUNT(*)                              AS row_count,
+      SUM(cm_mention_count)::bigint         AS total_mentions,
+      SUM(cm_citation_count)::bigint        AS total_citations,
+      COUNT(DISTINCT prompt_id)
+        FILTER (WHERE cm_mention_count > 0
+                   OR cm_citation_count > 0
+                   OR COALESCE(cm_visibility, 0) > 0)
+                                            AS visible_prompts
+    FROM mentions_flat
+    GROUP BY competitor_id
+  ),
+  by_competitor_provider AS (
+    SELECT
+      model_used,
+      platform,
+      competitor_id,
+      MAX(competitor_name)   AS competitor_name,
+      SUM(cm_visibility)     AS sum_visibility,
+      COUNT(*)               AS row_count,
+      COUNT(DISTINCT prompt_id)
+        FILTER (WHERE cm_mention_count > 0
+                   OR cm_citation_count > 0
+                   OR COALESCE(cm_visibility, 0) > 0)
+                             AS visible_prompts
+    FROM mentions_flat
+    GROUP BY model_used, platform, competitor_id
+  )
+  SELECT jsonb_build_object(
+    'brand_row_count',       b.row_count,
+    'brand_sum_visibility',  b.sum_visibility,
+    'brand_total_mentions',  b.total_mentions,
+    'brand_total_citations', b.total_citations,
+    'brand_prompt_count',    b.prompt_count,
+    'brand_visible_prompts', b.visible_prompts,
+    'by_competitor', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'competitor_id',    bc.competitor_id,
+                'name',             bc.name,
+                'sum_visibility',   bc.sum_visibility,
+                'row_count',        bc.row_count,
+                'total_mentions',   bc.total_mentions,
+                'total_citations',  bc.total_citations,
+                'visible_prompts',  bc.visible_prompts)
+              ORDER BY bc.row_count DESC, bc.competitor_id)
+       FROM by_competitor bc),
+      '[]'::jsonb),
+    'by_brand_provider', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',       bbp.model_used,
+                'platform',         bbp.platform,
+                'sum_visibility',   bbp.sum_visibility,
+                'row_count',        bbp.row_count,
+                'prompt_count',     bbp.prompt_count,
+                'visible_prompts',  bbp.visible_prompts)
+              ORDER BY bbp.platform NULLS LAST, bbp.model_used NULLS LAST)
+       FROM by_brand_provider bbp),
+      '[]'::jsonb),
+    'by_competitor_provider', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+                'model_used',       bcp.model_used,
+                'platform',         bcp.platform,
+                'competitor_id',    bcp.competitor_id,
+                'competitor_name',  bcp.competitor_name,
+                'sum_visibility',   bcp.sum_visibility,
+                'row_count',        bcp.row_count,
+                'visible_prompts',  bcp.visible_prompts)
+              ORDER BY bcp.platform NULLS LAST, bcp.model_used NULLS LAST, bcp.competitor_id)
+       FROM by_competitor_provider bcp),
+      '[]'::jsonb)
+  )
+  FROM brand_totals b;
+$$;
+


### PR DESCRIPTION
## Summary

Deleting a competitor stops future tracking runs from scoring it, but the Insights **Leaderboard**, the **provider breakdown** and the **Competitors comparison** kept showing it until the selected date window aged past its last scraped result — the `competitor_aggregates` RPC aggregates the historical `competitor_mentions` JSON on `prompt_results` and never checked whether the competitor still exists.

New migration `00035_competitor_aggregates_live_only.sql` redefines the function (`CREATE OR REPLACE`, return type unchanged) with a liveness check in the `mentions_flat` CTE: a mention row is kept only if its `competitor_id` resolves to a live `competitors` row of the same brand. Removed competitors drop out of every competitor-side CTE at once, for every date range.

- The function body is otherwise byte-identical to 00029 — the only functional change is the 5-line `EXISTS` clause.
- `SECURITY INVOKER` kept; grants from 00006 carry over with `CREATE OR REPLACE`.
- Brand-side metrics and the remaining competitors' rates are unaffected: the brand aggregates from the `filtered` CTE, and each remaining competitor's rate uses its own `visible_prompts` over the shared `brand_prompt_count`.
- Already-generated reports are stored snapshots and stay as they are.
- Consolidated `schema.sql` regenerated via `bash supabase/build-schema.sh`.

Migration will be applied to the hosted database after merge.

## Related issue

Closes #538

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Pick a brand with tracked results where a competitor appears on the Insights leaderboard.
2. Delete that competitor from the Competitors page.
3. Before this migration: the deleted competitor remains on the leaderboard, the provider chart and the comparison for any date range covering its old results. After: it disappears immediately from all three, while the brand's own numbers and the other competitors' rates stay identical.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR