### PR TITLE
fix(web): format mention/citation counts with thousands separators

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
@@ -27,6 +27,7 @@ import type {
   SoVTrendPoint,
 } from '@/lib/actions/tracking';
 import { getFaviconUrl } from '@/lib/favicon';
+import { formatCompactNumber } from '@/lib/format';
 
 // ─── Adaptive Y-axis ─────────────────────────────────────────────────────────
 // Visibility scores are theoretically 0–100 but realistic values for most
@@ -683,8 +684,8 @@ function LeaderboardEntry({ entry, rank }: { entry: CompetitorComparisonEntry; r
           {entry.isOwnBrand && <span className="text-[10px] font-medium text-primary">YOU</span>}
         </div>
         <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
-          <span>{entry.totalMentions} mentions</span>
-          <span>{entry.totalCitations} citations</span>
+          <span>{formatCompactNumber(entry.totalMentions)} mentions</span>
+          <span>{formatCompactNumber(entry.totalCitations)} citations</span>
         </div>
         <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
           <span className="tabular-nums">

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -235,7 +235,7 @@ function CountDeltaBadge({
   if (previous === 0 && current > 0) {
     return (
       <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
-        +{current} new
+        +{current.toLocaleString()} new
       </span>
     );
   }
@@ -1531,7 +1531,7 @@ export default function InsightsPage() {
                   title={t('mentions')}
                   tooltip="How many times your brand was referenced by name in AI-generated responses."
                   icon={Zap}
-                  value={summary!.totalMentions}
+                  value={summary!.totalMentions.toLocaleString()}
                   sub={
                     <CountDeltaBadge
                       current={summary!.totalMentions}
@@ -1550,7 +1550,7 @@ export default function InsightsPage() {
                   title={t('citations')}
                   tooltip="Times your brand's domain was cited as a source with a direct link in AI responses."
                   icon={Quote}
-                  value={summary!.totalCitations}
+                  value={summary!.totalCitations.toLocaleString()}
                   sub={
                     <CountDeltaBadge
                       current={summary!.totalCitations}


### PR DESCRIPTION
## Summary

The Insights KPI cards and competitor leaderboard rendered raw numbers instead of formatted ones, so large counts showed as `12345` instead of `12,345`. Every sibling dashboard page (Citations, Traffic, Topics) already formats counts with `toLocaleString()`. This applies the same convention:

- KPI cards (total mentions, total citations) now use `toLocaleString()`
- The "+X new" count delta badge now uses `toLocaleString()`
- The competitor leaderboard (tighter on space) now uses `formatCompactNumber()`, which falls back to `toLocaleString()` under 1,000 and shows compact k/M/B form above that

Score values (0-100, one decimal) are untouched.

## Related issue

Closes #587

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR