### PR TITLE
fix(web): count topic prompts by topic_id instead of category name

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/topics/page.tsx
@@ -54,7 +54,7 @@ export default function BrandTopicsPage({ params }: PageProps) {
         const counts: Record<string, number> = {};
         await Promise.all(
           data.map(async (t) => {
-            counts[t.id] = await getPromptCountByTopic(brandId, t.name);
+            counts[t.id] = await getPromptCountByTopic(brandId, t.id);
           }),
         );
         if (isCancelled?.()) return;

--- a/web/src/lib/actions/topic.ts
+++ b/web/src/lib/actions/topic.ts
@@ -95,7 +95,7 @@ export async function updateTopic(topicId: string, name: string): Promise<Topic>
   return mapTopicRow(data as Record<string, unknown>);
 }
 
-export async function getPromptCountByTopic(brandId: string, topicName: string): Promise<number> {
+export async function getPromptCountByTopic(brandId: string, topicId: string): Promise<number> {
   const supabase = await createClient();
 
   const { data: sets } = await supabase.from('prompt_sets').select('id').eq('brand_id', brandId);
@@ -107,7 +107,7 @@ export async function getPromptCountByTopic(brandId: string, topicName: string):
     .from('prompts')
     .select('id', { count: 'exact', head: true })
     .in('prompt_set_id', setIds)
-    .eq('category', topicName);
+    .eq('topic_id', topicId);
 
   if (error) throw new Error(error.message);
   return count ?? 0;


### PR DESCRIPTION
## Summary

- Renaming a topic on Manage Topics zeroed its prompt count: `getPromptCountByTopic` matched prompts by the legacy `prompts.category` text field, which still held the topic's old name after a rename.
- The Topics leaderboard, which counts by `topic_id`, kept showing the correct number — so the two surfaces disagreed.
- Switches `getPromptCountByTopic` to filter by `topic_id` instead of `category` name (the smaller, safer of the two fixes suggested in the issue), and updates its caller in the Manage Topics page to pass the topic's id instead of its name.

## Related issue

Closes #594

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`fix/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR