### PR TITLE
fix: surface agent action errors to users

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/agent/page.tsx
@@ -240,7 +240,12 @@ function AgentChat(props: {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({}),
     });
-    if (!res.ok) return;
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+
+      toast.error(body?.error ?? 'Failed to create chat');
+      return;
+    }
     const { conversation } = (await res.json()) as { conversation: ConversationRow };
     setConversations((prev) => [conversation, ...prev]);
     setActiveId(conversation.id);
@@ -251,7 +256,12 @@ function AgentChat(props: {
   async function deleteConversation(id: string) {
     if (!confirm(t('deleteConfirm'))) return;
     const res = await fetch(`/api/agent/conversations/${id}`, { method: 'DELETE' });
-    if (!res.ok) return;
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+
+      toast.error(body?.error ?? 'Failed to delete conversation');
+      return;
+    }
     setConversations((prev) => prev.filter((c) => c.id !== id));
     if (activeId === id) {
       setActiveId(null);
@@ -276,15 +286,24 @@ function AgentChat(props: {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
-      if (!res.ok) return;
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+
+        toast.error(body?.error ?? 'Failed to create conversation');
+        return;
+      }
       const { conversation } = (await res.json()) as { conversation: ConversationRow };
       setConversations((prev) => [conversation, ...prev]);
       setActiveId(conversation.id);
       activeIdRef.current = conversation.id;
       convId = conversation.id;
     }
-    sendMessage({ text }, { body: { conversationId: convId } });
-    setInput('');
+    try {
+      await sendMessage({ text }, { body: { conversationId: convId } });
+      setInput('');
+    } catch {
+      toast.error('Failed to send message');
+    }
   }
 
   return (


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

<!-- What does this PR do, and why? -->

Improve error handling in agent chat actions by surfacing API failures instead of silently returning.

Changes:
- Added error response handling for `newChat` when conversation creation fails.
- Added error response handling for `deleteConversation` when deletion fails.
- Added error handling for message submission failures in `onSubmit`.
- Display `toast.error(...)` messages using the API-provided error with fallback messages.
- Preserve the user's typed message when sending fails by only clearing the input after a successful send.

## Related issue

Closes #551 

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR