### PR TITLE
fix(web): wire up server-side pagination on Content Optimization list

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -51,6 +51,7 @@ import type { ContentOpportunity, ContentOpportunityStatus } from '@/types';
 import { toast } from 'sonner';
 import { Link } from '@/i18n/navigation';
 import { WebhookSettingsDialog } from './_webhook-settings';
+import { PAGE_SIZE, TablePager, usePagination } from '@/components/table-pager';
 
 const GENERATION_STORAGE_KEY = 'aeo:content-generation';
 const GENERATION_TIMEOUT_MS = 3 * 60 * 1000;
@@ -151,6 +152,11 @@ export default function ContentPage() {
   const [webhookOpen, setWebhookOpen] = useState(false);
   const pollRef = useRef(false);
 
+  // Server-side paging (#610) — the list can hold far more than one page's
+  // worth of opportunities, so `total` (the exact server count) drives the
+  // pager instead of the length of whatever page happens to be loaded.
+  const pager = usePagination(total, `${statusFilter}|${impactFilter}|${typeFilter}`);
+
   const loadData = useCallback(
     async (silent = false) => {
       if (!activeBrandId) {
@@ -170,7 +176,8 @@ export default function ContentPage() {
 
         const data = await getOpportunities(activeBrandId, {
           ...filters,
-          limit: 100,
+          limit: PAGE_SIZE,
+          offset: pager.start,
           sort: 'score',
         });
         setOpportunities(data.opportunities);
@@ -184,7 +191,7 @@ export default function ContentPage() {
         setLoading(false);
       }
     },
-    [activeBrandId, statusFilter, impactFilter, typeFilter],
+    [activeBrandId, statusFilter, impactFilter, typeFilter, pager.start],
   );
 
   useEffect(() => {
@@ -698,6 +705,14 @@ export default function ContentPage() {
                   No opportunities match your filters.
                 </div>
               )}
+              <TablePager
+                page={pager.page}
+                totalPages={pager.totalPages}
+                total={total}
+                start={pager.start}
+                end={pager.end}
+                onPage={pager.setPage}
+              />
             </CardContent>
           </Card>
         </>


### PR DESCRIPTION
## Summary

The Content Optimization list always fetched with a fixed `limit: 100` and no `offset`, while the UI advertised the full server-side total via the "{total} Available" badge and Total KPI. Any brand with more than 100 opportunities could never reach the rest from the UI — the numbers shown didn't match what was actually reachable.

- `getOpportunities` is now called with `limit: PAGE_SIZE, offset: pager.start` instead of a fixed `limit: 100`.
- Wires up the shared `usePagination`/`TablePager` (`web/src/components/table-pager.tsx`), already used on the Citations page, driven by the real server `total` rather than a local array length (Content can't pre-fetch everything client-side the way Citations does).
- The pager resets to page 0 whenever the status/impact/type filters change (resetKey pattern, matching Citations).
- The `highImpact`/`avgScore`/`sentCount` KPIs now reflect only the current page instead of silently summarizing whatever was in the first 100-row fetch — matching what the table can actually show. The `total`/"Available" badge continues to reflect the true server-side count.
- Bulk-select (`selectedIds`) was already scoped to `filtered`, derived from `opportunities` — now that `opportunities` holds real per-page data, selection is naturally page-scoped with no extra changes needed.

Note: the search box remains a client-side-only filter over the current page (the `/api/content/brand/:id` route has no `search` param) — that's a pre-existing gap, unchanged by this PR and out of scope for the issue's acceptance criteria.

## Related issue

Closes #610

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR