### PR TITLE
fix(web): pluralize Topics KPI strings and align pts decimal formatting

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -186,7 +186,7 @@
     "manageTopics": "Manage topics",
     "kpi": {
       "trackedTopics": "Tracked topics",
-      "unassignedPrompts": "{count} prompts without a topic",
+      "unassignedPrompts": "{count, plural, one {# prompt without a topic} other {# prompts without a topic}}",
       "allCategorised": "All prompts categorised",
       "bestPerformer": "Best performer",
       "biggestGap": "Biggest gap",
@@ -210,7 +210,7 @@
       "topCompetitor": "Top competitor",
       "lastRun": "Last run"
     },
-    "appearedIn": "Appeared in {visible} of {active} prompts",
+    "appearedIn": "Appeared in {visible} of {active, plural, one {# prompt} other {# prompts}}",
     "openDetails": "Open topic details",
     "relative": {
       "justNow": "just now",

--- a/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/topics/page.tsx
@@ -423,7 +423,7 @@ export default function TopicsPage() {
             value={
               kpis.gainer && kpis.gainer.visibilityChange !== null
                 ? t('ptsChange', {
-                    value: `${kpis.gainer.visibilityChange > 0 ? '+' : ''}${kpis.gainer.visibilityChange}`,
+                    value: `${kpis.gainer.visibilityChange > 0 ? '+' : ''}${kpis.gainer.visibilityChange.toFixed(1)}`,
                   })
                 : '—'
             }


### PR DESCRIPTION
## Summary

- `kpi.unassignedPrompts` and `appearedIn` used plain interpolation, so a count of 1 rendered "1 prompts without a topic" / "Appeared in 1 of 1 prompts". Both now use ICU plural form, matching the existing `citations.domainCount` precedent.
- The Top Mover KPI rendered the raw change value (`+4 pts`) while the leaderboard's Trend column formats the identical value with one decimal (`4.0 pts`). Applied `.toFixed(1)` to the Top Mover value so both surfaces now agree (`+4.0 pts`).

## Related issue

Closes #596

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`fix/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR