### PR TITLE
fix(metrics): shrink the position factor by mention evidence

### DIFF
--- a/server/src/config/visibility-score.js
+++ b/server/src/config/visibility-score.js
@@ -16,6 +16,15 @@ export const VISIBILITY_SCORE_WEIGHTS = {
 };
 
 /**
+ * Evidence shrinkage for the position factor: the blend uses
+ * pf × mentionAnswers / (mentionAnswers + POSITION_SUPPORT_ANSWERS), so the
+ * position term needs a body of mentions before it pays out — a perfect
+ * average over a handful of answers must not outrank entities that actually
+ * show up. High-volume entities are untouched; only thin samples are damped.
+ */
+export const POSITION_SUPPORT_ANSWERS = 10;
+
+/**
  * 0-100 score, one decimal. Returns null when the scope has no answers.
  * @param {{ answers: number, mentionAnswers: number, citationAnswers: number,
  *           positionFactor: number | null }} components
@@ -28,10 +37,11 @@ export function computeAiVisibilityScore({
 }) {
   if (!answers) return null;
   const w = VISIBILITY_SCORE_WEIGHTS;
+  const positionSupport = mentionAnswers / (mentionAnswers + POSITION_SUPPORT_ANSWERS);
   const raw =
     100 *
     (w.mention * (mentionAnswers / answers) +
       w.citation * (citationAnswers / answers) +
-      w.position * (positionFactor ?? 0));
+      w.position * (positionFactor ?? 0) * positionSupport);
   return Math.round(raw * 10) / 10;
 }

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_formula-dialog.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_formula-dialog.tsx
@@ -79,7 +79,9 @@ export function FormulaDialog() {
                     Position factor ({PCT.position}%)
                   </span>{' '}
                   — how early you&apos;re named in the answers that mention you: named first = 1,
-                  second = 0.5, third = 0.33, and so on, averaged.
+                  second = 0.5, third = 0.33, and so on, averaged. This term is weighted by how many
+                  answers actually mention the brand, so a perfect position in a handful of answers
+                  can&apos;t outrank brands that consistently show up.
                 </li>
               </ul>
               <p>

--- a/web/src/lib/visibility-score.test.ts
+++ b/web/src/lib/visibility-score.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { computeAiVisibilityScore, VISIBILITY_SCORE_WEIGHTS } from './visibility-score';
+import {
+  computeAiVisibilityScore,
+  POSITION_SUPPORT_ANSWERS,
+  VISIBILITY_SCORE_WEIGHTS,
+} from './visibility-score';
 
 describe('computeAiVisibilityScore', () => {
   it('blends the three components with the canonical weights', () => {
-    // 100 × (0.6×0.5 + 0.25×0.2 + 0.15×0.8) = 30 + 5 + 12 = 47
+    // position support: 5/(5+10) = 1/3 → effective pf = 0.8/3 = 0.2667
+    // 100 × (0.6×0.5 + 0.25×0.2 + 0.15×0.2667) = 30 + 5 + 4 = 39
     expect(
       computeAiVisibilityScore({
         answers: 10,
@@ -11,7 +16,7 @@ describe('computeAiVisibilityScore', () => {
         citationAnswers: 2,
         positionFactor: 0.8,
       }),
-    ).toBe(47);
+    ).toBe(39);
   });
 
   it('treats a null position factor as zero contribution', () => {
@@ -36,7 +41,18 @@ describe('computeAiVisibilityScore', () => {
     ).toBeNull();
   });
 
-  it('caps naturally at 100 when every answer mentions, cites and ranks first', () => {
+  it('approaches 100 as a perfect entity accumulates evidence', () => {
+    // Large perfect scope: support 10000/10010 ≈ 1 → rounds to 100.
+    expect(
+      computeAiVisibilityScore({
+        answers: 10_000,
+        mentionAnswers: 10_000,
+        citationAnswers: 10_000,
+        positionFactor: 1,
+      }),
+    ).toBe(100);
+    // Small perfect scope: the position term is still earning trust.
+    // 100 × (0.6 + 0.25 + 0.15 × 7/17) = 91.2
     expect(
       computeAiVisibilityScore({
         answers: 7,
@@ -44,11 +60,36 @@ describe('computeAiVisibilityScore', () => {
         citationAnswers: 7,
         positionFactor: 1,
       }),
-    ).toBe(100);
+    ).toBe(91.2);
+  });
+
+  it('damps a perfect position average built on a thin sample', () => {
+    // A competitor named first in 6 of 16k answers used to score a flat
+    // 15-point position floor and outrank one named in 500+. Support 6/16
+    // caps its position term at 5.6 points (5.7 total with the tiny
+    // mention/citation contributions).
+    expect(
+      computeAiVisibilityScore({
+        answers: 16_332,
+        mentionAnswers: 6,
+        citationAnswers: 4,
+        positionFactor: 1,
+      }),
+    ).toBe(5.7);
+    // A high-volume competitor is effectively untouched by the shrinkage:
+    // support 3892/3902 ≈ 0.997.
+    expect(
+      computeAiVisibilityScore({
+        answers: 16_332,
+        mentionAnswers: 3892,
+        citationAnswers: 2608,
+        positionFactor: 0.791,
+      }),
+    ).toBe(30.1);
   });
 
   it('rounds to one decimal', () => {
-    // 100 × 0.6 × (1/3) = 20.0; 100 × (0.6×1/3 + 0.25×1/3) = 28.333… → 28.3
+    // 100 × (0.6×1/3 + 0.25×1/3) = 28.333… → 28.3
     expect(
       computeAiVisibilityScore({
         answers: 3,
@@ -62,5 +103,6 @@ describe('computeAiVisibilityScore', () => {
   it('weights sum to 1 so the score stays on a 0-100 scale', () => {
     const { mention, citation, position } = VISIBILITY_SCORE_WEIGHTS;
     expect(mention + citation + position).toBe(1);
+    expect(POSITION_SUPPORT_ANSWERS).toBeGreaterThan(0);
   });
 });

--- a/web/src/lib/visibility-score.ts
+++ b/web/src/lib/visibility-score.ts
@@ -8,7 +8,10 @@
  * - mention rate / citation rate: share of answers (0..1) naming / citing
  *   the entity — deterministic parse-time detection, no LLM judges.
  * - position factor: mean of 1/mention_position over answers that name the
- *   entity (0..1; 1 = always named first). Null when never named.
+ *   entity (0..1; 1 = always named first). Null when never named. Before it
+ *   enters the blend it is shrunk by the evidence behind it (see
+ *   POSITION_SUPPORT_ANSWERS) — a perfect average over a handful of answers
+ *   must not outrank entities that actually show up.
  *
  * The same formula applies to ANY answer set — brand-wide, per prompt, per
  * topic, per platform, per day — which is what keeps every surface's number
@@ -22,6 +25,16 @@ export const VISIBILITY_SCORE_WEIGHTS = {
   citation: 0.25,
   position: 0.15,
 } as const;
+
+/**
+ * Evidence shrinkage for the position factor: the blend uses
+ * pf × mentionAnswers / (mentionAnswers + POSITION_SUPPORT_ANSWERS), so the
+ * position term needs a body of mentions before it pays out. Without this, a
+ * competitor named first in 6 of 16k answers scored a flat 15-point position
+ * floor and ranked above one named in 500+. High-volume entities are
+ * untouched (3892/3902 ≈ 1); only thin samples are damped.
+ */
+export const POSITION_SUPPORT_ANSWERS = 10;
 
 export interface VisibilityScoreComponents {
   /** Total answers in the scope (the shared denominator). */
@@ -38,10 +51,11 @@ export interface VisibilityScoreComponents {
 export function computeAiVisibilityScore(c: VisibilityScoreComponents): number | null {
   if (!c.answers) return null;
   const w = VISIBILITY_SCORE_WEIGHTS;
+  const positionSupport = c.mentionAnswers / (c.mentionAnswers + POSITION_SUPPORT_ANSWERS);
   const raw =
     100 *
     (w.mention * (c.mentionAnswers / c.answers) +
       w.citation * (c.citationAnswers / c.answers) +
-      w.position * (c.positionFactor ?? 0));
+      w.position * (c.positionFactor ?? 0) * positionSupport);
   return Math.round(raw * 10) / 10;
 }


### PR DESCRIPTION
## Summary

A competitor named first in **6 of ~16k answers** ranked **4th** on a brand's 30d leaderboard, above one named in 500+ answers. The position factor is an average over only the answers that mention the entity, so a perfect 1.0 average on a tiny sample paid out the full 15-point position weight as a floor.

The position term now enters the blend with **evidence shrinkage**:

```
score = 100 × (0.6 × mention rate
             + 0.25 × citation rate
             + 0.15 × position factor × mentionAnswers / (mentionAnswers + 10))
```

- Thin samples are damped toward zero (the reported case drops from 15.0 → 5.7 and falls to the bottom half of the leaderboard).
- High-volume entities are untouched — support ≈ 1 from a few dozen mentions up (a 3.9k-mention competitor shifts by ~0.05 points).
- Both mirrors of the score module (`web/src/lib/visibility-score.ts`, `server/src/config/visibility-score.js`) change identically, so **every surface re-ranks consistently** — leaderboard, trend chart (the misranked competitor also leaves the top-4 lines), Daily Pulse, reports, MCP, Looker.
- Nothing is re-analyzed and no stored data changes: the score is computed at read time from the same components.
- The Formulas dialog documents the evidence weighting in the position-factor bullet.
- Unit tests updated for the new math + a regression test for the thin-sample case.

## Related issue

Customer report (no tracked issue).

## Type of change

- [x] `fix` — Bug fix

## How to test

1. On a brand where a rarely-mentioned competitor with a perfect position ranked implausibly high, reload Insights: it drops to a rank consistent with its actual presence, and the trend chart's plotted competitors match the new leaderboard order.
2. High-volume competitors' scores are visually unchanged.
3. `yarn test` in `web/` (7 score tests) and `yarn vitest run` in `server/` pass.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
