### PR TITLE
fix: handle audit polling timeout state

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -73,6 +73,8 @@
     "noBrand": "Select a brand first.",
     "urlRequired": "Enter a URL to audit.",
     "failed": "Audit failed. Please try again.",
+    "takingLongerThanExpected": "This audit is taking longer than expected.",
+    "checkAgain": "Check again",
     "grade": {
       "good": "Good",
       "needsWork": "Needs work",

--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/[id]/page.tsx
@@ -32,46 +32,47 @@ export default function AuditDetailPage() {
   const [loading, setLoading] = useState(true);
   const [stage, setStage] = useState(0);
   const [timedOut, setTimedOut] = useState(false);
-  const cancelledRef = useRef(false);
+  const genRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const loadAndPoll = useCallback(async () => {
+    const gen = ++genRef.current;
+    const cancelled = () => genRef.current !== gen;
     try {
-      cancelledRef.current = false;
       setTimedOut(false);
 
       let result = await getAudit(id);
 
-      if (cancelledRef.current) return;
+      if (cancelled()) return;
 
       setAudit(result);
       setLoading(false);
 
       const deadline = Date.now() + 120_000;
 
-      while (!cancelledRef.current && result.status === 'running' && Date.now() < deadline) {
+      while (!cancelled() && result.status === 'running' && Date.now() < deadline) {
         await new Promise((resolve) => {
           timerRef.current = setTimeout(resolve, 3000);
         });
 
-        if (cancelledRef.current) return;
+        if (cancelled()) return;
 
         result = await getAudit(id);
 
-        if (cancelledRef.current) return;
+        if (cancelled()) return;
 
         setAudit(result);
       }
 
-      if (!cancelledRef.current && result.status === 'running' && Date.now() >= deadline) {
+      if (!cancelled() && result.status === 'running' && Date.now() >= deadline) {
         setTimedOut(true);
       }
 
-      if (!cancelledRef.current && result.status === 'failed') {
+      if (!cancelled() && result.status === 'failed') {
         toast.error(result.error || tFailed);
       }
     } catch (err) {
-      if (cancelledRef.current) return;
+      if (cancelled()) return;
 
       setLoading(false);
       toast.error(err instanceof Error ? err.message : tFailed);
@@ -86,7 +87,7 @@ export default function AuditDetailPage() {
     startPolling();
 
     return () => {
-      cancelledRef.current = true;
+      genRef.current++;
 
       if (timerRef.current) {
         clearTimeout(timerRef.current);

--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
@@ -31,45 +31,68 @@ export default function AuditDetailPage() {
   const [audit, setAudit] = useState<AuditResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [stage, setStage] = useState(0);
+  const [timedOut, setTimedOut] = useState(false);
+  const cancelledRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Load the audit and poll while it's still running.
-  useEffect(() => {
-    let cancelled = false;
-    let timer: ReturnType<typeof setTimeout>;
+  const loadAndPoll = useCallback(async () => {
+    try {
+      cancelledRef.current = false;
+      setTimedOut(false);
 
-    async function loadAndPoll() {
-      try {
-        let result = await getAudit(id);
-        if (cancelled) return;
+      let result = await getAudit(id);
+
+      if (cancelledRef.current) return;
+
+      setAudit(result);
+      setLoading(false);
+
+      const deadline = Date.now() + 120_000;
+
+      while (!cancelledRef.current && result.status === 'running' && Date.now() < deadline) {
+        await new Promise((resolve) => {
+          timerRef.current = setTimeout(resolve, 3000);
+        });
+
+        if (cancelledRef.current) return;
+
+        result = await getAudit(id);
+
+        if (cancelledRef.current) return;
+
         setAudit(result);
-        setLoading(false);
-
-        const deadline = Date.now() + 120_000;
-        while (!cancelled && result.status === 'running' && Date.now() < deadline) {
-          await new Promise((r) => {
-            timer = setTimeout(r, 3000);
-          });
-          if (cancelled) return;
-          result = await getAudit(id);
-          if (cancelled) return;
-          setAudit(result);
-        }
-        if (!cancelled && result.status === 'failed') {
-          toast.error(result.error || tFailed);
-        }
-      } catch (err) {
-        if (cancelled) return;
-        setLoading(false);
-        toast.error(err instanceof Error ? err.message : tFailed);
       }
-    }
 
-    loadAndPoll();
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
+      if (!cancelledRef.current && result.status === 'running' && Date.now() >= deadline) {
+        setTimedOut(true);
+      }
+
+      if (!cancelledRef.current && result.status === 'failed') {
+        toast.error(result.error || tFailed);
+      }
+    } catch (err) {
+      if (cancelledRef.current) return;
+
+      setLoading(false);
+      toast.error(err instanceof Error ? err.message : tFailed);
+    }
   }, [id, tFailed]);
+
+  useEffect(() => {
+    const startPolling = async () => {
+      await loadAndPoll();
+    };
+
+    startPolling();
+
+    return () => {
+      cancelledRef.current = true;
+
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [loadAndPoll]);
 
   // Advance the running-state stage label so the ~30s wait reads as progress.
   const isRunning = !audit || audit.status === 'running';
@@ -108,7 +131,7 @@ export default function AuditDetailPage() {
         >
           <ArrowLeft className="h-4 w-4" /> {t('title')}
         </Link>
-        {audit && audit.status !== 'running' && (
+        {audit && (audit.status !== 'running' || timedOut) && (
           <div className="flex items-center gap-1">
             <Button
               variant="ghost"
@@ -149,14 +172,28 @@ export default function AuditDetailPage() {
         )}
       </div>
 
-      {loading || (audit && audit.status === 'running') ? (
+      {loading ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" />
+            <div className="text-sm font-medium">{t('stages.fetch')}</div>
+            <div className="text-xs text-muted-foreground">~30s</div>
+          </CardContent>
+        </Card>
+      ) : audit && audit.status === 'running' && timedOut ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+            <div className="text-sm font-medium">{t('takingLongerThanExpected')}</div>
+
+            <Button onClick={loadAndPoll}>{t('checkAgain')}</Button>
+          </CardContent>
+        </Card>
+      ) : audit && audit.status === 'running' ? (
         <Card>
           <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
             <Loader2 className="h-6 w-6 animate-spin text-primary" />
             <div className="text-sm font-medium">
-              {loading
-                ? t('stages.fetch')
-                : [t('stages.fetch'), t('stages.analyze'), t('stages.recommend')][stage]}
+              {[t('stages.fetch'), t('stages.analyze'), t('stages.recommend')][stage]}
             </div>
             <div className="text-xs text-muted-foreground">~30s</div>
           </CardContent>


### PR DESCRIPTION
## Summary

Fix audit detail page polling timeout handling. Previously, when an audit remained in `running` state after the 120-second polling deadline, the page would silently stop polling and keep showing an infinite spinner with no available actions.

This change:
- Tracks a `timedOut` state when polling reaches the deadline while the audit is still running.
- Shows a dedicated "taking longer than expected" state instead of an endless spinner.
- Adds a "Check again" action to restart polling.
- Restores header actions (re-run/delete) when an audit times out.
- Adds translations for the new timeout state messages.

## Related issue

Closes #612 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [ ] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR