### PR TITLE
fix(insights): anchor the 24h view to the last completed tracking run

### DIFF
--- a/server/src/lib/job-runner.js
+++ b/server/src/lib/job-runner.js
@@ -58,7 +58,13 @@ export async function runTrackingJob(jobId, io) {
     const { brandId, promptId, promptIds, immediate } = jobRow.data;
     const proxy = createJobProxy(jobId, abortController.signal);
 
-    const result = await processTrackingJob({ brandId, promptId, promptIds, job: proxy });
+    const result = await processTrackingJob({
+      brandId,
+      promptId,
+      promptIds,
+      source: immediate ? 'manual' : 'cron',
+      job: proxy,
+    });
 
     await completeJob(jobId, result);
 

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -21,9 +21,9 @@ function resolveModelPlatform(model) {
 
 /**
  * Core logic: fetch prompts, run them through specified models, store results.
- * @param {{ brandId: string, promptId?: string, promptIds?: string[], job?: { progress: function, signal?: AbortSignal } }} opts
+ * @param {{ brandId: string, promptId?: string, promptIds?: string[], source?: string, job?: { progress: function, signal?: AbortSignal } }} opts
  */
-export async function processTrackingJob({ brandId, promptId, promptIds, job }) {
+export async function processTrackingJob({ brandId, promptId, promptIds, source, job }) {
   // 1. Fetch brand info with domains
   const { data: brand, error: brandErr } = await supabaseAdmin
     .from('brands')
@@ -72,6 +72,41 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
   if (!prompts || prompts.length === 0) {
     logger.info({ brandId }, 'no active prompts for brand');
     return { resultCount: 0 };
+  }
+
+  // Tracking-run ledger (00044): FULL runs stamp a row so the insights 24h
+  // view can anchor to the last COMPLETED run instead of a wall-clock window
+  // that empties and refills every morning. Single/subset-prompt runs must
+  // NOT stamp — a completed single-prompt "run" would swing the dashboard
+  // window onto one prompt's worth of data.
+  //
+  // By the time this function returns, this run's scraper results are already
+  // inserted (webhook mode drains its own submitted task_ids above; polling
+  // mode is inline), so completion is stamped at the end of this function —
+  // no webhook-side bookkeeping needed. The stall/deadline caps in the drain
+  // loop bound how long a stuck Cloro queue can delay the stamp.
+  const isFullRun = !promptId && (!promptIds || promptIds.length === 0);
+  let trackingRunId = null;
+  if (isFullRun) {
+    // A run that died mid-flight (crash, abort) leaves an uncompleted row;
+    // clear those so at most one in-progress row exists per brand.
+    await supabaseAdmin
+      .from('tracking_runs')
+      .delete()
+      .eq('brand_id', brandId)
+      .is('completed_at', null);
+
+    const { data: runRow, error: runErr } = await supabaseAdmin
+      .from('tracking_runs')
+      .insert({ brand_id: brandId, source: source || 'manual' })
+      .select('id')
+      .single();
+    if (runErr) {
+      // Ledger failure must never block tracking itself.
+      logger.warn({ err: runErr, brandId }, 'failed to create tracking_runs row');
+    } else {
+      trackingRunId = runRow.id;
+    }
   }
 
   // 3. Fetch competitors for this brand
@@ -479,6 +514,24 @@ export async function processTrackingJob({ brandId, promptId, promptIds, job }) 
     }
   } catch (err) {
     logger.error({ err, brandId }, 'failed to check opportunity generation eligibility');
+  }
+
+  // Stamp the ledger row. Zero results (every task failed) deletes the row
+  // instead: completing it would swing the 24h anchor onto an empty window,
+  // and leaving it open would pin the "in progress" banner — the dashboard
+  // keeps showing the previous completed run either way.
+  if (trackingRunId) {
+    if (insertedCount > 0) {
+      const { error: stampErr } = await supabaseAdmin
+        .from('tracking_runs')
+        .update({ completed_at: new Date().toISOString(), result_count: insertedCount })
+        .eq('id', trackingRunId);
+      if (stampErr) {
+        logger.error({ err: stampErr, brandId, trackingRunId }, 'failed to stamp tracking run');
+      }
+    } else {
+      await supabaseAdmin.from('tracking_runs').delete().eq('id', trackingRunId);
+    }
   }
 
   return { resultCount: insertedCount };

--- a/supabase/migrations/00044_tracking_runs.sql
+++ b/supabase/migrations/00044_tracking_runs.sql
@@ -1,0 +1,62 @@
+-- Tracking run ledger — stable insights 24h window.
+--
+-- One row per FULL tracking run (cron or manual Run All; single-prompt runs
+-- don't stamp). The insights 24h view anchors to the latest COMPLETED run so
+-- the daily refresh can't show an empty window or a shrinking prompt count
+-- while results stream in: the dashboard keeps the last completed run's
+-- window and switches to the new run atomically when the worker finishes
+-- draining.
+--
+-- The worker (service role) writes; org members read — an uncompleted row
+-- also powers the "tracking in progress" banner for cron-started runs, which
+-- browsers previously couldn't see (the old banner only knew about jobs
+-- started from that same browser via localStorage).
+
+CREATE TABLE public.tracking_runs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    brand_id uuid NOT NULL REFERENCES public.brands(id) ON DELETE CASCADE,
+    source text NOT NULL DEFAULT 'manual',
+    started_at timestamptz NOT NULL DEFAULT now(),
+    completed_at timestamptz,
+    result_count integer,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX tracking_runs_brand_completed_idx
+    ON public.tracking_runs (brand_id, completed_at DESC NULLS LAST);
+CREATE INDEX tracking_runs_brand_started_idx
+    ON public.tracking_runs (brand_id, started_at DESC);
+
+ALTER TABLE public.tracking_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tracking_runs: member select" ON public.tracking_runs
+    FOR SELECT USING (
+        brand_id IN (
+            SELECT b.id
+            FROM public.brands b
+            JOIN public.profiles p ON p.organization_id = b.organization_id
+            WHERE p.id = auth.uid()
+        )
+    );
+
+GRANT SELECT ON public.tracking_runs TO authenticated;
+
+-- Backfill: a synthetic completed run per brand anchored at its newest
+-- result, so the stable-window behavior applies immediately instead of
+-- waiting for each brand's next real run. Reads prompt_results only —
+-- existing data is untouched.
+WITH latest AS (
+    SELECT brand_id, max(created_at) AS last_at
+    FROM public.prompt_results
+    GROUP BY brand_id
+)
+INSERT INTO public.tracking_runs (brand_id, source, started_at, completed_at, result_count)
+SELECT l.brand_id,
+       'backfill',
+       l.last_at - interval '2 hours',
+       l.last_at,
+       (SELECT count(*)
+          FROM public.prompt_results pr
+         WHERE pr.brand_id = l.brand_id
+           AND pr.created_at > l.last_at - interval '2 hours')
+FROM latest l;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -4826,3 +4826,69 @@ $$;
 GRANT EXECUTE ON FUNCTION public.visibility_rate_trend(uuid, text, text[], text, timestamptz, timestamptz, uuid)
   TO authenticated;
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00044_tracking_runs.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Tracking run ledger — stable insights 24h window.
+--
+-- One row per FULL tracking run (cron or manual Run All; single-prompt runs
+-- don't stamp). The insights 24h view anchors to the latest COMPLETED run so
+-- the daily refresh can't show an empty window or a shrinking prompt count
+-- while results stream in: the dashboard keeps the last completed run's
+-- window and switches to the new run atomically when the worker finishes
+-- draining.
+--
+-- The worker (service role) writes; org members read — an uncompleted row
+-- also powers the "tracking in progress" banner for cron-started runs, which
+-- browsers previously couldn't see (the old banner only knew about jobs
+-- started from that same browser via localStorage).
+
+CREATE TABLE public.tracking_runs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    brand_id uuid NOT NULL REFERENCES public.brands(id) ON DELETE CASCADE,
+    source text NOT NULL DEFAULT 'manual',
+    started_at timestamptz NOT NULL DEFAULT now(),
+    completed_at timestamptz,
+    result_count integer,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX tracking_runs_brand_completed_idx
+    ON public.tracking_runs (brand_id, completed_at DESC NULLS LAST);
+CREATE INDEX tracking_runs_brand_started_idx
+    ON public.tracking_runs (brand_id, started_at DESC);
+
+ALTER TABLE public.tracking_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tracking_runs: member select" ON public.tracking_runs
+    FOR SELECT USING (
+        brand_id IN (
+            SELECT b.id
+            FROM public.brands b
+            JOIN public.profiles p ON p.organization_id = b.organization_id
+            WHERE p.id = auth.uid()
+        )
+    );
+
+GRANT SELECT ON public.tracking_runs TO authenticated;
+
+-- Backfill: a synthetic completed run per brand anchored at its newest
+-- result, so the stable-window behavior applies immediately instead of
+-- waiting for each brand's next real run. Reads prompt_results only —
+-- existing data is untouched.
+WITH latest AS (
+    SELECT brand_id, max(created_at) AS last_at
+    FROM public.prompt_results
+    GROUP BY brand_id
+)
+INSERT INTO public.tracking_runs (brand_id, source, started_at, completed_at, result_count)
+SELECT l.brand_id,
+       'backfill',
+       l.last_at - interval '2 hours',
+       l.last_at,
+       (SELECT count(*)
+          FROM public.prompt_results pr
+         WHERE pr.brand_id = l.brand_id
+           AND pr.created_at > l.last_at - interval '2 hours')
+FROM latest l;
+

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
@@ -448,15 +448,20 @@ export function VisibilityRateTrendChart({ data }: { data: VisibilityRateTrendDa
     );
   }
 
-  // Own brand always plots; competitors capped by period-average rate so a
-  // long roster doesn't turn the chart into spaghetti.
+  // Own brand always plots; competitors capped so a long roster doesn't turn
+  // the chart into spaghetti. Ranked by the LAST point's value — the rolling
+  // window makes that equal each entity's score over the charted window, i.e.
+  // the exact number the leaderboard sorts by — so the chart always plots the
+  // same brands the leaderboard's top rows show. (Period-averaging the points
+  // here used to pick a different set on short ranges.)
+  const lastRate = (key: string) => points[points.length - 1]?.values[key] ?? 0;
   const avgRate = (key: string) =>
     points.reduce((sum, p) => sum + (p.values[key] ?? 0), 0) / points.length;
   const shown = [
     ...entities.filter((e) => e.isOwnBrand),
     ...entities
       .filter((e) => !e.isOwnBrand)
-      .sort((a, b) => avgRate(b.key) - avgRate(a.key))
+      .sort((a, b) => lastRate(b.key) - lastRate(a.key) || avgRate(b.key) - avgRate(a.key))
       .slice(0, RATE_TREND_MAX_COMPETITORS),
   ].map((entity, i) => ({
     ...entity,

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -43,6 +43,8 @@ import { useBrandStore } from '@/stores/use-brand-store';
 import {
   getInsightsData,
   getVisibilityRateTrend,
+  getTrackingWindow,
+  type TrackingWindow,
   type VisibilityRateTrendData,
   triggerTrackingCheck,
   getJobStatus,
@@ -887,6 +889,29 @@ function TrackingProgressBanner({
   );
 }
 
+/**
+ * Banner for runs this browser did NOT start (the daily cron, or a teammate's
+ * Run All) — detected from the tracking_runs ledger, not localStorage. The
+ * dashboard keeps showing the last completed run's numbers until the active
+ * run finishes, then swaps in one step.
+ */
+function ServerRunBanner({ run }: { run: TrackingWindow['activeRun'] }) {
+  if (!run) return null;
+  return (
+    <div className="rounded-lg border border-primary/20 bg-primary/5 px-4 py-3">
+      <div className="flex items-center gap-2">
+        <Loader2 className="h-4 w-4 animate-spin text-primary" />
+        <span className="text-sm font-medium">
+          {run.source === 'cron' ? 'Daily tracking in progress' : 'Tracking in progress'}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          — showing the latest completed results; the numbers will refresh when this run finishes.
+        </span>
+      </div>
+    </div>
+  );
+}
+
 // ─── No Competitors Teaser ────────────────────────────────────────────────────
 
 /**
@@ -942,6 +967,8 @@ export default function InsightsPage() {
   const [recommendations, setRecommendations] = useState<InsightsRecommendations | null>(null);
   const [breakdownMetric, setBreakdownMetric] = useState<BreakdownMetric | null>(null);
   const [isExporting, setIsExporting] = useState(false);
+  const [cronRun, setCronRun] = useState<TrackingWindow['activeRun']>(null);
+  const cronRunRef = useRef<TrackingWindow['activeRun']>(null);
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
 
@@ -951,10 +978,28 @@ export default function InsightsPage() {
       if (!silent) setIsLoading(true);
       try {
         const f = overrideFilters ?? filtersRef.current;
-        const { dateFrom, dateTo } = getDateRange(f.datePreset, {
+        let { dateFrom, dateTo } = getDateRange(f.datePreset, {
           from: f.dateFrom,
           to: f.dateTo,
         });
+
+        // Stable 24h window (00044): anchor to the last COMPLETED tracking
+        // run so the morning refresh can't flash "no results" or shrink the
+        // counts while today's run streams in. Brands with no completed run
+        // yet (fresh onboarding) keep the live rolling window — nothing of
+        // theirs is old enough to age out, so it can't regress.
+        if (f.datePreset === '24h') {
+          const win = await getTrackingWindow(brand.id).catch(() => null);
+          if (win) {
+            cronRunRef.current = win.activeRun;
+            setCronRun(win.activeRun);
+            if (win.anchored) {
+              dateFrom = win.anchored.dateFrom;
+              dateTo = win.anchored.dateTo;
+            }
+          }
+        }
+
         const filterOpts = {
           model: f.model || undefined,
           region: f.region || undefined,
@@ -1053,6 +1098,34 @@ export default function InsightsPage() {
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  // Watch the tracking-run ledger so server-started (cron) runs surface too:
+  // the job banner below only knows about jobs this browser started via
+  // localStorage, which is why users never saw anything during the daily
+  // morning run. When the active run disappears (= completed), silently
+  // reload so the anchored 24h window swaps to the fresh run in one step.
+  useEffect(() => {
+    if (!brand?.id) return;
+    let cancelled = false;
+
+    const tick = async () => {
+      const win = await getTrackingWindow(brand.id).catch(() => null);
+      if (cancelled || !win) return;
+      const wasRunning = cronRunRef.current !== null;
+      cronRunRef.current = win.activeRun;
+      setCronRun(win.activeRun);
+      if (wasRunning && !win.activeRun) {
+        loadData(undefined, { silent: true });
+      }
+    };
+
+    const id = setInterval(tick, 60_000);
+    tick();
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [brand?.id, loadData]);
 
   // Restore active job from localStorage or URL query param (post-payment redirect)
   const searchParams = useSearchParams();
@@ -1271,6 +1344,11 @@ export default function InsightsPage() {
       : 0;
   const trulyEmpty = noResults && !hasAnyData;
 
+  // The localStorage-tracked job banner (with progress + Stop) wins when this
+  // browser started the run; the ledger banner covers everything else.
+  const localJobActive =
+    jobStatus !== null && (jobStatus.status === 'active' || jobStatus.status === 'waiting');
+
   if (trulyEmpty) {
     return (
       <div className="space-y-6">
@@ -1279,6 +1357,7 @@ export default function InsightsPage() {
           <p className="text-muted-foreground text-sm">{brand.name}</p>
         </div>
         <TrackingProgressBanner jobStatus={jobStatus} onStop={handleStopTracking} />
+        {!localJobActive && <ServerRunBanner run={cronRun} />}
         <EmptyState onRunPrompts={handleRunPrompts} isRunning={isRunning} isCloud={isCloud} />
         {!isCloud && (
           <div className="flex justify-center">
@@ -1373,6 +1452,7 @@ export default function InsightsPage() {
 
       {/* Tracking Progress */}
       <TrackingProgressBanner jobStatus={jobStatus} onStop={handleStopTracking} />
+      {!localJobActive && <ServerRunBanner run={cronRun} />}
 
       {/* Refetch overlay: on a filter/date change the previous window's data
           stays mounted (no skeleton — that's first-load only), so without a

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -599,6 +599,74 @@ export interface InsightsData {
   hasAnyData: boolean;
 }
 
+export interface TrackingWindow {
+  /**
+   * The stable 24h window: (previous completed run, latest completed run].
+   * Null when the brand has no completed run yet (fresh onboarding) — the
+   * caller falls back to the live rolling window, which cannot regress
+   * because a new brand has nothing older than 24h to age out.
+   */
+  anchored: { dateFrom: string; dateTo: string } | null;
+  /** A full run currently in flight (cron or manual), for the progress banner. */
+  activeRun: { startedAt: string; source: string } | null;
+}
+
+/**
+ * Resolve the effective 24h window from the tracking-run ledger (00044).
+ *
+ * The naive `[now - 24h, now]` window empties and refills every morning while
+ * the daily run streams in: old results age out second by second, new ones
+ * arrive over ~an hour, so users watch "no results" flashes and a shrinking
+ * prompt count. Anchoring to the latest COMPLETED run freezes the window
+ * between runs and swaps it atomically when the next run finishes draining.
+ *
+ * The lower bound is capped at the previous run's completion so the window
+ * never bleeds into the prior cycle's drain tail (a run that completes at
+ * 10:15 must not pick up yesterday's 10:20 stragglers).
+ */
+export async function getTrackingWindow(brandId: string): Promise<TrackingWindow> {
+  const supabase = await createClient();
+
+  const [completedResp, activeResp] = await Promise.all([
+    supabase
+      .from('tracking_runs')
+      .select('completed_at')
+      .eq('brand_id', brandId)
+      .not('completed_at', 'is', null)
+      .order('completed_at', { ascending: false })
+      .limit(2),
+    supabase
+      .from('tracking_runs')
+      .select('started_at, source')
+      .eq('brand_id', brandId)
+      .is('completed_at', null)
+      // A run row without a stamp older than the worker's drain ceiling is a
+      // crashed run, not an active one — never pin the banner on it.
+      .gte('started_at', new Date(Date.now() - 2 * 3600_000).toISOString())
+      .order('started_at', { ascending: false })
+      .limit(1),
+  ]);
+
+  const completed = completedResp.data ?? [];
+  const latest = completed[0]?.completed_at as string | undefined;
+
+  let anchored: TrackingWindow['anchored'] = null;
+  if (latest) {
+    const latestMs = new Date(latest).getTime();
+    const prev = completed[1]?.completed_at as string | undefined;
+    const lowerMs = Math.max(latestMs - 24 * 3600_000, prev ? new Date(prev).getTime() + 1 : 0);
+    anchored = { dateFrom: new Date(lowerMs).toISOString(), dateTo: latest };
+  }
+
+  const active = activeResp.data?.[0];
+  return {
+    anchored,
+    activeRun: active
+      ? { startedAt: active.started_at as string, source: (active.source as string) ?? 'manual' }
+      : null,
+  };
+}
+
 /**
  * One consolidated server action for the Insights page's first load (#313).
  *

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -1304,6 +1304,44 @@ export type Database = {
           },
         ];
       };
+      tracking_runs: {
+        Row: {
+          brand_id: string;
+          completed_at: string | null;
+          created_at: string;
+          id: string;
+          result_count: number | null;
+          source: string;
+          started_at: string;
+        };
+        Insert: {
+          brand_id: string;
+          completed_at?: string | null;
+          created_at?: string;
+          id?: string;
+          result_count?: number | null;
+          source?: string;
+          started_at?: string;
+        };
+        Update: {
+          brand_id?: string;
+          completed_at?: string | null;
+          created_at?: string;
+          id?: string;
+          result_count?: number | null;
+          source?: string;
+          started_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'tracking_runs_brand_id_fkey';
+            columns: ['brand_id'];
+            isOneToOne: false;
+            referencedRelation: 'brands';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       webhook_configs: {
         Row: {
           brand_id: string;


### PR DESCRIPTION
## Summary

Every morning while the daily run streamed in, the Insights 24h view briefly showed **"no results for the last 24 hrs"** and then a **shrinking tracked-prompt count**: the rolling `[now − 24h, now]` window was dropping yesterday's results second by second while today's arrived over ~an hour.

This PR anchors the 24h view to the **last completed tracking run**:

- **`00044` migration — `tracking_runs` ledger** (`brand_id`, `source`, `started_at`, `completed_at`, `result_count`) with member-select RLS, plus a synthetic backfilled run per brand so the fix applies immediately. *Already applied to the hosted DB.* Reads `prompt_results` only — no existing data is modified and nothing is re-scraped.
- **Worker stamping** — full runs (cron or manual Run All) insert a ledger row up front and stamp `completed_at` after the drain loop finishes; by then the run's results are all inserted, so no webhook-side bookkeeping is needed. Zero-result runs delete their row (the anchor never moves onto an empty window); single/subset-prompt runs never stamp.
- **Insights 24h window** — resolved from the ledger as `(previous completed run, latest completed run]`: always full, frozen between runs, and swapped **atomically** when the next run completes. Brands with no completed run yet (fresh onboarding) keep the live rolling window, where regression is impossible because nothing is older than 24h. Other presets are untouched.
- **`ServerRunBanner`** — cron/teammate-started runs now show an in-progress banner (the old banner only knew about jobs started from that browser via localStorage, which is why users saw nothing during the morning run). A 60s ledger poll reloads the page silently the moment the active run completes.
- **Trend chart / leaderboard consistency** — the chart's top-4 competitor cap now ranks by the last point's value (equal to the leaderboard's window score by construction), so both surfaces always show the same brands; on short ranges the old period-average pick could drop a competitor the leaderboard ranked 2nd.

## Related issue

Fixes the customer-reported morning flash/regression on the Insights 24h view (no tracked issue).

## Type of change

- [x] `fix` — Bug fix

## How to test

1. On a brand with tracking history, open Insights with the 24h preset — the KPI cards, trend chart, leaderboard, and SOV all reflect the latest completed run, at any time of day.
2. Trigger a full run (or wait for the daily cron): a "tracking in progress" banner appears **in every browser**, the numbers stay frozen on the previous run, and the page refreshes itself to the new run's numbers when the drain finishes — no empty state, no shrinking counts.
3. A brand created fresh (no completed run) still streams results live during its first run.
4. The trend chart's plotted competitors match the leaderboard's top rows exactly.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
