### PR TITLE
fix(web): make insights info tooltips and legend keyboard/screen-read…

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/_charts.tsx
@@ -583,12 +583,16 @@ export function VisibilityRateTrendChart({ data }: { data: VisibilityRateTrendDa
         {shown.map((entity) => (
           <li
             key={entity.key}
-            className="flex cursor-default items-center gap-1.5 text-xs transition-opacity"
+            tabIndex={0}
+            aria-label={entity.name}
+            className="flex cursor-default items-center gap-1.5 rounded-sm text-xs transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             style={{
               opacity: hoveredKey !== null && hoveredKey !== entity.key ? 0.35 : 1,
             }}
             onMouseEnter={() => setHoveredKey(entity.key)}
             onMouseLeave={() => setHoveredKey(null)}
+            onFocus={() => setHoveredKey(entity.key)}
+            onBlur={() => setHoveredKey(null)}
           >
             <span
               className="h-2.5 w-2.5 shrink-0 rounded-sm"

--- a/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/insights/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useId } from 'react';
 import { Link, useRouter } from '@/i18n/navigation';
 import { useSearchParams } from 'next/navigation';
 import { createPortal } from 'react-dom';
@@ -170,25 +170,40 @@ function getDateRange(preset: DatePreset, custom: { from: string; to: string }) 
 function InfoTip({ content }: { content: string }) {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const ref = useRef<HTMLSpanElement>(null);
+  const tooltipId = useId();
 
   function show() {
     const r = ref.current?.getBoundingClientRect();
     if (r) setPos({ x: r.left + r.width / 2, y: r.bottom + 6 });
   }
 
+  function hide() {
+    setPos(null);
+  }
+
   return (
     <>
       <span
         ref={ref}
+        tabIndex={0}
+        aria-label="More information"
+        aria-describedby={pos ? tooltipId : undefined}
         onMouseEnter={show}
-        onMouseLeave={() => setPos(null)}
-        className="inline-flex items-center cursor-help"
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') hide();
+        }}
+        className="inline-flex items-center cursor-help rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <HelpCircle className="h-3 w-3 text-muted-foreground/60 hover:text-muted-foreground transition-colors" />
       </span>
       {pos &&
         createPortal(
           <div
+            id={tooltipId}
+            role="tooltip"
             style={{ left: pos.x, top: pos.y, transform: 'translateX(-50%)' }}
             className="pointer-events-none fixed z-[9999] w-56 rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md"
           >


### PR DESCRIPTION
## Summary

The `InfoTip` tooltips on the Insights page (including the Visibility score explainer) and the chart legend items only responded to mouse hover, with no way for keyboard or screen-reader users to reach them.

- `InfoTip`: trigger is now focusable (`tabIndex={0}`), opens/closes on focus/blur in addition to hover, dismisses on Escape, and has `aria-label` + `role="tooltip"`/`aria-describedby` wiring so screen readers announce the content
- Chart legend items: same focus/blur handling added (mirrors existing hover-to-highlight behavior), plus `aria-label` and a focus-visible ring

Hover behavior is unchanged.

## Related issue

Closes #588

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR