### PR TITLE
fix(server): generate content opportunities and briefs in the brand's…

### DIFF
--- a/server/src/lib/opportunity-generator.js
+++ b/server/src/lib/opportunity-generator.js
@@ -6,6 +6,7 @@
 import { generateObject } from 'ai';
 import { z } from 'zod';
 import { resolveModel } from './ai-provider.js';
+import { getLanguageName } from './languages.js';
 import supabaseAdmin from '../config/supabase.js';
 import { logger } from './logger.js';
 
@@ -64,10 +65,12 @@ export async function generateContentOpportunities(brandId) {
 
   const { data: brand } = await supabaseAdmin
     .from('brands')
-    .select('id, name, description, industry')
+    .select('id, name, description, industry, language')
     .eq('id', brandId)
     .single();
   if (!brand) return;
+
+  const langName = getLanguageName(brand.language);
 
   const { data: domains } = await supabaseAdmin
     .from('brand_domains')
@@ -161,7 +164,9 @@ Competitors: ${(compRes.data || []).map((c) => c.name).join(', ') || 'None'}
 Prompt Data:
 ${scored.map((p, i) => `[${i}] "${p.text}" | Intent: ${p.intent} | AI Vol: ${p.estAiVolume}/mo | Vis: ${p.avgVisibility}% | Gap: ${p.competitorGap}%`).join('\n')}
 
-Generate actionable content opportunities.`;
+Generate actionable content opportunities.
+
+IMPORTANT: Write every opportunity title and description in ${langName}.`;
 
   const { object } = await generateObject({
     model: resolveModel(),

--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -11,6 +11,7 @@ import {
 import { createJob, getJob } from '../lib/job-manager.js';
 import { runContentJob } from '../lib/job-runner.js';
 import { resolveModel } from '../lib/ai-provider.js';
+import { getLanguageName } from '../lib/languages.js';
 import supabaseAdmin from '../config/supabase.js';
 import {
   assertBrandAccess,
@@ -601,9 +602,11 @@ export async function generateBriefForOpportunity(opportunityId, { force = false
 
   const { data: brand } = await supabaseAdmin
     .from('brands')
-    .select('name, industry, description, organization_id')
+    .select('name, industry, description, organization_id, language')
     .eq('id', opportunity.brand_id)
     .single();
+
+  const langName = getLanguageName(brand?.language);
 
   // Quota is charged to the opportunity's org, and enforced here in the
   // shared core so the dashboard route and the internal MCP route draw
@@ -673,7 +676,9 @@ Competitors Cited: ${(sourceData.competitorsCited || []).join(', ') || 'none'}
 Latest Results Summary:
 ${latestResults.map((r) => `- ${r.platform}: visibility ${r.visibility_score}%, mentions: ${r.mention_count}, citations: ${r.citation_count}, sentiment: ${r.sentiment}`).join('\n') || 'No results yet'}
 
-Generate a detailed content brief for this opportunity.`;
+Generate a detailed content brief for this opportunity.
+
+IMPORTANT: Write every brief field in ${langName}.`;
 
   const aiModel = resolveModel(model);
 


### PR DESCRIPTION
## Summary

- Content Opportunities and their AI-generated briefs were always produced in English, even for brands with a non-English `brands.language` (e.g. `tr`), because neither generation path read the `language` column or told the model what language to write in.
- Add `language` to the brand `.select(...)` in both `server/src/lib/opportunity-generator.js` (opportunity generation) and `server/src/routes/content.js` (brief generation).
- Pass `getLanguageName(brand.language)` into each prompt with an `IMPORTANT: Write ... in ${langName}.` instruction — matching the same convention already used in `content-worker.js`, `topics.js`, `competitors.js`, and `prompts.js`.
- No migration or re-analysis needed: `language` already defaults to `'en'` on `brands`, so English brands see no behavior change; the fix applies on the next generation cycle.

## Related issue

Closes #638

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes (run from `server/`; this PR only touches `server/`, no `web/` changes)
- [x] `npm run format:check` passes (run from `server/`)
- [x] `npm run test` passes (run from `server/`, 147/147 tests)
- [x] Changes are focused — one concern per PR