### PR TITLE
fix(metrics): raise position-factor support to 20 mentioned answers

### DIFF
--- a/server/src/config/visibility-score.js
+++ b/server/src/config/visibility-score.js
@@ -21,8 +21,11 @@ export const VISIBILITY_SCORE_WEIGHTS = {
  * position term needs a body of mentions before it pays out — a perfect
  * average over a handful of answers must not outrank entities that actually
  * show up. High-volume entities are untouched; only thin samples are damped.
+ *
+ * Calibrated at 20 (half strength at 20 mentioned answers) — see the web
+ * mirror for the rationale.
  */
-export const POSITION_SUPPORT_ANSWERS = 10;
+export const POSITION_SUPPORT_ANSWERS = 20;
 
 /**
  * 0-100 score, one decimal. Returns null when the scope has no answers.

--- a/web/src/lib/visibility-score.test.ts
+++ b/web/src/lib/visibility-score.test.ts
@@ -7,8 +7,8 @@ import {
 
 describe('computeAiVisibilityScore', () => {
   it('blends the three components with the canonical weights', () => {
-    // position support: 5/(5+10) = 1/3 → effective pf = 0.8/3 = 0.2667
-    // 100 × (0.6×0.5 + 0.25×0.2 + 0.15×0.2667) = 30 + 5 + 4 = 39
+    // position support: 5/(5+20) = 0.2 → effective pf = 0.8×0.2 = 0.16
+    // 100 × (0.6×0.5 + 0.25×0.2 + 0.15×0.16) = 30 + 5 + 2.4 = 37.4
     expect(
       computeAiVisibilityScore({
         answers: 10,
@@ -16,7 +16,7 @@ describe('computeAiVisibilityScore', () => {
         citationAnswers: 2,
         positionFactor: 0.8,
       }),
-    ).toBe(39);
+    ).toBe(37.4);
   });
 
   it('treats a null position factor as zero contribution', () => {
@@ -52,7 +52,7 @@ describe('computeAiVisibilityScore', () => {
       }),
     ).toBe(100);
     // Small perfect scope: the position term is still earning trust.
-    // 100 × (0.6 + 0.25 + 0.15 × 7/17) = 91.2
+    // 100 × (0.6 + 0.25 + 0.15 × 7/27) = 88.9
     expect(
       computeAiVisibilityScore({
         answers: 7,
@@ -60,14 +60,15 @@ describe('computeAiVisibilityScore', () => {
         citationAnswers: 7,
         positionFactor: 1,
       }),
-    ).toBe(91.2);
+    ).toBe(88.9);
   });
 
   it('damps a perfect position average built on a thin sample', () => {
     // A competitor named first in 6 of 16k answers used to score a flat
-    // 15-point position floor and outrank one named in 500+. Support 6/16
-    // caps its position term at 5.6 points (5.7 total with the tiny
-    // mention/citation contributions).
+    // 15-point position floor and outrank one named in 500+. Support 6/26
+    // caps its position term at 3.5 points — below entities that are
+    // actually present (an entity mentioned 25× in mid positions now ranks
+    // above this one, which K=10 still got backwards).
     expect(
       computeAiVisibilityScore({
         answers: 16_332,
@@ -75,7 +76,7 @@ describe('computeAiVisibilityScore', () => {
         citationAnswers: 4,
         positionFactor: 1,
       }),
-    ).toBe(5.7);
+    ).toBe(3.5);
     // A high-volume competitor is effectively untouched by the shrinkage:
     // support 3892/3902 ≈ 0.997.
     expect(

--- a/web/src/lib/visibility-score.ts
+++ b/web/src/lib/visibility-score.ts
@@ -32,9 +32,13 @@ export const VISIBILITY_SCORE_WEIGHTS = {
  * position term needs a body of mentions before it pays out. Without this, a
  * competitor named first in 6 of 16k answers scored a flat 15-point position
  * floor and ranked above one named in 500+. High-volume entities are
- * untouched (3892/3902 ≈ 1); only thin samples are damped.
+ * untouched; only thin samples are damped.
+ *
+ * Calibrated at 20 (half strength at 20 mentioned answers): at 10, a perfect
+ * position over ~6 answers still edged out an entity mentioned 4× more often
+ * in mid positions — presence should win that comparison.
  */
-export const POSITION_SUPPORT_ANSWERS = 10;
+export const POSITION_SUPPORT_ANSWERS = 20;
 
 export interface VisibilityScoreComponents {
   /** Total answers in the scope (the shared denominator). */


### PR DESCRIPTION
## Summary

Calibration follow-up to #584. At `POSITION_SUPPORT_ANSWERS = 10`, a competitor named first in 6 answers (24h score 5.9) still edged out one mentioned 25 times in mid positions (5.5) — presence should win that comparison.

Raise the support constant to **20** (position term reaches half strength at 20 mentioned answers):

- The 24h ordering flips to match actual visibility: the 25-mention entity (4.5) now ranks above the 6-mention one (3.7).
- High-volume entities remain untouched — a 445-mention competitor moves 29.7 → 29.6.
- One constant in both score-module mirrors; test expectations updated.

## Related issue

Follow-up to #584 (customer report, no tracked issue).

## Type of change

- [x] `fix` — Bug fix

## How to test

1. On the 24h Insights view, competitors with a handful of first-place mentions rank below competitors that are mentioned several times more often in mid positions.
2. Top-of-leaderboard scores are visually unchanged.
3. `yarn test` (web) and `yarn vitest run` (server) pass.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
