### PR TITLE
fix(insights): explain both numbers in the Share of Voice pie tooltip

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
@@ -616,10 +616,17 @@ export function ShareOfVoicePlatformChart({
                   const platformShare =
                     totalVoiceMentions > 0 ? (p.voiceMentions / totalVoiceMentions) * 100 : 0;
                   return (
-                    <div className="rounded-md border bg-popover px-2.5 py-1.5 text-xs shadow-sm">
+                    <div className="rounded-md border bg-popover px-2.5 py-1.5 text-xs shadow-sm max-w-[240px]">
                       <div className="font-medium">{p.provider}</div>
                       <div className="text-muted-foreground">
-                        {p.sov.toFixed(1)}% SoV · {platformShare.toFixed(1)}% of voice
+                        Your share of voice:{' '}
+                        <span className="font-medium text-foreground">{p.sov.toFixed(1)}%</span> —
+                        your brand accounts for {p.brandMentions.toLocaleString()} of the{' '}
+                        {p.voiceMentions.toLocaleString()} brand + competitor mentions here
+                      </div>
+                      <div className="mt-1 text-muted-foreground">
+                        {platformShare.toFixed(1)}% of all tracked mentions happened on {p.provider}{' '}
+                        (slice size)
                       </div>
                     </div>
                   );


### PR DESCRIPTION
## Summary

Hovering a slice of the Insights **Share of Voice** pie showed a cryptic one-liner like `6.1% SoV · 56.0% of voice` — two different metrics, both abbreviated, with no hint of what either means or why they differ.

The tooltip now spells both out:

- **Your share of voice: 6.1%** — your brand accounts for N of the M brand + competitor mentions here
- **56.0% of all tracked mentions happened on <provider> (slice size)**

Same numbers, same layout, just readable copy — no data or chart changes.

## Related issue

—

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open Insights for a brand with competitor mentions and scroll to Share of Voice.
2. Hover any pie slice — the tooltip now explains your share on that platform (with the mention counts behind it) and that the second percentage is the platform's slice of all tracked mentions.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR