### PR TITLE
fix: map prompt topic ID from database rows

### DIFF
--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -45,6 +45,7 @@ function mapPromptRow(row: Record<string, unknown>): Prompt {
     promptSetId: row.prompt_set_id as string,
     text: row.text as string,
     category: (row.category as string | null) ?? undefined,
+    topicId: (row.topic_id as string | null) ?? undefined,
     platforms: ((row.platforms as string[]) ?? []) as AIPlatform[],
     regions: (row.regions as string[]) ?? [],
     models: (row.models as string[]) ?? [],


### PR DESCRIPTION
## Summary

Fixes the prompt mapping so `topic_id` is preserved when converting database rows into `Prompt` objects.

### Changes
- Added `topicId` to `mapPromptRow` by mapping the `topic_id` database column to the `Prompt` model.
- No query changes were required since `getPromptSets` already selects `prompts(*)`, which includes `topic_id`.

This ensures prompts with an associated topic export a non-empty `topic_id` in the CSV, while prompts without a topic continue to export an empty cell.

## Related issue

Closes #590 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
```