### PR TITLE
fix(pulse): wait for the brand's Cloro queue to drain before computing

### DIFF
--- a/server/src/lib/pulse/engine.js
+++ b/server/src/lib/pulse/engine.js
@@ -41,6 +41,35 @@ async function resolveRecipients(organizationId, settings) {
   return emails;
 }
 
+// In webhook mode the tracking job can "complete" while Cloro is still
+// delivering results (the worker's drain loop gives up after 10 minutes
+// without progress, but Cloro's real latency is 30-80 minutes) — a pulse
+// computed at that moment emails partial-window numbers that contradict the
+// dashboard. Wait for the brand's pending-task queue to drain first; the
+// cap only exists so an orphaned task row can't block the pulse forever
+// (cleanupStalePendingTasks sweeps those after 2h).
+const DRAIN_POLL_MS = 60_000;
+const DRAIN_MAX_WAIT_MS = 90 * 60_000;
+
+async function waitForCloroDrain(brandId) {
+  const deadline = Date.now() + DRAIN_MAX_WAIT_MS;
+  for (;;) {
+    const { count } = await supabaseAdmin
+      .from('cloro_pending_tasks')
+      .select('task_id', { count: 'exact', head: true })
+      .eq('brand_id', brandId);
+    if (!count) return true;
+    if (Date.now() >= deadline) {
+      logger.warn(
+        { brandId, pending: count },
+        'pulse proceeding although cloro tasks are still pending',
+      );
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, DRAIN_POLL_MS));
+  }
+}
+
 /** Warning keys already sent for this brand in the last 7 days. */
 async function recentWarningKeys(brandId, now) {
   const since = new Date(now.getTime() - 7 * 86_400_000).toISOString();
@@ -101,8 +130,13 @@ export async function generatePulseForBrand(brandId) {
       .maybeSingle();
     if (existing) return { skipped: 'already_sent' };
 
+    // Don't compute until this brand's Cloro results have actually landed —
+    // the numbers must match what the dashboard will show for the same
+    // window (see waitForCloroDrain).
+    await waitForCloroDrain(brandId);
+
     const windowDays = frequency === 'weekly' ? 7 : 1;
-    const metrics = await computePulseMetrics(brandId, { windowDays, now });
+    const metrics = await computePulseMetrics(brandId, { windowDays, now: new Date() });
 
     // Skip brands with no fresh tracking results in the window.
     if (metrics.kpis.totalResults === 0) return { skipped: 'no_fresh_results' };


### PR DESCRIPTION
## Summary

Daily Pulse emails could carry partial-window numbers that contradicted the dashboard. In webhook mode a tracking job can "complete" while Cloro is still delivering results: the worker's drain loop gives up after 10 minutes without progress (40 polls × 15s), but Cloro's real delivery latency is 30–80 minutes. The pulse trigger fires on job completion, so on days when the stall-abort hit, the digest was computed from whatever had landed by then — in one observed run, 859 of the day's results arrived *after* the pulse went out, and the emailed visibility rate differed from the dashboard by 5 points.

Fix: `generatePulseForBrand` now waits for the brand's `cloro_pending_tasks` queue to drain before computing (60s poll, 90-minute cap so an orphaned task row can't block the pulse forever — `cleanupStalePendingTasks` sweeps those after 2h). The metrics window anchors to the actual compute time after the wait. The engine already runs fire-and-forget off the job runner, so waiting holds no tracking concurrency slot.

Verified on the test brand: after the fix, the regenerated pulse matches the dashboard exactly for the same window.

## Related issue

—

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. With `cloro_pending_tasks` rows present for a brand, trigger `node src/scripts/test-pulse.js <brandId>` — the engine polls until the queue drains, then computes.
2. With an empty queue, the pulse generates immediately (no added latency).
3. KPI numbers in the generated payload match the dashboard for the same window.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR