### PR TITLE
fix: filter zero-visit platforms from traffic breakdown

### DIFF
--- a/web/src/lib/actions/traffic.ts
+++ b/web/src/lib/actions/traffic.ts
@@ -207,6 +207,7 @@ export async function getTrafficSummary(
       visits: platformMap.get(platform) ?? 0,
       visitsPrev: platformMapPrev.get(platform) ?? 0,
     }))
+    .filter((p) => p.visits > 0)
     .sort((a, b) => b.visits - a.visits);
 
   const topPages = Array.from(pageMap.entries())


### PR DESCRIPTION
Closes #606. Platforms that only existed in the previous period were appearing with visits=0 in the current period's platformBreakdown, inflating the Platforms KPI and showing 0-visit rows in the table. The chart already filtered these out, so this adds a matching filter to the data action to keep KPI, table, and chart consistent. All tests pass.