### PR TITLE
docs: add custom robots.txt with AI crawler allowances and sitemap reference

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,129 @@
+# ============================================
+# Ansvisor Docs Robots.txt
+# ============================================
+
+Sitemap: https://docs.ansvisor.com/sitemap.xml
+
+User-agent: *
+Disallow: /cdn-cgi/
+Disallow: /_next/
+Allow: /_next/image
+Allow: /
+
+# --------------------------------------------
+# OpenAI
+# --------------------------------------------
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+# --------------------------------------------
+# Google
+# --------------------------------------------
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: GoogleOther
+Allow: /
+
+# --------------------------------------------
+# Microsoft / Copilot
+# --------------------------------------------
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: AdIdxBot
+Allow: /
+
+# --------------------------------------------
+# Anthropic
+# --------------------------------------------
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Anthropic-ai
+Allow: /
+
+# --------------------------------------------
+# Perplexity
+# --------------------------------------------
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+# --------------------------------------------
+# Apple
+# --------------------------------------------
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+# --------------------------------------------
+# Common Crawl
+# --------------------------------------------
+
+User-agent: CCBot
+Allow: /
+
+# --------------------------------------------
+# Exa
+# --------------------------------------------
+
+User-agent: ExaBot
+Allow: /
+
+# --------------------------------------------
+# Firecrawl
+# --------------------------------------------
+
+User-agent: FirecrawlAgent
+Allow: /
+
+# --------------------------------------------
+# Amazon
+# --------------------------------------------
+
+User-agent: Amazonbot
+Allow: /
+
+# --------------------------------------------
+# Meta
+# --------------------------------------------
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+# --------------------------------------------
+# ByteDance
+# --------------------------------------------
+
+User-agent: Bytespider
+Allow: /
+
+# --------------------------------------------
+# You.com
+# --------------------------------------------
+
+User-agent: YouBot
+Allow: /


### PR DESCRIPTION
## Summary

Adds a custom `robots.txt` for the Mintlify-hosted docs site (docs.ansvisor.com), replacing the Mintlify default.

- Explicitly allows the major AI crawlers (OpenAI, Google, Microsoft, Anthropic, Perplexity, Apple, Common Crawl, Exa, Firecrawl, Amazon, Meta, ByteDance, You.com) — the docs should be maximally visible to answer engines.
- Keeps `/cdn-cgi/` and `/_next/` (except `/_next/image`) disallowed for generic crawlers.
- References the auto-generated sitemap (`Sitemap: https://docs.ansvisor.com/sitemap.xml`) so crawlers discover it from robots.

## Related issue

None — small docs infrastructure addition.

## Type of change

- [x] `docs` — Documentation only

## How to test

1. Deploy the docs site (Mintlify picks up a root-level `robots.txt` automatically).
2. `curl https://docs.ansvisor.com/robots.txt` — should return this file instead of the Mintlify default.
3. Confirm the `Sitemap:` line points at the live `sitemap.xml`.

## Checklist

- [x] Changes are focused — one concern per PR
