### PR TITLE
fix(web): show period-specific empty state on AI Traffic page

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -51,6 +51,7 @@ import {
   X,
   Loader2,
   Download,
+  CalendarX2,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
@@ -351,6 +352,23 @@ function EmptyLogsState({ hasFilters }: { hasFilters: boolean }) {
       </div>
     );
   }
+}
+
+function NoTrafficForPeriod({ rangeLabel, onReset }: { rangeLabel: string; onReset: () => void }) {
+  return (
+    <Card>
+      <CardContent className="py-16 text-center">
+        <CalendarX2 className="h-10 w-10 mx-auto text-muted-foreground/50" />
+        <h3 className="text-lg font-semibold mt-4">No traffic in this period</h3>
+        <p className="text-sm text-muted-foreground mt-1 max-w-md mx-auto">
+          No AI-referred visits in the {rangeLabel}. There is traffic data in other time periods.
+        </p>
+        <Button variant="outline" size="sm" className="mt-4" onClick={onReset}>
+          Show all data
+        </Button>
+      </CardContent>
+    </Card>
+  );
 }
 
 // ─── Date range ─────────────
@@ -664,6 +682,8 @@ function TrafficPageContent({ brand }: { brand: Brand }) {
   const topPlatform = summary?.platformBreakdown[0];
 
   const isEmpty = totalVisits === 0 && logs.length === 0;
+  const hasAnyData = summary?.hasAnyData ?? false;
+  const trulyEmpty = isEmpty && !hasAnyData;
 
   return (
     <div className="space-y-6">
@@ -703,7 +723,7 @@ function TrafficPageContent({ brand }: { brand: Brand }) {
       {/* Snippet Banner */}
       <SnippetBanner trackingCode={brand.trackingCode} />
 
-      {isEmpty ? (
+      {trulyEmpty ? (
         <Card>
           <CardContent className="py-16 text-center">
             <Globe className="h-10 w-10 mx-auto text-muted-foreground/50" />
@@ -715,6 +735,11 @@ function TrafficPageContent({ brand }: { brand: Brand }) {
             </p>
           </CardContent>
         </Card>
+      ) : isEmpty ? (
+        <NoTrafficForPeriod
+          rangeLabel={rangeSubLabel}
+          onReset={() => handleDatePresetChange('all')}
+        />
       ) : (
         <>
           {/* KPI Cards */}

--- a/web/src/lib/actions/traffic.ts
+++ b/web/src/lib/actions/traffic.ts
@@ -25,6 +25,7 @@ export interface TrafficSummary {
   totalVisitsPrev: number;
   platformBreakdown: { platform: string; visits: number; visitsPrev: number }[];
   topPages: { url: string; visits: number; visitsPrev: number }[];
+  hasAnyData: boolean;
 }
 
 export interface TrafficTrendPoint {
@@ -181,7 +182,11 @@ export async function getTrafficSummary(
 
   const columns = 'source_platform, url, created_at, id';
   const hasPrev = Boolean(prevFrom && prevTo);
-  const [totalVisits, totalVisitsPrev] = await Promise.all([
+  // The window is already the full lifetime when neither bound is set, so
+  // totalVisits doubles as the lifetime check — only worth a second cheap
+  // count query when the window actually narrows the result.
+  const hasWindow = Boolean(from || to);
+  const [totalVisits, totalVisitsPrev, , , lifetimeVisits] = await Promise.all([
     countVisits(from, to, true),
     hasPrev ? countVisits(prevFrom, prevTo) : Promise.resolve(0),
     scanTrafficLogs(
@@ -198,7 +203,10 @@ export async function getTrafficSummary(
           aggregate(platformMapPrev, pageMapPrev),
         )
       : Promise.resolve(),
+    hasWindow ? countVisits() : Promise.resolve(null),
   ]);
+
+  const hasAnyData = hasWindow ? (lifetimeVisits as number) > 0 : totalVisits > 0;
 
   const allPlatforms = new Set([...platformMap.keys(), ...platformMapPrev.keys()]);
   const platformBreakdown = Array.from(allPlatforms)
@@ -224,6 +232,7 @@ export async function getTrafficSummary(
     totalVisitsPrev,
     platformBreakdown,
     topPages,
+    hasAnyData,
   };
 }
 


### PR DESCRIPTION
## Summary

The Traffic page's empty check (`totalVisits === 0 && logs.length === 0`) was date-range-blind, so a brand with plenty of historical traffic that picks a narrow window (e.g. "Last 24 hours") with no visits in it saw the snippet-onboarding card ("Add the tracking snippet to your website...") — wrongly implying their integration was broken.

This mirrors the `NoDataForPeriod` pattern already used on the Insights page:
- `getTrafficSummary` (`web/src/lib/actions/traffic.ts`) now returns `hasAnyData`, a cheap unfiltered `count`-only check for whether the brand has *any* lifetime traffic, independent of the selected window.
- The Traffic page (`web/src/app/[locale]/.../traffic/page.tsx`) splits the old single `isEmpty` into `isEmpty` (nothing in the current window) and `trulyEmpty` (`isEmpty && !hasAnyData`). The onboarding card now only shows for `trulyEmpty`. A new `NoTrafficForPeriod` state renders when the window is empty but lifetime data exists, naming the selected range with a "Show all data" button that resets to "All time."

## Related issue

Closes #608

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR