### PR TITLE
fix(web): return addPromptToSet failures as values instead of throwing

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -252,7 +252,7 @@ export default function PromptsPage() {
         }
         targetSetId = result.promptSet.id;
       } else {
-        await Promise.all(
+        const results = await Promise.all(
           activePrompts.map((p) =>
             addPromptToSet({
               promptSetId: targetSetId,
@@ -263,6 +263,14 @@ export default function PromptsPage() {
             }),
           ),
         );
+        const failed = results.find((r) => 'error' in r);
+        if (failed && 'error' in failed) {
+          toast.error(failed.error);
+          // Some prompts may have saved before the failure — refresh so the
+          // list reflects what actually landed.
+          await loadData();
+          return;
+        }
       }
 
       setSuggestions([]);
@@ -290,10 +298,14 @@ export default function PromptsPage() {
       };
 
       if (existingSet) {
-        await addPromptToSet({
+        const result = await addPromptToSet({
           promptSetId: existingSet.id,
           ...promptData,
         });
+        if ('error' in result) {
+          toast.error(result.error);
+          return;
+        }
       } else {
         const result = await savePromptSet({
           brandId,

--- a/web/src/lib/actions/fanout.ts
+++ b/web/src/lib/actions/fanout.ts
@@ -3,7 +3,6 @@
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { addPromptToSet } from '@/lib/actions/prompt';
-import { PlanLimitError } from '@/lib/guards/plan-guard';
 import { API_BASE_URL } from '@/config/api';
 
 /**
@@ -263,19 +262,11 @@ export async function trackFanoutQuery(brandId: string, query: string): Promise<
       : ['chatgpt-web'];
   const models = Array.isArray(defaults?.models) ? (defaults!.models as string[]) : [];
 
-  // User-facing failures (plan limit, invalid input) come back as a VALUE:
-  // production masks every error thrown from a server action, so a thrown
-  // PlanLimitError reached users as the meaningless digest message (#427).
-  let created;
-  try {
-    created = await addPromptToSet({ promptSetId: ps.id as string, text, platforms, models });
-  } catch (err) {
-    if (err instanceof PlanLimitError) return { error: err.message };
-    throw err;
-  }
+  const created = await addPromptToSet({ promptSetId: ps.id as string, text, platforms, models });
+  if ('error' in created) return { error: created.error };
 
   revalidatePath('/dashboard/prompts');
-  return { promptId: created.id };
+  return { promptId: created.prompt.id };
 }
 
 /**

--- a/web/src/lib/actions/prompt-suggestions.ts
+++ b/web/src/lib/actions/prompt-suggestions.ts
@@ -157,13 +157,17 @@ export async function acceptSuggestion(
   const models =
     options?.models ?? (Array.isArray(defaults?.models) ? (defaults!.models as string[]) : []);
 
-  const created = await addPromptToSet({
+  const result = await addPromptToSet({
     promptSetId: ps.id,
     text: row.suggested_text,
     category: row.topic_name ?? undefined,
     platforms,
     models,
   });
+  if ('error' in result) {
+    throw new Error(result.error);
+  }
+  const created = result.prompt;
 
   const ack = await fetch(`${AEO_SERVER_URL}/api/prompts/suggestions/${suggestionId}/accept`, {
     method: 'POST',

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -372,7 +372,15 @@ interface AddPromptInput {
   models?: string[];
 }
 
-export async function addPromptToSet(input: AddPromptInput): Promise<Prompt> {
+export type AddPromptToSetResult = { prompt: Prompt } | { error: string; code?: 'plan_limit' };
+
+/**
+ * User-facing failures (plan limit, empty platform selection, DB errors) come
+ * back as a VALUE: production masks every error thrown from a server action,
+ * so a thrown PlanLimitError would reach users as the meaningless digest
+ * message (#427).
+ */
+export async function addPromptToSet(input: AddPromptInput): Promise<AddPromptToSetResult> {
   const supabase = await createClient();
 
   const { data: ps } = await supabase
@@ -381,19 +389,24 @@ export async function addPromptToSet(input: AddPromptInput): Promise<Prompt> {
     .eq('id', input.promptSetId)
     .single();
 
-  if (!ps?.brand_id) throw new Error('Prompt set not found');
+  if (!ps?.brand_id) return { error: 'Prompt set not found' };
 
   const { organizationId: orgId, region: brandRegion } = await getBrandContext(
     supabase,
     ps.brand_id as string,
   );
   const currentCount = await getOrgPromptCount(supabase, orgId);
-  await enforceLimit(orgId, 'maxPrompts', currentCount);
+  try {
+    await enforceLimit(orgId, 'maxPrompts', currentCount);
+  } catch (err) {
+    if (err instanceof PlanLimitError) return { error: err.message, code: 'plan_limit' };
+    throw err;
+  }
 
   const plan = await getOrgPlan(orgId);
   const filtered = filterByPlan(plan, input.platforms, input.models ?? []);
   if (filtered.platforms.length === 0 && filtered.models.length === 0) {
-    throw new Error('At least one platform or model must be selected.');
+    return { error: 'At least one platform or model must be selected.' };
   }
 
   const topicId = await resolveTopicId(supabase, ps.brand_id as string, input.category);
@@ -411,7 +424,7 @@ export async function addPromptToSet(input: AddPromptInput): Promise<Prompt> {
     ? Array.from(new Set([...filtered.platforms, 'chatgpt-shopping']))
     : stripShoppingWhenDisabled(filtered.platforms, false);
   if (platforms.length === 0 && filtered.models.length === 0) {
-    throw new Error('At least one platform or model must be selected.');
+    return { error: 'At least one platform or model must be selected.' };
   }
 
   const { data, error } = await supabase
@@ -430,11 +443,11 @@ export async function addPromptToSet(input: AddPromptInput): Promise<Prompt> {
     .single();
 
   if (error || !data) {
-    throw new Error(error?.message ?? 'Failed to add prompt');
+    return { error: error?.message ?? 'Failed to add prompt' };
   }
 
   revalidatePath('/dashboard/brands');
-  return mapPromptRow(data as Record<string, unknown>);
+  return { prompt: mapPromptRow(data as Record<string, unknown>) };
 }
 
 export type AddPromptToBrandResult = { prompt: Prompt } | { error: string };
@@ -482,22 +495,17 @@ export async function addPromptToBrand(
     promptSetId = createdSet.id as string;
   }
 
-  let created: Prompt;
-  try {
-    created = await addPromptToSet({
-      promptSetId,
-      text: trimmed,
-      category: input.category,
-      platforms: input.platforms,
-      models: input.models ?? [],
-    });
-  } catch (err) {
-    if (err instanceof PlanLimitError) return { error: err.message };
-    throw err;
-  }
+  const result = await addPromptToSet({
+    promptSetId,
+    text: trimmed,
+    category: input.category,
+    platforms: input.platforms,
+    models: input.models ?? [],
+  });
+  if ('error' in result) return { error: result.error };
 
   revalidatePath('/dashboard/prompts');
-  return { prompt: created };
+  return { prompt: result.prompt };
 }
 
 export async function deletePrompt(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

`addPromptToSet` still threw on user-reachable failures, so in production the plan-limit and validation messages surfaced as the masked `An error occurred in the Server Components render… digest` toast. This converts it to the same value-shape `savePromptSet` adopted in #536:

- `addPromptToSet` now returns `{ prompt } | { error, code?: 'plan_limit' }`; all four throw sites became values ("Prompt set not found", `PlanLimitError` → `code: 'plan_limit'`, empty platform/model selection, Supabase insert errors).
- Callers beyond the two named in the issue were adapted too: `addPromptToBrand` and `trackFanoutQuery` drop their try/catch wrappers and forward the error value; `acceptSuggestion` keeps its existing throwing contract, adapted to the new shape.
- The brand Prompts page (bulk suggestion save + manual add) shows the real message via toast; the bulk path also refreshes the list when a parallel save partially fails, so prompts that did land appear.

## Related issue

Closes #547

## Type of change

- [x] `fix` — Bug fix

## How to test

1. On an org at its prompt cap, open Brand → Prompts and add a single prompt — the toast shows the human-readable plan-limit message, never the digest string.
2. Same at the bulk "Save prompts" flow for generated suggestions.
3. Deselect all platforms and models on the manual add card — the toast reads "At least one platform or model must be selected."
4. Fan-out "Track" and suggestion "Accept" flows still work end to end.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
