### PR TITLE
fix(prompts): show prompt-level visibility rate instead of zero-diluted average score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Prompts: the All Prompts **Visibility column now shows the prompt-level Visibility Rate** (share of runs in the last 30 days with a brand mention or citation) instead of the all-runs average score, which runs without any brand presence diluted into misleading single digits — same rate language as the Insights headline and topic pages; the tooltip keeps run counts and the average score across visible runs, and the CSV export gains `visibility_rate_30d` / `visible_runs_30d`
+
 ### Added
 
 - **Daily Pulse** — a per-brand digest generated after the daily tracking run: KPI strip (visibility rate, 7-day trend, mentions, citations, sentiment), highlights (first-time citations, top prompt gains, leaderboard overtakes, first appearance on a new engine) and anomaly warnings (sharp visibility drop, competitor surge, high-volume prompt losing citations) with a platform-outage guard and a 7-day warning cooldown. Email via Resend on cloud (active/trialing orgs only), a `daily_pulse.created` webhook event everywhere, and Settings → Notifications for per-brand frequency and recipients (#540)

--- a/supabase/migrations/00037_prompt_visibility_summary_rate.sql
+++ b/supabase/migrations/00037_prompt_visibility_summary_rate.sql
@@ -1,0 +1,61 @@
+-- Add prompt-level visibility-rate inputs to the All Prompts summary.
+--
+-- The Visibility column averaged visibility_score across ALL runs, so runs
+-- where the brand didn't appear dragged heavily-mentioned prompts down to
+-- misleading single digits (same dilution the Insights headline had before
+-- the Visibility Rate switch in #490/#493). The table now needs:
+--
+--   visible_runs           runs with >= 1 brand mention/citation — the
+--                          numerator of the prompt-level rate (runs is the
+--                          denominator), matching the run-visibility rule
+--                          used by insights_aggregates / topic detail
+--   avg_visibility_visible average score across visible runs only, for the
+--                          "how strong when it shows up" tooltip
+--
+-- avg_visibility (all-runs average) is kept for compatibility.
+--
+-- The return type changes, so PostgreSQL requires the existing function to
+-- be dropped before it can be recreated with the additional columns.
+
+DROP FUNCTION public.prompt_visibility_summaries(uuid, timestamptz);
+
+CREATE FUNCTION public.prompt_visibility_summaries(
+  p_brand_id  uuid,
+  p_date_from timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  prompt_id              uuid,
+  avg_visibility         double precision,
+  avg_visibility_visible double precision,
+  total_mentions         bigint,
+  total_citations        bigint,
+  runs                   bigint,
+  visible_runs           bigint,
+  last_run_at            timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT pr.prompt_id,
+         AVG(COALESCE(pr.visibility_score, 0))::double precision AS avg_visibility,
+         AVG(COALESCE(pr.visibility_score, 0))
+           FILTER (WHERE pr.mention_count > 0 OR pr.citation_count > 0)
+           ::double precision                                    AS avg_visibility_visible,
+         COALESCE(SUM(pr.mention_count), 0)::bigint              AS total_mentions,
+         COALESCE(SUM(pr.citation_count), 0)::bigint             AS total_citations,
+         COUNT(*)::bigint                                        AS runs,
+         COUNT(*) FILTER (WHERE pr.mention_count > 0 OR pr.citation_count > 0)::bigint
+                                                                 AS visible_runs,
+         MAX(pr.created_at)                                      AS last_run_at
+  FROM public.prompt_results pr
+  WHERE pr.brand_id = p_brand_id
+    AND pr.prompt_id IS NOT NULL
+    AND pr.platform <> 'chatgpt-shopping'  -- #155 - isolate from analytics
+    AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+  GROUP BY pr.prompt_id
+$$;
+
+GRANT EXECUTE ON FUNCTION public.prompt_visibility_summaries(uuid, timestamptz)
+  TO authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -4187,3 +4187,68 @@ GRANT ALL ON TABLE "public"."sent_pulses" TO "anon";
 GRANT ALL ON TABLE "public"."sent_pulses" TO "authenticated";
 GRANT ALL ON TABLE "public"."sent_pulses" TO "service_role";
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00037_prompt_visibility_summary_rate.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Add prompt-level visibility-rate inputs to the All Prompts summary.
+--
+-- The Visibility column averaged visibility_score across ALL runs, so runs
+-- where the brand didn't appear dragged heavily-mentioned prompts down to
+-- misleading single digits (same dilution the Insights headline had before
+-- the Visibility Rate switch in #490/#493). The table now needs:
+--
+--   visible_runs           runs with >= 1 brand mention/citation — the
+--                          numerator of the prompt-level rate (runs is the
+--                          denominator), matching the run-visibility rule
+--                          used by insights_aggregates / topic detail
+--   avg_visibility_visible average score across visible runs only, for the
+--                          "how strong when it shows up" tooltip
+--
+-- avg_visibility (all-runs average) is kept for compatibility.
+--
+-- The return type changes, so PostgreSQL requires the existing function to
+-- be dropped before it can be recreated with the additional columns.
+
+DROP FUNCTION public.prompt_visibility_summaries(uuid, timestamptz);
+
+CREATE FUNCTION public.prompt_visibility_summaries(
+  p_brand_id  uuid,
+  p_date_from timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  prompt_id              uuid,
+  avg_visibility         double precision,
+  avg_visibility_visible double precision,
+  total_mentions         bigint,
+  total_citations        bigint,
+  runs                   bigint,
+  visible_runs           bigint,
+  last_run_at            timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT pr.prompt_id,
+         AVG(COALESCE(pr.visibility_score, 0))::double precision AS avg_visibility,
+         AVG(COALESCE(pr.visibility_score, 0))
+           FILTER (WHERE pr.mention_count > 0 OR pr.citation_count > 0)
+           ::double precision                                    AS avg_visibility_visible,
+         COALESCE(SUM(pr.mention_count), 0)::bigint              AS total_mentions,
+         COALESCE(SUM(pr.citation_count), 0)::bigint             AS total_citations,
+         COUNT(*)::bigint                                        AS runs,
+         COUNT(*) FILTER (WHERE pr.mention_count > 0 OR pr.citation_count > 0)::bigint
+                                                                 AS visible_runs,
+         MAX(pr.created_at)                                      AS last_run_at
+  FROM public.prompt_results pr
+  WHERE pr.brand_id = p_brand_id
+    AND pr.prompt_id IS NOT NULL
+    AND pr.platform <> 'chatgpt-shopping'  -- #155 - isolate from analytics
+    AND (p_date_from IS NULL OR pr.created_at >= p_date_from)
+  GROUP BY pr.prompt_id
+$$;
+
+GRANT EXECUTE ON FUNCTION public.prompt_visibility_summaries(uuid, timestamptz)
+  TO authenticated;
+

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/page.tsx
@@ -762,8 +762,8 @@ export default function PromptDetailPage() {
         <div className={cn('space-y-6', isRefetching && 'opacity-60')}>
           <div className="grid gap-4 sm:grid-cols-3">
             <KpiCard
-              title="Visibility Score"
-              value={`${data.summary.avgVisibilityScore}/100`}
+              title={`Visibility Rate — appeared in ${data.summary.visibleResults} of ${data.summary.totalResults} answers`}
+              value={data.summary.visibilityRate}
               icon={Eye}
             />
             <KpiCard

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -1855,7 +1855,7 @@ function AllPromptsTab({
               </ColHead>
               <SortableHead
                 className="text-right"
-                tooltip="Average brand visibility score in AI answers for this prompt over the last 30 days."
+                tooltip="Visibility Rate: the percentage of AI answers for this prompt (last 30 days) that mentioned or cited the brand. Hover a value for run counts and the average score across visible answers."
                 sortKey="visibility"
                 activeSort={activeSort}
                 dir={dir}
@@ -1981,7 +1981,7 @@ function AllPromptsTab({
                             visibilityColorClass(vis.visibilityRate),
                           )}
                         >
-                          {vis.visibilityRate}%
+                          {vis.visibilityRate}
                         </span>
                         <div className="h-1.5 w-16 rounded-full bg-muted overflow-hidden">
                           <div

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -143,13 +143,14 @@ function ColHead({
 
 // ─── Sortable column header (All Prompts) ─────────────────────────────────────
 
-type AllPromptsSortKey = 'visibility' | 'mentions' | 'citations' | 'volume' | 'lastRun';
+type AllPromptsSortKey = 'visibility' | 'mentions' | 'citations' | 'volume' | 'runs' | 'lastRun';
 
 const ALL_PROMPTS_SORT_KEYS: AllPromptsSortKey[] = [
   'visibility',
   'mentions',
   'citations',
   'volume',
+  'runs',
   'lastRun',
 ];
 
@@ -1752,6 +1753,8 @@ function AllPromptsTab({
           return vis ? vis.totalCitations : null;
         case 'volume':
           return vol ? vol.estAiVolume : null;
+        case 'runs':
+          return vis ? vis.runs : null;
         case 'lastRun':
           return vis?.lastRunAt ? new Date(vis.lastRunAt).getTime() : null;
       }
@@ -1901,6 +1904,16 @@ function AllPromptsTab({
               </ColHead>
               <SortableHead
                 className="text-right"
+                tooltip="Number of tracking runs for this prompt over the last 30 days (one per platform per day)."
+                sortKey="runs"
+                activeSort={activeSort}
+                dir={dir}
+                onSort={handleSort}
+              >
+                Runs
+              </SortableHead>
+              <SortableHead
+                className="text-right"
                 tooltip="Most recent tracking run for this prompt."
                 sortKey="lastRun"
                 activeSort={activeSort}
@@ -2027,6 +2040,13 @@ function AllPromptsTab({
                         label={vol?.competition ?? null}
                       />
                     </div>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums text-sm">
+                    {vis ? (
+                      vis.runs.toLocaleString()
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
                   </TableCell>
                   <TableCell className="text-right text-xs text-muted-foreground">
                     {formatRelative(vis?.lastRunAt)}

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -221,6 +221,8 @@ const PROMPT_EXPORT_HEADERS = [
   'est_ai_volume',
   'total_google_volume',
   'intent',
+  'visibility_rate_30d',
+  'visible_runs_30d',
   'avg_visibility_30d',
   'total_mentions_30d',
   'total_citations_30d',
@@ -1125,6 +1127,8 @@ export default function PromptsPage() {
       est_ai_volume: volumeByPromptId.get(p.id)?.estAiVolume ?? '',
       total_google_volume: volumeByPromptId.get(p.id)?.totalGoogleVolume ?? '',
       intent: volumeByPromptId.get(p.id)?.intent ?? '',
+      visibility_rate_30d: visibility[p.id]?.visibilityRate ?? '',
+      visible_runs_30d: visibility[p.id]?.visibleRuns ?? '',
       avg_visibility_30d: visibility[p.id]?.avgVisibility ?? '',
       total_mentions_30d: visibility[p.id]?.totalMentions ?? '',
       total_citations_30d: visibility[p.id]?.totalCitations ?? '',
@@ -1741,7 +1745,7 @@ function AllPromptsTab({
       const vol = volumeByPromptId.get(p.id);
       switch (activeSort) {
         case 'visibility':
-          return vis ? vis.avgVisibility : null;
+          return vis ? vis.visibilityRate : null;
         case 'mentions':
           return vis ? vis.totalMentions : null;
         case 'citations':
@@ -1963,23 +1967,30 @@ function AllPromptsTab({
                   </TableCell>
                   <TableCell className="text-right">
                     {vis ? (
-                      <div className="inline-flex items-center gap-2 justify-end min-w-[110px]">
+                      <div
+                        className="inline-flex items-center gap-2 justify-end min-w-[110px]"
+                        title={`Appeared in ${vis.visibleRuns} of ${vis.runs} runs (30d)${
+                          vis.avgVisibilityVisible !== null
+                            ? ` · avg score when visible: ${vis.avgVisibilityVisible.toFixed(0)}`
+                            : ''
+                        }`}
+                      >
                         <span
                           className={cn(
                             'text-sm font-semibold tabular-nums',
-                            visibilityColorClass(vis.avgVisibility),
+                            visibilityColorClass(vis.visibilityRate),
                           )}
                         >
-                          {vis.avgVisibility.toFixed(0)}
+                          {vis.visibilityRate}%
                         </span>
                         <div className="h-1.5 w-16 rounded-full bg-muted overflow-hidden">
                           <div
                             className={cn(
                               'h-full rounded-full',
-                              visibilityBarClass(vis.avgVisibility),
+                              visibilityBarClass(vis.visibilityRate),
                             )}
                             style={{
-                              width: `${Math.min(100, Math.max(0, vis.avgVisibility))}%`,
+                              width: `${Math.min(100, Math.max(0, vis.visibilityRate))}%`,
                             }}
                           />
                         </div>

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -1301,9 +1301,15 @@ export async function cancelTrackingJob(jobId: string): Promise<void> {
 
 export interface PromptVisibilitySummary {
   avgVisibility: number;
+  /** Average score across visible runs only (null when never visible). */
+  avgVisibilityVisible: number | null;
   totalMentions: number;
   totalCitations: number;
   runs: number;
+  /** Runs with >= 1 brand mention/citation — numerator of the prompt-level rate. */
+  visibleRuns: number;
+  /** visibleRuns / runs as a percentage, one decimal — same rounding as the Insights headline. */
+  visibilityRate: number;
   lastRunAt: string;
 }
 
@@ -1337,11 +1343,16 @@ export async function getPromptVisibilitySummaries(
 
   const result: Record<string, PromptVisibilitySummary> = {};
   for (const row of data ?? []) {
+    const runs = Number(row.runs ?? 0);
+    const visibleRuns = Number(row.visible_runs ?? 0);
     result[row.prompt_id] = {
       avgVisibility: row.avg_visibility ?? 0,
+      avgVisibilityVisible: row.avg_visibility_visible ?? null,
       totalMentions: Number(row.total_mentions ?? 0),
       totalCitations: Number(row.total_citations ?? 0),
-      runs: Number(row.runs ?? 0),
+      runs,
+      visibleRuns,
+      visibilityRate: runs > 0 ? Math.round((visibleRuns / runs) * 1000) / 10 : 0,
       lastRunAt: row.last_run_at,
     };
   }

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -115,6 +115,10 @@ export interface PromptDetailData {
   };
   summary: {
     avgVisibilityScore: number;
+    /** visibleResults / totalResults as a percentage, one decimal. */
+    visibilityRate: number;
+    /** Results with >= 1 brand mention/citation. */
+    visibleResults: number;
     totalMentions: number;
     totalCitations: number;
     totalResults: number;
@@ -906,6 +910,13 @@ export async function getPromptDetail(
     totalResults > 0
       ? Math.round(results.reduce((sum, row) => sum + row.visibilityScore, 0) / totalResults)
       : 0;
+  // Prompt-level Visibility Rate — same run-visibility rule as the All
+  // Prompts column and the Insights headline (mention or citation > 0).
+  const visibleResults = results.filter(
+    (row) => row.mentionCount > 0 || row.citationCount > 0,
+  ).length;
+  const visibilityRate =
+    totalResults > 0 ? Math.round((visibleResults / totalResults) * 1000) / 10 : 0;
 
   // Aggregate citations by domain — same shape and rounding as getCitationsOverview,
   // but scoped to this prompt's already-loaded results.
@@ -997,6 +1008,8 @@ export async function getPromptDetail(
     },
     summary: {
       avgVisibilityScore,
+      visibilityRate,
+      visibleResults,
       totalMentions: results.reduce((sum, row) => sum + row.mentionCount, 0),
       totalCitations: results.reduce((sum, row) => sum + row.citationCount, 0),
       totalResults,

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -1450,9 +1450,11 @@ export type Database = {
         Returns: {
           prompt_id: string;
           avg_visibility: number;
+          avg_visibility_visible: number | null;
           total_mentions: number;
           total_citations: number;
           runs: number;
+          visible_runs: number;
           last_run_at: string;
         }[];
       };


### PR DESCRIPTION
## Summary

The All Prompts **Visibility** column averaged `visibility_score` across **all** runs in the last 30 days, so every run where the brand didn't appear entered the average as 0. Heavily-mentioned prompts were dragged down to misleading single digits — e.g. a prompt with 310 mentions and 234 citations showed **21**. This is the same dilution the Insights headline had before the Visibility Rate switch (#490, #493); this column was the last surface still on the old formula.

The column now shows the **prompt-level Visibility Rate**: the share of runs (last 30d, `chatgpt-shopping` excluded per #155) with ≥1 brand mention or citation — the same run-visibility rule and rounding used by `insights_aggregates` and the topic detail page, so all surfaces speak the same language.

- Migration `00037`: `prompt_visibility_summaries` gains `visible_runs` (rate numerator) and `avg_visibility_visible` (average score across visible runs only); `avg_visibility` kept for compatibility. Return type changes, so DROP + CREATE as in 00034. **Already applied to the hosted database** (backward-compatible — currently deployed code reads fields by name).
- Web: the cell renders `{rate}%` with the bar scaled to the rate; the tooltip explains it — "Appeared in X of Y runs (30d) · avg score when visible: Z". Sorting by the column uses the rate. CSV export gains `visibility_rate_30d` and `visible_runs_30d` while keeping the old columns.

Real-data spot checks after the change:

| Prompt (mentions / citations) | Old avg score | New rate | Avg when visible |
|---|---|---|---|
| 310 / 234 | 21 | 37.1% (69/186 runs) | 57 |
| 174 / 118 | 52 | 83.3% (35/42 runs) | 62 |
| 152 / 42 | 9 | 13.6% (25/184 runs) | 66 |

## Related issue

Follow-up to the Visibility Rate alignment work in #490 / #493.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open Prompts → All Prompts for a brand with tracked results.
2. The Visibility column shows a percentage; hover a value — the tooltip shows the run counts and the average score across visible runs.
3. A prompt with many mentions spread across some of its runs shows its appearance share (e.g. 37%) instead of a near-zero averaged score.
4. Sort by the column and export CSV — both follow the rate.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR