### PR TITLE
feat(insights): Reports shortcut button next to Export CSV

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -60,6 +60,7 @@ import type { Topic } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { buttonVariants } from '@/components/ui/button-variants';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import {
   BarChart3,
@@ -80,6 +81,7 @@ import {
   ArrowRight,
   ArrowUpRight,
   Download,
+  FileText,
   Layers,
   Lightbulb,
   Sparkles,
@@ -1317,6 +1319,11 @@ export default function InsightsPage() {
             )}
             {isExporting ? 'Exporting...' : 'Export CSV'}
           </Button>
+
+          <Link href="/dashboard/reports" className={cn(buttonVariants(), 'gap-2')}>
+            <FileText className="h-4 w-4" />
+            Reports
+          </Link>
 
           {/* Self-host only */}
           {!isCloud && (


### PR DESCRIPTION
## Summary

Adds a primary (solid) **Reports** button to the right of **Export CSV** in the Insights page header, linking to `/dashboard/reports`. Report generation is fed by the same Insights data, so this gives the natural next step a visible entry point right where users are looking at the numbers.

Uses the existing `Link` + `buttonVariants()` pattern (the repo's `Button` has no `asChild`), with the `FileText` icon.

## Related issue

—

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open Insights for any brand.
2. A solid **Reports** button appears to the right of Export CSV; clicking it navigates to the Reports page.
3. Locale-prefixed routing works (button uses the i18n `Link`).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR