### PR TITLE
feat: optional US state-level geo-targeting for AI prompt tracking

### DIFF
--- a/server/src/lib/cloro-scraper.js
+++ b/server/src/lib/cloro-scraper.js
@@ -31,8 +31,14 @@ function getApiKey() {
   return key;
 }
 
-function buildRequestBody(promptText, scraperId, region) {
+export function buildRequestBody(promptText, scraperId, region, state) {
   const country = region || 'US';
+
+  // State-level geo-targeting (#554): the AI endpoints accept a USPS state
+  // code alongside country US and route through an in-state proxy. Google
+  // AIO / AI Mode use location/uule for sub-country targeting instead and
+  // must never receive it — their branches below skip this spread.
+  const stateField = country === 'US' && state ? { state } : {};
 
   if (scraperId === 'chatgpt-shopping') {
     // ChatGPT Shopping uses the same CHATGPT task but flips include.shopping.
@@ -41,6 +47,7 @@ function buildRequestBody(promptText, scraperId, region) {
     return {
       prompt: promptText,
       country,
+      ...stateField,
       include: {
         html: false,
         markdown: true,
@@ -74,6 +81,7 @@ function buildRequestBody(promptText, scraperId, region) {
   return {
     prompt: promptText,
     country,
+    ...stateField,
     include: {
       html: false,
       markdown: true,
@@ -223,16 +231,20 @@ export function parseScraperResponse(result, scraperId) {
  * @param {string} promptText
  * @param {string} scraperId
  * @param {string} [region]
- * @param {{ webhookUrl?: string }} [opts]
+ * @param {{ webhookUrl?: string, state?: string }} [opts] - `state` is the
+ *   brand's optional USPS code (#554); only forwarded on US AI-endpoint tasks.
  * @returns {Promise<{ taskId: string, scraperId: string }>}
  */
 export async function submitScraperTask(promptText, scraperId, region, opts = {}) {
   const taskType = SCRAPER_TASK_TYPES[scraperId];
   if (!taskType) throw new Error(`Unknown scraper: ${scraperId}`);
 
-  const payload = buildRequestBody(promptText, scraperId, region);
+  const payload = buildRequestBody(promptText, scraperId, region, opts.state);
 
-  logger.info({ taskType, scraperId, region: region || 'US' }, 'submitting cloro scraper task');
+  logger.info(
+    { taskType, scraperId, region: region || 'US', state: payload.state },
+    'submitting cloro scraper task',
+  );
 
   const requestBody = { taskType, payload };
   if (opts.webhookUrl) {

--- a/server/src/lib/cloro-scraper.test.js
+++ b/server/src/lib/cloro-scraper.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseScraperResponse } from './cloro-scraper.js';
+import { buildRequestBody, parseScraperResponse } from './cloro-scraper.js';
 
 describe('cloro-scraper – parseScraperResponse', () => {
   describe('chatgpt-shopping', () => {
@@ -274,5 +274,37 @@ describe('cloro-scraper – parseScraperResponse', () => {
         parseScraperResponse({ markdown: 't', sources: [] }, 'gemini-web').search_queries,
       ).toEqual([]);
     });
+  });
+});
+
+describe('cloro-scraper – buildRequestBody state targeting (#554)', () => {
+  const AI_ENDPOINTS = ['chatgpt-web', 'copilot-web', 'grok-web', 'perplexity-web', 'gemini-web'];
+
+  it('includes state on AI-endpoint tasks for US brands', () => {
+    for (const scraperId of AI_ENDPOINTS) {
+      expect(buildRequestBody('p', scraperId, 'US', 'CA').state).toBe('CA');
+    }
+  });
+
+  it('includes state on chatgpt-shopping (same CHATGPT task)', () => {
+    expect(buildRequestBody('p', 'chatgpt-shopping', 'US', 'TX').state).toBe('TX');
+  });
+
+  it('never includes state on Google AIO / AI Mode payloads', () => {
+    expect(buildRequestBody('p', 'google-aio', 'US', 'CA')).not.toHaveProperty('state');
+    expect(buildRequestBody('p', 'google-aimode', 'US', 'CA')).not.toHaveProperty('state');
+  });
+
+  it('drops state when the task country is not US', () => {
+    expect(buildRequestBody('p', 'chatgpt-web', 'DE', 'CA')).not.toHaveProperty('state');
+  });
+
+  it('omits the key entirely when the brand has no state', () => {
+    expect(buildRequestBody('p', 'chatgpt-web', 'US', null)).not.toHaveProperty('state');
+    expect(buildRequestBody('p', 'chatgpt-web', 'US', undefined)).not.toHaveProperty('state');
+  });
+
+  it('defaults the country to US so a stateful brand with a null prompt region still targets', () => {
+    expect(buildRequestBody('p', 'chatgpt-web', null, 'NY').state).toBe('NY');
   });
 });

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -27,7 +27,7 @@ export async function processTrackingJob({ brandId, promptId, promptIds, source,
   // 1. Fetch brand info with domains
   const { data: brand, error: brandErr } = await supabaseAdmin
     .from('brands')
-    .select('id, name, organization_id, shopping_mode_enabled')
+    .select('id, name, organization_id, shopping_mode_enabled, state')
     .eq('id', brandId)
     .single();
   if (brandErr || !brand) throw new Error(`Brand not found: ${brandId}`);
@@ -214,7 +214,10 @@ export async function processTrackingJob({ brandId, promptId, promptIds, source,
     // Submit all tasks concurrently
     const submissions = await Promise.allSettled(
       scraperTasks.map((t) =>
-        submitScraperTask(t.prompt.text, t.scraperId, t.region, { webhookUrl }).then((res) => ({
+        submitScraperTask(t.prompt.text, t.scraperId, t.region, {
+          webhookUrl,
+          state: brand.state,
+        }).then((res) => ({
           ...res,
           meta: t,
         })),

--- a/supabase/migrations/00043_brand_state.sql
+++ b/supabase/migrations/00043_brand_state.sql
@@ -1,0 +1,11 @@
+-- US state-level geo-targeting for AI prompt tracking (#554).
+--
+-- Optional two-letter USPS state code on the brand. NULL = nationwide, which
+-- keeps the current behavior for every existing brand. The tracking worker
+-- forwards it to the scraping provider only for US brands on the AI endpoints
+-- (Google AIO / AI Mode use a different sub-country mechanism and never see
+-- this column).
+
+ALTER TABLE public.brands
+  ADD COLUMN state text
+  CHECK (state IS NULL OR state ~ '^[A-Z]{2}$');

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -4827,6 +4827,21 @@ GRANT EXECUTE ON FUNCTION public.visibility_rate_trend(uuid, text, text[], text,
   TO authenticated;
 
 -- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00043_brand_state.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- US state-level geo-targeting for AI prompt tracking (#554).
+--
+-- Optional two-letter USPS state code on the brand. NULL = nationwide, which
+-- keeps the current behavior for every existing brand. The tracking worker
+-- forwards it to the scraping provider only for US brands on the AI endpoints
+-- (Google AIO / AI Mode use a different sub-country mechanism and never see
+-- this column).
+
+ALTER TABLE public.brands
+  ADD COLUMN state text
+  CHECK (state IS NULL OR state ~ '^[A-Z]{2}$');
+
+-- ─────────────────────────────────────────────────────────────────────────
 -- migrations/00044_tracking_runs.sql
 -- ─────────────────────────────────────────────────────────────────────────
 -- Tracking run ledger — stable insights 24h window.

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/settings/page.tsx
@@ -15,6 +15,7 @@ import { getCompetitors, addCompetitor, deleteCompetitor } from '@/lib/actions/c
 import { getFaviconUrl } from '@/lib/favicon';
 import type { Competitor } from '@/types';
 import { INDUSTRIES, type Brand, type BrandDomain } from '@/types';
+import { REGIONS, US_STATES } from '@/config/prompt-options';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -148,6 +149,8 @@ function GeneralTab({
   const [name, setName] = useState(brand.name);
   const [industry, setIndustry] = useState(brand.industry ?? '');
   const [description, setDescription] = useState(brand.description ?? '');
+  const [region, setRegion] = useState(brand.region ?? 'US');
+  const [usState, setUsState] = useState(brand.state ?? '');
   const [isSaving, setIsSaving] = useState(false);
 
   const handleSave = async () => {
@@ -158,12 +161,16 @@ function GeneralTab({
         name: name.trim(),
         industry: industry || null,
         description: description || null,
+        region,
+        state: region === 'US' ? usState || null : null,
       });
       onUpdate({
         name: updated.name,
         slug: updated.slug,
         industry: updated.industry,
         description: updated.description,
+        region: updated.region,
+        state: updated.state,
         updatedAt: updated.updatedAt,
       });
       toast.success(t('settings.saved'));
@@ -217,6 +224,54 @@ function GeneralTab({
             rows={3}
           />
         </div>
+
+        <div className="space-y-2">
+          <Label>Region</Label>
+          <Select
+            value={region}
+            onValueChange={(v) => {
+              if (!v) return;
+              setRegion(v);
+              if (v !== 'US') setUsState('');
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {REGIONS.map((r) => (
+                <SelectItem key={r.code} value={r.code}>
+                  {r.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {region === 'US' && (
+          <div className="space-y-2">
+            <Label>State (optional)</Label>
+            <Select
+              value={usState || 'nationwide'}
+              onValueChange={(v) => setUsState(!v || v === 'nationwide' ? '' : v)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="nationwide">Nationwide (no state)</SelectItem>
+                {US_STATES.map((s) => (
+                  <SelectItem key={s.code} value={s.code}>
+                    {s.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Localizes AI answers to this state from the next tracking run onward.
+            </p>
+          </div>
+        )}
 
         <Button onClick={handleSave} disabled={isSaving || !name.trim()} className="gap-2">
           {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
@@ -12,7 +12,7 @@ import { triggerTrackingCheck } from '@/lib/actions/tracking';
 import { usePlanContext } from '@/components/providers/plan-provider';
 import { getFaviconUrl } from '@/lib/favicon';
 import { useBrandStore } from '@/stores/use-brand-store';
-import { REGIONS, LANGUAGES } from '@/config/prompt-options';
+import { REGIONS, US_STATES, LANGUAGES } from '@/config/prompt-options';
 import { ALL_MODELS, ALL_SCRAPERS } from '@/config/prompt-options';
 import { getPlan, type PlanId } from '@/config/plans';
 import type { Brand } from '@/types';
@@ -228,6 +228,7 @@ export default function NewBrandPage() {
 
   // Step 2
   const [region, setRegion] = useState('US');
+  const [usState, setUsState] = useState('');
   const [language, setLanguage] = useState('en');
 
   // Intermediate state
@@ -382,6 +383,7 @@ export default function NewBrandPage() {
           logoUrl: logoUrl ?? null,
           description: description.trim() || null,
           region,
+          state: region === 'US' ? usState || null : null,
           language,
         });
 
@@ -418,6 +420,7 @@ export default function NewBrandPage() {
           logoUrl,
           description: description.trim() || undefined,
           region,
+          state: region === 'US' ? usState || undefined : undefined,
           language,
           domains: domain ? [{ domain, isPrimary: true }] : [],
         });
@@ -830,7 +833,14 @@ export default function NewBrandPage() {
           <div className="space-y-4">
             <div className="space-y-2">
               <Label>Region</Label>
-              <Select value={region} onValueChange={(v) => v && setRegion(v)}>
+              <Select
+                value={region}
+                onValueChange={(v) => {
+                  if (!v) return;
+                  setRegion(v);
+                  if (v !== 'US') setUsState('');
+                }}
+              >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -843,6 +853,31 @@ export default function NewBrandPage() {
                 </SelectContent>
               </Select>
             </div>
+
+            {region === 'US' && (
+              <div className="space-y-2">
+                <Label>State (optional)</Label>
+                <Select
+                  value={usState || 'nationwide'}
+                  onValueChange={(v) => setUsState(!v || v === 'nationwide' ? '' : v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="nationwide">Nationwide (no state)</SelectItem>
+                    {US_STATES.map((s) => (
+                      <SelectItem key={s.code} value={s.code}>
+                        {s.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Localizes AI answers to this state. Leave empty for nationwide results.
+                </p>
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label>Language</Label>

--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -10,7 +10,7 @@ import { triggerTrackingCheck } from '@/lib/actions/tracking';
 import { addCompetitor, getCompetitors } from '@/lib/actions/competitor';
 import { getFaviconUrl } from '@/lib/favicon';
 import { useBrandStore } from '@/stores/use-brand-store';
-import { REGIONS, LANGUAGES } from '@/config/prompt-options';
+import { REGIONS, US_STATES, LANGUAGES } from '@/config/prompt-options';
 import { ALL_MODELS, ALL_SCRAPERS } from '@/config/prompt-options';
 import { isCloud, PLANS, SUBSCRIBABLE_PLANS, getPlan, type PlanId } from '@/config/plans';
 import { setPersonProperties, track } from '@/lib/analytics';
@@ -237,6 +237,7 @@ export default function OnboardingPage() {
 
   // Step 2
   const [region, setRegion] = useState('US');
+  const [usState, setUsState] = useState('');
   const [language, setLanguage] = useState('en');
 
   // Intermediate state
@@ -411,6 +412,7 @@ export default function OnboardingPage() {
               industry: b.industry ?? undefined,
               description: b.description ?? undefined,
               region: b.region ?? undefined,
+              state: b.state ?? undefined,
               language: b.language ?? undefined,
               shoppingModeEnabled: !!b.shopping_mode_enabled,
               isActive: (b as { is_active?: boolean }).is_active ?? true,
@@ -431,6 +433,7 @@ export default function OnboardingPage() {
             setWebsite(mapped.domains[0]?.domain || '');
             setDescription(mapped.description || '');
             setRegion(mapped.region || 'US');
+            setUsState(mapped.state || '');
             setLanguage(mapped.language || 'en');
 
             const topics = await getTopics(mapped.id);
@@ -554,6 +557,7 @@ export default function OnboardingPage() {
           logoUrl,
           description: description.trim() || undefined,
           region,
+          state: region === 'US' ? usState || undefined : undefined,
           language,
           domains: domain ? [{ domain, isPrimary: true }] : [],
         });
@@ -1086,7 +1090,14 @@ export default function OnboardingPage() {
           <div className="space-y-4">
             <div className="space-y-2">
               <Label>Region</Label>
-              <Select value={region} onValueChange={(v) => v && setRegion(v)}>
+              <Select
+                value={region}
+                onValueChange={(v) => {
+                  if (!v) return;
+                  setRegion(v);
+                  if (v !== 'US') setUsState('');
+                }}
+              >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -1099,6 +1110,31 @@ export default function OnboardingPage() {
                 </SelectContent>
               </Select>
             </div>
+
+            {region === 'US' && (
+              <div className="space-y-2">
+                <Label>State (optional)</Label>
+                <Select
+                  value={usState || 'nationwide'}
+                  onValueChange={(v) => setUsState(!v || v === 'nationwide' ? '' : v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="nationwide">Nationwide (no state)</SelectItem>
+                    {US_STATES.map((s) => (
+                      <SelectItem key={s.code} value={s.code}>
+                        {s.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Localizes AI answers to this state. Leave empty for nationwide results.
+                </p>
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label>Language</Label>

--- a/web/src/config/prompt-options.ts
+++ b/web/src/config/prompt-options.ts
@@ -21,6 +21,68 @@ export const REGIONS = [
 
 export type RegionCode = (typeof REGIONS)[number]['code'];
 
+/**
+ * US states for optional state-level geo-targeting (#554). Static on purpose:
+ * the UI must not depend on the scraping provider's states endpoint. Codes are
+ * USPS two-letter abbreviations, which is what the provider expects alongside
+ * `country: 'US'`.
+ */
+export const US_STATES = [
+  { code: 'AL', label: 'Alabama' },
+  { code: 'AK', label: 'Alaska' },
+  { code: 'AZ', label: 'Arizona' },
+  { code: 'AR', label: 'Arkansas' },
+  { code: 'CA', label: 'California' },
+  { code: 'CO', label: 'Colorado' },
+  { code: 'CT', label: 'Connecticut' },
+  { code: 'DE', label: 'Delaware' },
+  { code: 'DC', label: 'District of Columbia' },
+  { code: 'FL', label: 'Florida' },
+  { code: 'GA', label: 'Georgia' },
+  { code: 'HI', label: 'Hawaii' },
+  { code: 'ID', label: 'Idaho' },
+  { code: 'IL', label: 'Illinois' },
+  { code: 'IN', label: 'Indiana' },
+  { code: 'IA', label: 'Iowa' },
+  { code: 'KS', label: 'Kansas' },
+  { code: 'KY', label: 'Kentucky' },
+  { code: 'LA', label: 'Louisiana' },
+  { code: 'ME', label: 'Maine' },
+  { code: 'MD', label: 'Maryland' },
+  { code: 'MA', label: 'Massachusetts' },
+  { code: 'MI', label: 'Michigan' },
+  { code: 'MN', label: 'Minnesota' },
+  { code: 'MS', label: 'Mississippi' },
+  { code: 'MO', label: 'Missouri' },
+  { code: 'MT', label: 'Montana' },
+  { code: 'NE', label: 'Nebraska' },
+  { code: 'NV', label: 'Nevada' },
+  { code: 'NH', label: 'New Hampshire' },
+  { code: 'NJ', label: 'New Jersey' },
+  { code: 'NM', label: 'New Mexico' },
+  { code: 'NY', label: 'New York' },
+  { code: 'NC', label: 'North Carolina' },
+  { code: 'ND', label: 'North Dakota' },
+  { code: 'OH', label: 'Ohio' },
+  { code: 'OK', label: 'Oklahoma' },
+  { code: 'OR', label: 'Oregon' },
+  { code: 'PA', label: 'Pennsylvania' },
+  { code: 'RI', label: 'Rhode Island' },
+  { code: 'SC', label: 'South Carolina' },
+  { code: 'SD', label: 'South Dakota' },
+  { code: 'TN', label: 'Tennessee' },
+  { code: 'TX', label: 'Texas' },
+  { code: 'UT', label: 'Utah' },
+  { code: 'VT', label: 'Vermont' },
+  { code: 'VA', label: 'Virginia' },
+  { code: 'WA', label: 'Washington' },
+  { code: 'WV', label: 'West Virginia' },
+  { code: 'WI', label: 'Wisconsin' },
+  { code: 'WY', label: 'Wyoming' },
+] as const;
+
+export type UsStateCode = (typeof US_STATES)[number]['code'];
+
 export const LANGUAGES = [
   { code: 'en', label: 'English (en)' },
   { code: 'de', label: 'German (de)' },

--- a/web/src/lib/actions/brand.ts
+++ b/web/src/lib/actions/brand.ts
@@ -35,6 +35,7 @@ function mapBrandRow(brand: Record<string, unknown>, domains: Record<string, unk
     industry: (brand.industry as string | null) ?? undefined,
     description: (brand.description as string | null) ?? undefined,
     region: (brand.region as string | null) ?? undefined,
+    state: (brand.state as string | null) ?? undefined,
     language: (brand.language as string | null) ?? undefined,
     trackingCode: (brand.tracking_code as string | null) ?? undefined,
     shoppingModeEnabled: !!brand.shopping_mode_enabled,
@@ -85,6 +86,7 @@ interface CreateBrandInput {
   industry?: string;
   description?: string;
   region?: string;
+  state?: string;
   language?: string;
   domains: { domain: string; country?: string; isPrimary: boolean }[];
 }
@@ -111,6 +113,9 @@ export async function createBrand(input: CreateBrandInput): Promise<Brand> {
       industry: input.industry || null,
       description: input.description || null,
       region: input.region || 'US',
+      // State only makes sense for US brands; drop it silently otherwise so
+      // a stale value from a region switch can't leak into the row.
+      state: (input.region || 'US') === 'US' ? input.state || null : null,
       language: input.language || 'en',
     })
     .select()
@@ -147,6 +152,7 @@ interface UpdateBrandInput {
   industry?: string | null;
   description?: string | null;
   region?: string;
+  state?: string | null;
   language?: string;
 }
 
@@ -162,6 +168,9 @@ export async function updateBrand(id: string, updates: UpdateBrandInput): Promis
   if ('industry' in updates) payload.industry = updates.industry ?? null;
   if ('description' in updates) payload.description = updates.description ?? null;
   if (updates.region !== undefined) payload.region = updates.region;
+  if ('state' in updates) payload.state = updates.state ?? null;
+  // A region change away from US invalidates any stored state.
+  if (updates.region !== undefined && updates.region !== 'US') payload.state = null;
   if (updates.language !== undefined) payload.language = updates.language;
 
   const { data, error } = await supabase

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -20,6 +20,8 @@ export interface Brand {
   industry?: string;
   description?: string;
   region?: string;
+  /** Optional US state (USPS code) for state-level geo-targeting; US brands only (#554). */
+  state?: string;
   language?: string;
   trackingCode?: string;
   shoppingModeEnabled: boolean;

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -295,6 +295,7 @@ export type Database = {
           region: string | null;
           shopping_mode_enabled: boolean;
           slug: string;
+          state: string | null;
           tracking_code: string;
           updated_at: string;
         };
@@ -311,6 +312,7 @@ export type Database = {
           region?: string | null;
           shopping_mode_enabled?: boolean;
           slug: string;
+          state?: string | null;
           tracking_code?: string;
           updated_at?: string;
         };
@@ -327,6 +329,7 @@ export type Database = {
           region?: string | null;
           shopping_mode_enabled?: boolean;
           slug?: string;
+          state?: string | null;
           tracking_code?: string;
           updated_at?: string;
         };


### PR DESCRIPTION
## Summary

US brands can now optionally pick a state (USPS two-letter code) and get **state-localized AI answers**: the tracking worker forwards the state to the scraping provider on AI-endpoint tasks, which routes the request through an in-state proxy.

- **`00043` migration** — nullable `brands.state` with a two-letter CHECK; `NULL` = nationwide, so every existing brand keeps today's behavior. *Already applied to the hosted DB.*
- **Static `US_STATES` list** (50 states + DC) in `web/src/config/prompt-options.ts` — no runtime dependency on the provider's states endpoint.
- **"State (optional)" select** on the Add Brand market step, the onboarding market step, and the brand settings General tab (Region is now editable there too). The field only renders when the region is `US`, includes an explicit "Nationwide (no state)" option, and switching the region away from `US` clears the value both in the UI and in `updateBrand`.
- **Server** — the worker reads `brands.state` and passes it to `submitScraperTask`; `buildRequestBody` includes `state` **only** when `country === 'US'` and the task is an AI endpoint (`chatgpt-web`, `chatgpt-shopping`, `copilot-web`, `grok-web`, `perplexity-web`, `gemini-web`). Google AIO / AI Mode payloads are untouched — they use a different sub-country mechanism.
- 6 new unit tests cover the request-body matrix (AI endpoints, shopping, Google exclusions, non-US regions, missing state).

## Related issue

Closes #554

## Type of change

- [x] `feat` — New feature

## How to test

1. Brand settings → General: with region `US`, pick a state and save; switch region to another country — the state field disappears and the stored value clears.
2. Create a brand (Add Brand or onboarding) with region `US` + a state; verify `brands.state` holds the code.
3. Run tracking for a US+state brand: AI-endpoint requests to the provider include `state`; `google-aio` / `google-aimode` payloads don't.
4. Brands without a state (or non-US) behave exactly as before.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
