### PR TITLE
fix: return validation errors from prompt workflow actions

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/_workflow-cards.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/[id]/_workflow-cards.tsx
@@ -110,8 +110,12 @@ export function NotesCard({
     if (!body) return;
     setSaving(true);
     try {
-      const note = await addPromptNote(promptId, body);
-      onNotesChange([note, ...notes]);
+      const result = await addPromptNote(promptId, body);
+      if ('error' in result) {
+        toast.error(result.error);
+        return;
+      }
+      onNotesChange([result.note, ...notes]);
       setDraft('');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to add note');
@@ -152,9 +156,12 @@ export function NotesCard({
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
               rows={2}
+              maxLength={2000}
               className="text-sm"
             />
-            <div className="flex justify-end">
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">{draft.length}/2000</p>
+
               <Button
                 size="sm"
                 className="gap-2"
@@ -217,14 +224,19 @@ export function TargetUrlsCard({
 }) {
   const [draft, setDraft] = useState('');
   const [saving, setSaving] = useState(false);
+  const [urlError, setUrlError] = useState<string | null>(null);
 
   const handleAdd = useCallback(async () => {
     const value = draft.trim();
     if (!value) return;
     setSaving(true);
     try {
-      const added = await addPromptTargetUrl(promptId, value);
-      onUrlsChange([...urls, added]);
+      const result = await addPromptTargetUrl(promptId, value);
+      if ('error' in result) {
+        setUrlError(result.error);
+        return;
+      }
+      onUrlsChange([...urls, result.targetUrl]);
       setDraft('');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to add URL');
@@ -264,7 +276,10 @@ export function TargetUrlsCard({
             <Input
               placeholder="https://example.com/blog/comparison-post"
               value={draft}
-              onChange={(e) => setDraft(e.target.value)}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                setUrlError(null);
+              }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.preventDefault();
@@ -287,6 +302,7 @@ export function TargetUrlsCard({
               )}
               Add
             </Button>
+            {urlError && <p className="text-xs text-destructive">{urlError}</p>}
           </div>
         )}
         {urls.length === 0 ? (

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_suggestions-card.tsx
@@ -128,7 +128,11 @@ export function SuggestionsCard({ brandId, onAccepted }: Props) {
     setPendingId(s.id);
     startTransition(async () => {
       try {
-        await acceptSuggestion(s.id);
+        const result = await acceptSuggestion(s.id);
+        if ('error' in result) {
+          toast.error(result.error);
+          return;
+        }
         setSuggestions((prev) => prev.filter((x) => x.id !== s.id));
         onAccepted?.();
         toast.success('Prompt added to your tracked list');

--- a/web/src/lib/actions/prompt-suggestions.ts
+++ b/web/src/lib/actions/prompt-suggestions.ts
@@ -112,10 +112,12 @@ export async function dismissSuggestion(suggestionId: string): Promise<{ success
   return res.json();
 }
 
+export type AcceptSuggestionResult = { promptId: string } | { error: string };
+
 export async function acceptSuggestion(
   suggestionId: string,
   options?: { platforms?: string[]; models?: string[] },
-): Promise<{ promptId: string }> {
+): Promise<AcceptSuggestionResult> {
   const session = await getSession();
   const supabase = await createClient();
 
@@ -126,7 +128,7 @@ export async function acceptSuggestion(
     .eq('status', 'new')
     .single();
   if (rowErr || !row) {
-    throw new Error('Suggestion not found or already processed');
+    return { error: 'Suggestion not found or already processed' };
   }
 
   const { data: ps, error: psErr } = await supabase
@@ -137,7 +139,7 @@ export async function acceptSuggestion(
     .limit(1)
     .maybeSingle();
   if (psErr || !ps) {
-    throw new Error('No prompt set exists for this brand. Create one first.');
+    return { error: 'No prompt set exists for this brand. Create one first.' };
   }
 
   const { data: defaults } = await supabase
@@ -165,7 +167,7 @@ export async function acceptSuggestion(
     models,
   });
   if ('error' in result) {
-    throw new Error(result.error);
+    return { error: result.error };
   }
   const created = result.prompt;
 

--- a/web/src/lib/actions/prompt-workflow.ts
+++ b/web/src/lib/actions/prompt-workflow.ts
@@ -105,10 +105,12 @@ export async function setPromptWorkStatus(
   if (error) throw new Error(error.message);
 }
 
-export async function addPromptNote(promptId: string, body: string): Promise<PromptNote> {
+export type AddPromptNoteResult = { note: PromptNote } | { error: string };
+
+export async function addPromptNote(promptId: string, body: string): Promise<AddPromptNoteResult> {
   const trimmed = body.trim();
-  if (!trimmed) throw new Error('Note cannot be empty');
-  if (trimmed.length > 2000) throw new Error('Note is too long (max 2000 characters)');
+  if (!trimmed) return { error: 'Note cannot be empty' };
+  if (trimmed.length > 2000) return { error: 'Note is too long (max 2000 characters)' };
 
   const supabase = await createClient();
   const {
@@ -120,16 +122,18 @@ export async function addPromptNote(promptId: string, body: string): Promise<Pro
     .insert({ prompt_id: promptId, body: trimmed, author_id: user?.id ?? null })
     .select('id, prompt_id, body, created_at, profiles(full_name)')
     .single();
-  if (error) throw new Error(error.message);
+  if (error) return { error: error.message };
 
   const r = data as unknown as Record<string, unknown>;
   const profile = r.profiles as { full_name: string | null } | null;
   return {
-    id: r.id as string,
-    promptId: r.prompt_id as string,
-    body: r.body as string,
-    authorName: profile?.full_name ?? null,
-    createdAt: r.created_at as string,
+    note: {
+      id: r.id as string,
+      promptId: r.prompt_id as string,
+      body: r.body as string,
+      authorName: profile?.full_name ?? null,
+      createdAt: r.created_at as string,
+    },
   };
 }
 
@@ -232,16 +236,18 @@ async function backfillCitedStats(
   return { citedCount, firstCitedAt, lastCitedAt };
 }
 
+export type AddPromptTargetUrlResult = { targetUrl: PromptTargetUrl } | { error: string };
+
 export async function addPromptTargetUrl(
   promptId: string,
   url: string,
   label?: string,
-): Promise<PromptTargetUrl> {
+): Promise<AddPromptTargetUrlResult> {
   let normalized: string;
   try {
     normalized = normalizeTargetUrl(url);
   } catch {
-    throw new Error('Enter a valid URL');
+    return { error: 'Enter a valid URL' };
   }
 
   const supabase = await createClient();
@@ -260,13 +266,21 @@ export async function addPromptTargetUrl(
     .select('id, prompt_id, url, label, created_at, cited_count, first_cited_at, last_cited_at')
     .single();
   if (error) {
-    if (error.code === '23505') throw new Error('This URL is already targeted for this prompt');
-    throw new Error(error.message);
+    if (error.code === '23505') {
+      return { error: 'This URL is already targeted for this prompt' };
+    }
+
+    return { error: error.message };
   }
 
   const mapped = mapTargetUrlRow(data as unknown as Record<string, unknown>);
   const stats = await backfillCitedStats(supabase, promptId, mapped.id, mapped.url);
-  return { ...mapped, ...stats };
+  return {
+    targetUrl: {
+      ...mapped,
+      ...stats,
+    },
+  };
 }
 
 export async function deletePromptTargetUrl(id: string): Promise<void> {


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

<!-- What does this PR do, and why? -->

Fix prompt workflow actions that were throwing user-triggerable validation errors and causing masked Server Components digest errors in production.

Changes:
- Updated `addPromptTargetUrl` to return `{ targetUrl } | { error }` instead of throwing validation errors.
- Updated target URL handling to display validation errors inline below the input instead of showing a toast.
- Updated `addPromptNote` to return `{ note } | { error }` for validation failures.
- Added `maxLength={2000}` and a character counter to the note textarea.
- Updated `acceptSuggestion` to return `{ promptId } | { error }` and handle validation failures without throwing.
- Updated affected call sites to handle errors using the `'error' in result` pattern.

## Related issue

Closes #549 

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR