### PR TITLE
feat: trigger prompt volume analysis after checkout

### DIFF
--- a/server/src/lib/volume-analysis.js
+++ b/server/src/lib/volume-analysis.js
@@ -83,7 +83,10 @@ export async function fetchAndSaveVolumes(promptId, keywords, intent, locationCo
   return saved;
 }
 
-export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
+export async function analyzeBrandVolumes(
+  brandId,
+  { promptIds, locationCode, languageCode, force = false, onlyMissing = false } = {},
+) {
   const { data: brand, error: brandError } = await supabaseAdmin
     .from('brands')
     .select('region, language')
@@ -97,9 +100,10 @@ export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
     throw new Error(`Brand ${brandId} not found`);
   }
 
-  const resolvedLocationCode = brand.region ? regionToLocationCode(brand.region) : undefined;
-
-  const resolvedLanguageCode = brand.language ? languageToCode(brand.language) : undefined;
+  const resolvedLocationCode =
+    locationCode ?? (brand.region ? regionToLocationCode(brand.region) : undefined);
+  const resolvedLanguageCode =
+    languageCode ?? (brand.language ? languageToCode(brand.language) : undefined);
   const { data: promptSets, error: psError } = await supabaseAdmin
     .from('prompt_sets')
     .select('id')
@@ -114,11 +118,16 @@ export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
   }
 
   const setIds = promptSets.map((ps) => ps.id);
+  let promptsQuery = supabaseAdmin.from('prompts').select('id, text');
 
-  const { data: prompts, error: pError } = await supabaseAdmin
-    .from('prompts')
-    .select('id, text')
-    .in('prompt_set_id', setIds);
+  if (promptIds?.length) {
+    promptsQuery = promptsQuery.in('id', promptIds);
+  } else {
+    promptsQuery = promptsQuery.in('prompt_set_id', setIds);
+  }
+
+  const { data: prompts, error: pError } = await promptsQuery;
+
   if (pError) {
     throw new Error(`Failed to fetch prompts: ${pError.message}`);
   }
@@ -127,15 +136,15 @@ export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
     return [];
   }
 
-  const promptIds = prompts.map((p) => p.id);
-
+  const analyzedPromptIds = prompts.map((p) => p.id);
   const existingMap = {};
+  const existingPromptIds = new Set();
 
-  if (!force) {
+  if (!force || onlyMissing) {
     const { data: existingRows, error: existingError } = await supabaseAdmin
       .from('prompt_volumes')
       .select('prompt_id, intent, keywords')
-      .in('prompt_id', promptIds);
+      .in('prompt_id', analyzedPromptIds);
 
     if (existingError) {
       throw new Error(`Failed to fetch existing volumes: ${existingError.message}`);
@@ -143,6 +152,8 @@ export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
 
     if (existingRows) {
       for (const row of existingRows) {
+        existingPromptIds.add(row.prompt_id);
+
         if (row.keywords?.length) {
           existingMap[row.prompt_id] = {
             intent: row.intent,
@@ -153,10 +164,16 @@ export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
     }
   }
 
+  let promptsToAnalyze = prompts;
+
+  if (onlyMissing) {
+    promptsToAnalyze = prompts.filter(({ id }) => !existingPromptIds.has(id));
+  }
+
   const aiModel = resolveModel();
   const results = [];
 
-  for (const { id: promptId, text: promptText } of prompts) {
+  for (const { id: promptId, text: promptText } of promptsToAnalyze) {
     try {
       let intent;
       let keywords;
@@ -178,11 +195,15 @@ export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
         resolvedLocationCode,
         resolvedLanguageCode,
       );
+
       results.push(mapVolumeRow(saved));
     } catch (err) {
       logger.error({ err, promptId }, 'volume analysis failed for prompt');
 
-      results.push({ promptId, error: err.message });
+      results.push({
+        promptId,
+        error: err.message,
+      });
     }
   }
   return results;

--- a/server/src/lib/volume-analysis.js
+++ b/server/src/lib/volume-analysis.js
@@ -1,0 +1,189 @@
+import { resolveModel } from '../lib/ai-provider.js';
+import { regionToLocationCode, languageToCode } from '../lib/dataforseo-codes.js';
+import supabaseAdmin from '../config/supabase.js';
+import { AI_VOLUME_MULTIPLIER, extractIntentKeywords } from '../lib/intent-extraction.js';
+import { getSearchVolumes } from './dataforseo.js';
+import logger from './logger.js';
+
+export function mapVolumeRow(saved) {
+  return {
+    id: saved.id,
+    promptId: saved.prompt_id,
+    intent: saved.intent,
+    keywords: saved.keywords,
+    googleVolumes: saved.google_volumes,
+    totalGoogleVolume: saved.total_google_volume,
+    aiVolumeMultiplier: parseFloat(saved.ai_volume_multiplier),
+    estAiVolume: saved.est_ai_volume,
+    competitionIndex: saved.competition_index ?? null,
+    competition: saved.competition ?? null,
+    locationCode: saved.location_code,
+    languageCode: saved.language_code,
+    fetchedAt: saved.fetched_at,
+  };
+}
+
+export async function fetchAndSaveVolumes(promptId, keywords, intent, locationCode, languageCode) {
+  const volumes = await getSearchVolumes(keywords, {
+    locationCode: locationCode || undefined,
+    languageCode: languageCode || undefined,
+  });
+
+  // google_volumes stays a { keyword: number } map for the UI. Competition is
+  // aggregated per prompt as a volume-weighted average of the keyword indices.
+  const googleVolumes = {};
+  let totalGoogleVolume = 0;
+  let competitionWeightedSum = 0;
+  let competitionWeight = 0;
+  for (const [keyword, data] of Object.entries(volumes)) {
+    googleVolumes[keyword] = data.volume;
+    totalGoogleVolume += data.volume;
+    if (data.competitionIndex !== null && data.competitionIndex !== undefined) {
+      competitionWeightedSum += data.competitionIndex * data.volume;
+      competitionWeight += data.volume;
+    }
+  }
+
+  const competitionIndex =
+    competitionWeight > 0 ? Math.round(competitionWeightedSum / competitionWeight) : null;
+  const competition =
+    competitionIndex === null
+      ? null
+      : competitionIndex <= 33
+        ? 'LOW'
+        : competitionIndex <= 66
+          ? 'MEDIUM'
+          : 'HIGH';
+
+  const estAiVolume = Math.round(totalGoogleVolume * AI_VOLUME_MULTIPLIER);
+
+  const { data: saved, error: dbError } = await supabaseAdmin
+    .from('prompt_volumes')
+    .upsert(
+      {
+        prompt_id: promptId,
+        intent,
+        keywords,
+        google_volumes: googleVolumes,
+        total_google_volume: totalGoogleVolume,
+        ai_volume_multiplier: AI_VOLUME_MULTIPLIER,
+        est_ai_volume: estAiVolume,
+        competition_index: competitionIndex,
+        competition,
+        location_code: locationCode || null,
+        language_code: languageCode || null,
+        fetched_at: new Date().toISOString(),
+      },
+      { onConflict: 'prompt_id' },
+    )
+    .select()
+    .single();
+
+  if (dbError) throw new Error(dbError.message);
+  return saved;
+}
+
+export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
+  const { data: brand, error: brandError } = await supabaseAdmin
+    .from('brands')
+    .select('region, language')
+    .eq('id', brandId)
+    .maybeSingle();
+
+  if (brandError) {
+    throw new Error(`Failed to fetch brand: ${brandError.message}`);
+  }
+  if (!brand) {
+    throw new Error(`Brand ${brandId} not found`);
+  }
+
+  const resolvedLocationCode = brand.region ? regionToLocationCode(brand.region) : undefined;
+
+  const resolvedLanguageCode = brand.language ? languageToCode(brand.language) : undefined;
+  const { data: promptSets, error: psError } = await supabaseAdmin
+    .from('prompt_sets')
+    .select('id')
+    .eq('brand_id', brandId);
+
+  if (psError) {
+    throw new Error(`Failed to fetch prompt sets: ${psError.message}`);
+  }
+
+  if (!promptSets || promptSets.length === 0) {
+    return [];
+  }
+
+  const setIds = promptSets.map((ps) => ps.id);
+
+  const { data: prompts, error: pError } = await supabaseAdmin
+    .from('prompts')
+    .select('id, text')
+    .in('prompt_set_id', setIds);
+  if (pError) {
+    throw new Error(`Failed to fetch prompts: ${pError.message}`);
+  }
+
+  if (!prompts || prompts.length === 0) {
+    return [];
+  }
+
+  const promptIds = prompts.map((p) => p.id);
+
+  const existingMap = {};
+
+  if (!force) {
+    const { data: existingRows, error: existingError } = await supabaseAdmin
+      .from('prompt_volumes')
+      .select('prompt_id, intent, keywords')
+      .in('prompt_id', promptIds);
+
+    if (existingError) {
+      throw new Error(`Failed to fetch existing volumes: ${existingError.message}`);
+    }
+
+    if (existingRows) {
+      for (const row of existingRows) {
+        if (row.keywords?.length) {
+          existingMap[row.prompt_id] = {
+            intent: row.intent,
+            keywords: row.keywords,
+          };
+        }
+      }
+    }
+  }
+
+  const aiModel = resolveModel();
+  const results = [];
+
+  for (const { id: promptId, text: promptText } of prompts) {
+    try {
+      let intent;
+      let keywords;
+
+      const cached = existingMap[promptId];
+      if (cached) {
+        intent = cached.intent;
+        keywords = cached.keywords;
+      } else {
+        const intentResult = await extractIntentKeywords(promptText, aiModel);
+        intent = intentResult.intent;
+        keywords = intentResult.keywords;
+      }
+
+      const saved = await fetchAndSaveVolumes(
+        promptId,
+        keywords,
+        intent,
+        resolvedLocationCode,
+        resolvedLanguageCode,
+      );
+      results.push(mapVolumeRow(saved));
+    } catch (err) {
+      logger.error({err, promptId},'volume analysis failed for prompt');
+      
+      results.push({ promptId, error: err.message });
+    }
+  }
+  return results;
+}

--- a/server/src/lib/volume-analysis.js
+++ b/server/src/lib/volume-analysis.js
@@ -180,8 +180,8 @@ export async function analyzeBrandVolumes(brandId, { force = false } = {}) {
       );
       results.push(mapVolumeRow(saved));
     } catch (err) {
-      logger.error({err, promptId},'volume analysis failed for prompt');
-      
+      logger.error({ err, promptId }, 'volume analysis failed for prompt');
+
       results.push({ promptId, error: err.message });
     }
   }

--- a/server/src/routes/volumes.js
+++ b/server/src/routes/volumes.js
@@ -10,8 +10,7 @@ import {
 import supabaseAdmin from '../config/supabase.js';
 import { assertBrandAccess, assertPromptAccess } from '../lib/access.js';
 import { extractIntentKeywords } from '../lib/intent-extraction.js';
-import { mapVolumeRow, fetchAndSaveVolumes } from '../lib/volume-analysis.js';
-import { analyzeBrandVolumes } from '../lib/volume-analysis.js';
+import { mapVolumeRow, fetchAndSaveVolumes, analyzeBrandVolumes } from '../lib/volume-analysis.js';
 
 const router = Router();
 
@@ -118,7 +117,7 @@ router.post('/analyze-batch', requireFeature('prompt_volumes'), async (req, res)
   try {
     const { remaining, orgId } = await enforceVolumeQuota(req.user.id);
 
-    const { prompts, force } = req.body;
+    const { prompts, locationCode, languageCode, force } = req.body;
 
     if (!Array.isArray(prompts) || prompts.length === 0) {
       return res.status(400).json({ error: 'prompts array is required and must not be empty' });
@@ -150,7 +149,12 @@ router.post('/analyze-batch', requireFeature('prompt_volumes'), async (req, res)
       });
     }
 
-    const results = await analyzeBrandVolumes(brandId, { force });
+    const results = await analyzeBrandVolumes(brandId, {
+      promptIds,
+      locationCode,
+      languageCode,
+      force,
+    });
     const successCount = results.filter((r) => !r.error).length;
     if (successCount > 0 && orgId) {
       await supabaseAdmin.from('volume_usage').insert({

--- a/server/src/routes/volumes.js
+++ b/server/src/routes/volumes.js
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import { resolveModel } from '../lib/ai-provider.js';
-import { getSearchVolumes } from '../lib/dataforseo.js';
 import { regionToLocationCode, languageToCode } from '../lib/dataforseo-codes.js';
 import {
   requireFeature,
@@ -10,87 +9,11 @@ import {
 } from '../lib/plan-guard.js';
 import supabaseAdmin from '../config/supabase.js';
 import { assertBrandAccess, assertPromptAccess } from '../lib/access.js';
-import { AI_VOLUME_MULTIPLIER, extractIntentKeywords } from '../lib/intent-extraction.js';
+import { extractIntentKeywords } from '../lib/intent-extraction.js';
+import { mapVolumeRow, fetchAndSaveVolumes } from '../lib/volume-analysis.js';
+import { analyzeBrandVolumes } from '../lib/volume-analysis.js';
 
 const router = Router();
-
-function mapVolumeRow(saved) {
-  return {
-    id: saved.id,
-    promptId: saved.prompt_id,
-    intent: saved.intent,
-    keywords: saved.keywords,
-    googleVolumes: saved.google_volumes,
-    totalGoogleVolume: saved.total_google_volume,
-    aiVolumeMultiplier: parseFloat(saved.ai_volume_multiplier),
-    estAiVolume: saved.est_ai_volume,
-    competitionIndex: saved.competition_index ?? null,
-    competition: saved.competition ?? null,
-    locationCode: saved.location_code,
-    languageCode: saved.language_code,
-    fetchedAt: saved.fetched_at,
-  };
-}
-
-async function fetchAndSaveVolumes(promptId, keywords, intent, locationCode, languageCode) {
-  const volumes = await getSearchVolumes(keywords, {
-    locationCode: locationCode || undefined,
-    languageCode: languageCode || undefined,
-  });
-
-  // google_volumes stays a { keyword: number } map for the UI. Competition is
-  // aggregated per prompt as a volume-weighted average of the keyword indices.
-  const googleVolumes = {};
-  let totalGoogleVolume = 0;
-  let competitionWeightedSum = 0;
-  let competitionWeight = 0;
-  for (const [keyword, data] of Object.entries(volumes)) {
-    googleVolumes[keyword] = data.volume;
-    totalGoogleVolume += data.volume;
-    if (data.competitionIndex !== null && data.competitionIndex !== undefined) {
-      competitionWeightedSum += data.competitionIndex * data.volume;
-      competitionWeight += data.volume;
-    }
-  }
-
-  const competitionIndex =
-    competitionWeight > 0 ? Math.round(competitionWeightedSum / competitionWeight) : null;
-  const competition =
-    competitionIndex === null
-      ? null
-      : competitionIndex <= 33
-        ? 'LOW'
-        : competitionIndex <= 66
-          ? 'MEDIUM'
-          : 'HIGH';
-
-  const estAiVolume = Math.round(totalGoogleVolume * AI_VOLUME_MULTIPLIER);
-
-  const { data: saved, error: dbError } = await supabaseAdmin
-    .from('prompt_volumes')
-    .upsert(
-      {
-        prompt_id: promptId,
-        intent,
-        keywords,
-        google_volumes: googleVolumes,
-        total_google_volume: totalGoogleVolume,
-        ai_volume_multiplier: AI_VOLUME_MULTIPLIER,
-        est_ai_volume: estAiVolume,
-        competition_index: competitionIndex,
-        competition,
-        location_code: locationCode || null,
-        language_code: languageCode || null,
-        fetched_at: new Date().toISOString(),
-      },
-      { onConflict: 'prompt_id' },
-    )
-    .select()
-    .single();
-
-  if (dbError) throw new Error(dbError.message);
-  return saved;
-}
 
 /**
  * POST /api/volumes/analyze
@@ -195,7 +118,7 @@ router.post('/analyze-batch', requireFeature('prompt_volumes'), async (req, res)
   try {
     const { remaining, orgId } = await enforceVolumeQuota(req.user.id);
 
-    const { prompts, locationCode, languageCode, model, force } = req.body;
+    const { prompts, force } = req.body;
 
     if (!Array.isArray(prompts) || prompts.length === 0) {
       return res.status(400).json({ error: 'prompts array is required and must not be empty' });
@@ -209,79 +132,25 @@ router.post('/analyze-batch', requireFeature('prompt_volumes'), async (req, res)
 
     await assertPromptAccess(promptIds, req.user.id);
 
-    // Resolve DataForSEO location/language from the brand the prompts belong to,
-    // unless the caller explicitly passed an override in the request body.
-    let resolvedLocationCode = locationCode;
-    let resolvedLanguageCode = languageCode;
-    if (resolvedLocationCode == null || resolvedLanguageCode == null) {
-      const { data: brandRow } = await supabaseAdmin
-        .from('prompts')
-        .select('prompt_sets!inner(brands!inner(region, language))')
-        .in('id', promptIds)
-        .limit(1)
-        .maybeSingle();
-      const brand = brandRow?.prompt_sets?.brands;
-      if (brand) {
-        if (resolvedLocationCode == null) {
-          resolvedLocationCode = regionToLocationCode(brand.region);
-        }
-        if (resolvedLanguageCode == null) {
-          resolvedLanguageCode = languageToCode(brand.language);
-        }
-      }
+    const { data: brandRow, error: brandError } = await supabaseAdmin
+      .from('prompts')
+      .select('prompt_sets!inner(brands!inner(id))')
+      .in('id', promptIds)
+      .limit(1)
+      .maybeSingle();
+
+    if (brandError) {
+      throw new Error(`Failed to resolve brand: ${brandError.message}`);
+    }
+    const brandId = brandRow?.prompt_sets?.brands?.id;
+
+    if (!brandId) {
+      return res.status(400).json({
+        error: 'Unable to resolve brand from prompts',
+      });
     }
 
-    let existingMap = {};
-
-    if (!force) {
-      const { data: existingRows } = await supabaseAdmin
-        .from('prompt_volumes')
-        .select('prompt_id, intent, keywords')
-        .in('prompt_id', promptIds);
-
-      if (existingRows) {
-        for (const row of existingRows) {
-          if (row.keywords?.length) {
-            existingMap[row.prompt_id] = {
-              intent: row.intent,
-              keywords: row.keywords,
-            };
-          }
-        }
-      }
-    }
-
-    const aiModel = resolveModel(model);
-    const results = [];
-
-    for (const { promptId, promptText } of prompts) {
-      try {
-        let intent;
-        let keywords;
-
-        const cached = existingMap[promptId];
-        if (cached) {
-          intent = cached.intent;
-          keywords = cached.keywords;
-        } else {
-          const intentResult = await extractIntentKeywords(promptText, aiModel);
-          intent = intentResult.intent;
-          keywords = intentResult.keywords;
-        }
-
-        const saved = await fetchAndSaveVolumes(
-          promptId,
-          keywords,
-          intent,
-          resolvedLocationCode,
-          resolvedLanguageCode,
-        );
-        results.push(mapVolumeRow(saved));
-      } catch (err) {
-        results.push({ promptId, error: err.message });
-      }
-    }
-
+    const results = await analyzeBrandVolumes(brandId, { force });
     const successCount = results.filter((r) => !r.error).length;
     if (successCount > 0 && orgId) {
       await supabaseAdmin.from('volume_usage').insert({

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -364,7 +364,9 @@ app.post('/api/internal/analyze-volumes', async (req, res) => {
       return res.status(400).json({ success: false, message: 'brandId is required' });
     }
 
-    analyzeBrandVolumes(brandId).catch((err) => {
+    analyzeBrandVolumes(brandId, {
+      onlyMissing: true,
+    }).catch((err) => {
       req.log.error({ err, brandId }, 'internal analyze-volumes error');
     });
 

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -361,14 +361,14 @@ app.post('/api/internal/analyze-volumes', async (req, res) => {
   try {
     const { brandId } = req.body;
     if (!brandId) {
-    return res.status(400).json({ success: false, message: 'brandId is required' });
+      return res.status(400).json({ success: false, message: 'brandId is required' });
     }
 
     analyzeBrandVolumes(brandId).catch((err) => {
-    req.log.error({ err, brandId }, 'internal analyze-volumes error');
-  });
+      req.log.error({ err, brandId }, 'internal analyze-volumes error');
+    });
 
-  return res.status(202).json({success: true, message: 'Volume analysis started'});
+    return res.status(202).json({ success: true, message: 'Volume analysis started' });
   } catch (err) {
     req.log.error({ err }, 'internal analyze volume error');
     return res.status(500).json({ success: false, message: err.message });

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -29,6 +29,7 @@ import { getSiteAuditQuotaStatus } from './lib/plan-guard.js';
 import { recountBrandCitations } from './lib/citation-recount.js';
 import supabaseAdmin from './config/supabase.js';
 import { getPlan, hasFeature, isCloud, isSubscriptionActive } from './config/plans.js';
+import { analyzeBrandVolumes } from './lib/volume-analysis.js';
 
 const app = express();
 app.set('trust proxy', 1);
@@ -346,6 +347,30 @@ app.post('/api/internal/trigger-tracking', async (req, res) => {
     return res.json({ success: true, jobId: job.id });
   } catch (err) {
     req.log.error({ err }, 'internal trigger-tracking error');
+    return res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// --- Internal analyze volumes endpoint (CRON_SECRET auth, called by Stripe success route) ---
+app.post('/api/internal/analyze-volumes', async (req, res) => {
+  const secret = req.headers.authorization?.replace('Bearer ', '');
+  if (!process.env.CRON_SECRET || secret !== process.env.CRON_SECRET) {
+    return res.status(401).json({ success: false, message: 'Unauthorized' });
+  }
+
+  try {
+    const { brandId } = req.body;
+    if (!brandId) {
+    return res.status(400).json({ success: false, message: 'brandId is required' });
+    }
+
+    analyzeBrandVolumes(brandId).catch((err) => {
+    req.log.error({ err, brandId }, 'internal analyze-volumes error');
+  });
+
+  return res.status(202).json({success: true, message: 'Volume analysis started'});
+  } catch (err) {
+    req.log.error({ err }, 'internal analyze volume error');
     return res.status(500).json({ success: false, message: err.message });
   }
 });

--- a/web/src/app/api/stripe/success/route.ts
+++ b/web/src/app/api/stripe/success/route.ts
@@ -106,6 +106,28 @@ export async function GET(req: NextRequest) {
               } catch (fetchErr) {
                 console.error('[stripe/success] Failed to call trigger-tracking:', fetchErr);
               }
+
+              try {
+                const volumesRes = await fetch(`${serverUrl}/api/internal/analyze-volumes`, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${cronSecret}`,
+                  },
+                  body: JSON.stringify({ brandId: brand.id }),
+                });
+
+                if (volumesRes.ok) {
+                  console.log('[stripe/success] Volume analysis triggered for brand:', brand.id);
+                } else {
+                  console.error(
+                    '[stripe/success] Volume analysis trigger failed:',
+                    volumesRes.status,
+                  );
+                }
+              } catch (fetchErr) {
+                console.error('[stripe/success] Failed to call volume analysis:', fetchErr);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

This PR automatically triggers prompt volume analysis after a successful Stripe checkout, so new users don't have to manually click **Analyze prompts** before seeing Volume and Competition data.

### Changes
- Extracted the shared prompt volume analysis logic into `server/src/lib/volume-analysis.js`.
- Updated the manual `/api/volumes/analyze-batch` endpoint to reuse the shared implementation.
- Added a new internal endpoint `POST /api/internal/analyze-volumes` secured with `CRON_SECRET` authentication.
- The internal endpoint starts the analysis asynchronously and immediately returns `202 Accepted`.
- Triggered the new internal endpoint from the Stripe success flow immediately after the existing tracking kickoff.
- Automatic onboarding analysis does **not** consume the user's monthly volume analysis quota; manual analysis behavior remains unchanged.

## Related issue

Closes #541

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR