### PR TITLE
fix(web): show distinct error state with retry for failed suggestion …

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
@@ -15,6 +15,7 @@ import {
   Info,
   ChevronDown,
   ChevronRight,
+  AlertTriangle,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -37,6 +38,7 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
   const [suggestions, setSuggestions] = useState<PromptSuggestion[]>([]);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [pendingId, setPendingId] = useState<string | null>(null);
   // Collapsed by default so the card is a one-line strip and the prompt table
@@ -74,12 +76,15 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
 
   const load = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const { suggestions: s } = await getPromptSuggestions(brandId);
       setSuggestions(s);
       setLoaded(true);
     } catch (err) {
       console.error('Failed to load suggestions:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load suggestions');
+      toast.error('Failed to load suggestions');
     } finally {
       setLoading(false);
     }
@@ -94,6 +99,7 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
   useEffect(() => {
     setLoaded(false);
     setSuggestions([]);
+    setError(null);
   }, [brandId]);
 
   useEffect(() => {
@@ -109,6 +115,7 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
       const fresh = await refreshPromptSuggestions(brandId);
       setSuggestions(fresh);
       setLoaded(true);
+      setError(null);
       toast.success('Suggestions refreshed');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Refresh failed');
@@ -210,6 +217,22 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
           {loading ? (
             <div className="flex items-center justify-center py-10">
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center py-10 text-center">
+              <AlertTriangle className="h-8 w-8 text-destructive/60 mb-2" />
+              <p className="text-sm font-medium mb-1">Couldn&apos;t load suggestions</p>
+              <p className="text-xs text-muted-foreground mb-3 max-w-sm">{error}</p>
+              <Button
+                onClick={load}
+                disabled={loading}
+                size="sm"
+                variant="outline"
+                className="gap-2"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Retry
+              </Button>
             </div>
           ) : suggestions.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-10 text-center">


### PR DESCRIPTION
## Summary

When the prompt suggestions card failed to load, the error was swallowed into `console.error` and the card silently rendered the same "No suggestions right now" empty state as a genuinely empty result — telling the user to click Refresh when the real problem was a failed request.

- Added an `error` state to `SuggestionsCard`, cleared on load start, brand change, and successful refresh
- `load()`'s catch block now sets the error and fires `toast.error`, matching the pattern already used by `handleRefresh`
- A new distinct "Couldn't load suggestions" state renders instead of the empty state when the load failed, with a Retry button that re-invokes `load()`

## Related issue

Closes #592

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR