### PR TITLE
fix(web): show distinct error states with retry across Topics loaders

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -199,6 +199,7 @@
     "leaderboardHint": "Click a topic to drill into detailed analytics",
     "emptyTitle": "No topics defined yet.",
     "emptyBody": "Add topics from brand settings to enable topic-based analytics.",
+    "loadError": "Failed to load topics",
     "columns": {
       "topic": "Topic",
       "prompts": "Prompts",

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState, use } from 'react';
+import { toast } from 'sonner';
 import { Link, useRouter } from '@/i18n/navigation';
 import { useBrandStore } from '@/stores/use-brand-store';
 import {
@@ -17,10 +18,12 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
+  AlertCircle,
   ArrowLeft,
   BarChart3,
   Eye,
   Quote,
+  RotateCw,
   TrendingDown,
   TrendingUp,
   Zap,
@@ -153,10 +156,12 @@ export default function TopicDetailPage({ params }: { params: Promise<{ id: stri
   const [competitors, setCompetitors] = useState<CompetitorComparisonData | null>(null);
   const [results, setResults] = useState<PromptResultWithText[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const loadData = useCallback(async () => {
     if (!activeBrandId || !topicId) return;
     setLoading(true);
+    setError(null);
     try {
       // One server action (#312): Next.js runs server actions sequentially, so
       // the old six-call Promise.all paid the sum of all six. This is one round
@@ -170,6 +175,8 @@ export default function TopicDetailPage({ params }: { params: Promise<{ id: stri
       setResults(detail.results);
     } catch (err) {
       console.error('Failed to load topic detail', err);
+      setError(err instanceof Error ? err.message : 'Failed to load this topic');
+      toast.error('Failed to load this topic');
     } finally {
       setLoading(false);
     }
@@ -188,6 +195,24 @@ export default function TopicDetailPage({ params }: { params: Promise<{ id: stri
             <p className="mt-1 text-sm text-muted-foreground">
               Select a brand from the top switcher first.
             </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-[60vh] items-center justify-center">
+        <Card className="max-w-md">
+          <CardContent className="pt-6 text-center">
+            <AlertCircle className="mx-auto h-9 w-9 text-destructive/60" />
+            <h2 className="mt-3 text-base font-semibold">Couldn&apos;t load this topic</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{error}</p>
+            <Button onClick={loadData} className="mt-4 gap-2" size="sm" variant="outline">
+              <RotateCw className="h-3.5 w-3.5" />
+              Retry
+            </Button>
           </CardContent>
         </Card>
       </div>

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/_suggestions-card.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/_suggestions-card.tsx
@@ -13,6 +13,7 @@ import {
   Info,
   ChevronDown,
   ChevronRight,
+  AlertTriangle,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -37,6 +38,7 @@ export function TopicSuggestionsCard({ brandId, canManage, onAccepted }: Props) 
   const [suggestions, setSuggestions] = useState<TopicSuggestion[]>([]);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [pendingId, setPendingId] = useState<string | null>(null);
   // Collapsed by default so the card is a one-line strip and the leaderboard
@@ -74,12 +76,15 @@ export function TopicSuggestionsCard({ brandId, canManage, onAccepted }: Props) 
 
   const load = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const s = await getTopicSuggestions(brandId);
       setSuggestions(s);
       setLoaded(true);
     } catch (err) {
       console.error('Failed to load topic suggestions:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load topic suggestions');
+      toast.error('Failed to load topic suggestions');
     } finally {
       setLoading(false);
     }
@@ -93,6 +98,7 @@ export function TopicSuggestionsCard({ brandId, canManage, onAccepted }: Props) 
   useEffect(() => {
     setLoaded(false);
     setSuggestions([]);
+    setError(null);
   }, [brandId]);
 
   useEffect(() => {
@@ -108,6 +114,7 @@ export function TopicSuggestionsCard({ brandId, canManage, onAccepted }: Props) 
       const fresh = await refreshTopicSuggestions(brandId);
       setSuggestions(fresh);
       setLoaded(true);
+      setError(null);
       toast.success('Topic suggestions refreshed');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Refresh failed');
@@ -209,6 +216,22 @@ export function TopicSuggestionsCard({ brandId, canManage, onAccepted }: Props) 
           {loading ? (
             <div className="flex items-center justify-center py-10">
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center py-10 text-center">
+              <AlertTriangle className="h-8 w-8 text-destructive/60 mb-2" />
+              <p className="text-sm font-medium mb-1">Couldn&apos;t load suggestions</p>
+              <p className="text-xs text-muted-foreground mb-3 max-w-sm">{error}</p>
+              <Button
+                onClick={load}
+                disabled={loading}
+                size="sm"
+                variant="outline"
+                className="gap-2"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Retry
+              </Button>
             </div>
           ) : suggestions.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-10 text-center">

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
@@ -33,11 +33,13 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import {
+  AlertCircle,
   ArrowRight,
   Download,
   Flame,
   Layers,
   Minus,
+  RotateCw,
   Settings2,
   Tag,
   TrendingDown,
@@ -174,6 +176,7 @@ export default function TopicsPage() {
   const [topics, setTopics] = useState<TopicOverviewRow[]>([]);
   const [unassignedPromptCount, setUnassignedPromptCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [isAdding, setIsAdding] = useState(false);
   const [newName, setNewName] = useState('');
   const [open, setOpen] = useState(false);
@@ -185,16 +188,19 @@ export default function TopicsPage() {
       return;
     }
     setLoading(true);
+    setError(null);
     try {
       const data = await getTopicsOverview(activeBrandId);
       setTopics(data.topics);
       setUnassignedPromptCount(data.unassignedPromptCount);
     } catch (err) {
       console.error('Failed to load topics overview', err);
+      setError(err instanceof Error ? err.message : t('loadError'));
+      toast.error(t('loadError'));
     } finally {
       setLoading(false);
     }
-  }, [activeBrandId]);
+  }, [activeBrandId, t]);
 
   useEffect(() => {
     loadData();
@@ -453,6 +459,20 @@ export default function TopicsPage() {
               {Array.from({ length: 5 }).map((_, i) => (
                 <Skeleton key={i} className="h-12" />
               ))}
+            </div>
+          ) : error ? (
+            <div className="py-14 text-center text-sm">
+              <AlertCircle className="mx-auto h-9 w-9 text-destructive/60" />
+              <p className="mt-2 font-medium">{t('loadError')}</p>
+              <Button
+                className="mt-4 gap-2"
+                size="sm"
+                variant="outline"
+                onClick={() => void loadData()}
+              >
+                <RotateCw className="h-4 w-4" />
+                {common('retry')}
+              </Button>
             </div>
           ) : topics.length === 0 ? (
             <div className="py-14 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- All three Topics data loaders swallowed failures into `console.error`, so a failed request rendered as a normal empty state — "No topics defined yet" or "Topic not found" — with no way to tell an outage from a genuinely empty account, and no retry.
- Adds an `error` state to each loader and a distinct error UI with a retry action:
  - `topics/page.tsx` — leaderboard card now shows a "Failed to load topics" error with retry instead of the empty state (uses the page's existing i18n).
  - `topics/[id]/page.tsx` — a failed load now shows a "Couldn't load this topic" card with retry; "Topic not found" is now reserved for a successful fetch that genuinely returns nothing.
  - `topics/_suggestions-card.tsx` — mirrors the pattern already shipped for the Prompts suggestions card (#previous fix), same error state + retry button.

## Related issue

Closes #595

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`fix/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR