### PR TITLE
fix: increase agent max output tokens

### DIFF
--- a/web/src/app/api/agent/chat/route.ts
+++ b/web/src/app/api/agent/chat/route.ts
@@ -95,6 +95,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: buildAgentModel(anthropicKey),
+    maxOutputTokens: 16000,
     system: buildAgentSystemPrompt(new Date()),
     messages: await convertToModelMessages(messages),
     tools: buildAgentTools(auth),


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

Added an explicit `maxOutputTokens` limit to the AI Agent chat stream to prevent long responses from being truncated mid-answer due to the provider defaulting to a lower token limit.

## Related issue

Closes #539 

## Type of change

<!-- Check all that apply -->

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR