### PR TITLE
Fix traffic chart date labels across timezones

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/_charts.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/_charts.tsx
@@ -96,6 +96,16 @@ export function getPlatformName(platform: string): string {
   return PLATFORM_NAMES[platform] ?? platform;
 }
 
+function formatTrafficBucketDate(value: string): string {
+  const d = new Date(value);
+
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
 // ─── Custom Tooltips ──────────────────────────────────────────────────────────
 
 function AreaTooltip({
@@ -110,7 +120,9 @@ function AreaTooltip({
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded-lg border bg-background px-3 py-2 shadow-md text-xs">
-      <p className="font-medium text-foreground mb-1">{label}</p>
+      <p className="font-medium text-foreground mb-1">
+        {label ? formatTrafficBucketDate(label) : ''}
+      </p>
       {payload.map((entry) => (
         <div key={entry.name} className="flex items-center gap-2">
           <span
@@ -207,10 +219,7 @@ export function ReferralTrendChart({ data }: { data: TrafficTrendPoint[] }) {
             tickLine={false}
             axisLine={false}
             className="fill-muted-foreground"
-            tickFormatter={(v: string) => {
-              const d = new Date(v);
-              return d.toLocaleDateString('en', { month: 'short', day: 'numeric' });
-            }}
+            tickFormatter={(v: string) => formatTrafficBucketDate(v)}
           />
           <YAxis
             tick={{ fontSize: 11 }}


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

Fix the AI Traffic trend chart date labels shifting by one day in negative UTC-offset timezones.

The chart buckets visits by UTC day on the server using `YYYY-MM-DD` keys, but the frontend was parsing those bucket keys with `new Date()` and formatting them in the browser's local timezone. This caused dates like `2026-08-01` to display as `Jul 31` in regions such as America/Los_Angeles.

Changes:
- Added a shared helper to format traffic bucket dates using `timeZone: 'UTC'`.
- Updated the X-axis formatter to preserve the UTC bucket date.
- Updated the custom tooltip to use the same formatted date instead of displaying the raw ISO date.
- Changed locale handling from hardcoded `'en'` to `undefined` so it follows the user's browser locale.

## Related issue

Closes #605 

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR