### PR TITLE
fix(server): normalize PUBLIC_APP_URL to origin in pulse emails

### DIFF
--- a/server/src/lib/pulse/engine.js
+++ b/server/src/lib/pulse/engine.js
@@ -20,8 +20,23 @@ import { renderPulseEmail, sendPulseEmail } from './email.js';
 
 const WEEKLY_SEND_UTC_DAY = 1; // Monday
 
+let warnedAppUrlPath = false;
+
 function appUrl() {
-  return (process.env.PUBLIC_APP_URL || 'http://localhost:3000').replace(/\/$/, '');
+  const raw = process.env.PUBLIC_APP_URL || 'http://localhost:3000';
+  try {
+    const url = new URL(raw);
+    if (url.pathname !== '/' && url.pathname !== '' && !warnedAppUrlPath) {
+      warnedAppUrlPath = true;
+      logger.warn(
+        { PUBLIC_APP_URL: raw },
+        '[pulse] PUBLIC_APP_URL includes a path; using the origin only. Set it to the bare origin (e.g. https://app.example.com) to silence this warning.',
+      );
+    }
+    return url.origin;
+  } catch {
+    return raw.replace(/\/$/, '');
+  }
 }
 
 /** Recipient emails: explicit list from settings, else every org member. */


### PR DESCRIPTION
## Summary

- If `PUBLIC_APP_URL` is set with a path (e.g. `https://app.example.com/dashboard/insights` instead of the bare origin), `appUrl()` in `server/src/lib/pulse/engine.js` only stripped a trailing slash, so the path passed through untouched. The pulse engine then appends its own paths, producing doubled URLs like `/dashboard/insights/dashboard/insights` for the CTA and `/dashboard/insights/dashboard/settings?tab=notifications` for the manage-notifications footer link — this happened in a real deployment.
- `appUrl()` now parses the value with `new URL(value).origin` (falling back to the raw value if parsing fails) and logs a one-time warning via the existing `logger` when the configured value contains a path, so the operator learns their env is misconfigured instead of emails silently breaking.
- Localhost default (`http://localhost:3000`) behavior is unchanged.

## Related issue

Closes #639

## Type of change

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes (run from `server/`; this PR only touches `server/`, no `web/` changes)
- [x] `npm run format:check` passes (run from `server/`)
- [x] `npm run test` passes (run from `server/`, 147/147 tests — no existing test file covers the `pulse/` module, so none were added for this small, isolated fix)
- [x] Changes are focused — one concern per PR