### PR TITLE
fix(web): pluralize day/mention counts in metric breakdown sheet

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_metric-breakdown-sheet.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_metric-breakdown-sheet.tsx
@@ -95,7 +95,7 @@ export function MetricBreakdownSheet({ brandId, metric, onOpenChange, filters }:
           <SheetTitle className="text-base">{title} Breakdown</SheetTitle>
           <SheetDescription className="text-xs">
             {data
-              ? `Last ${data.windowDays} days vs previous ${data.windowDays} days`
+              ? `Last ${data.windowDays} day${data.windowDays !== 1 ? 's' : ''} vs previous ${data.windowDays} day${data.windowDays !== 1 ? 's' : ''}`
               : 'Comparing the selected window with the previous equal-length window.'}
           </SheetDescription>
         </SheetHeader>
@@ -367,7 +367,7 @@ function formatContribution(row: BreakdownRow, metric: BreakdownMetric): string 
   }
 
   const verb = isLoss ? 'lost' : 'gained';
-  const core = `${verb} ${abs.toLocaleString()} mentions`;
+  const core = `${verb} ${abs.toLocaleString()} mention${abs !== 1 ? 's' : ''}`;
   if (row.deltaPct === null) return core;
   const sign = row.deltaPct < 0 ? '−' : '+';
   return `${core} (${sign}${Math.abs(row.deltaPct)}%)`;


### PR DESCRIPTION
## Summary

Fixes hardcoded plural strings in the Insights metric breakdown sheet. The default `24h` date preset resolves to `windowDays === 1`, so the subtitle read "Last 1 days vs previous 1 days" instead of "Last 1 day vs previous 1 day". Similarly, a mentions delta of exactly 1 rendered "gained 1 mentions"/"lost 1 mentions" instead of the singular form. Both strings now pluralize based on the count, matching the existing pattern used elsewhere on the page (`page.tsx:773`).

## Related issue

Closes #586

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR