### PR TITLE
fix(web): populate the Citations Region filter from observed data

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -857,7 +857,6 @@ export default function CitationsPage() {
 
       // Surface filter options from the observed models/regions.
       const platformOptions = buildPlatformOptions(overview.rows);
-      const regions = new Set<string>();
       setAvailablePlatforms((prev) =>
         Array.from(
           new Map(
@@ -865,9 +864,11 @@ export default function CitationsPage() {
           ).values(),
         ).sort((a, b) => a.label.localeCompare(b.label) || a.value.localeCompare(b.value)),
       );
-      if (regions.size > 0) {
+      if (overview.availableRegions.length > 0) {
         setAvailableRegions((prev) =>
-          Array.from(new Set([...prev, ...regions])).sort((a, b) => a.localeCompare(b)),
+          Array.from(new Set([...prev, ...overview.availableRegions])).sort((a, b) =>
+            a.localeCompare(b),
+          ),
         );
       }
     } catch {

--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -75,6 +75,8 @@ export interface CitationsOverview {
     avgCitationsPerResult: number;
   };
   sourceTypeBreakdown: CitationsSourceBreakdown[];
+  /** Distinct regions observed on results in the scanned (filtered) window (#598). */
+  availableRegions: string[];
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -273,6 +275,7 @@ export async function getCitationsOverview(
   const articleTypeCache = new Map<string, ArticleType | null>();
 
   let totalCitations = 0;
+  const regionsSeen = new Set<string>();
 
   const aggregateResult = (result: OverviewResultRow) => {
     const citations = Array.isArray(result.citations) ? result.citations : [];
@@ -349,7 +352,10 @@ export async function getCitationsOverview(
     filters,
     'id, prompt_id, platform, model_used, region, created_at, citations, citation_count',
     (batch) => {
-      for (const result of batch) aggregateResult(result);
+      for (const result of batch) {
+        if (result.region) regionsSeen.add(result.region);
+        aggregateResult(result);
+      }
     },
   );
 
@@ -419,6 +425,7 @@ export async function getCitationsOverview(
         totalResults > 0 ? Math.round((totalCitations / totalResults) * 10) / 10 : 0,
     },
     sourceTypeBreakdown,
+    availableRegions: Array.from(regionsSeen).sort(),
   };
 }
 


### PR DESCRIPTION
## Summary

- The Region filter dropdown on the Citations page was permanently empty — `loadData` created a `Set<string>` for regions and never added anything to it, so the dropdown only ever showed "All Regions".
- `getCitationsOverview` already selects `region` from `prompt_results` while scanning the filtered window, but discarded it before it reached the client.
- `getCitationsOverview` now collects the distinct, non-null regions it observes and returns them as `availableRegions` on `CitationsOverview`.
- The page's `loadData` now populates `availableRegions` state from that field instead of the dead local `Set`, using the same accumulate-and-sort merge already used for platform options.

## Related issue

Closes #598

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`fix/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR