### PR TITLE
fix: tolerate Cloro delivery gaps and refuse to stamp partial tracking runs

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -93,3 +93,7 @@ AI_VOLUME_MULTIPLIER=0.15
 # COMPOSIO_GSC_AUTH_CONFIG_ID=
 # Pinned Search Console toolkit version for tool execution (optional override)
 # COMPOSIO_GSC_TOOLKIT_VERSION=20260721_00
+
+# Drain-stall tolerance: consecutive 15s polls with no new Cloro result before
+# a run stops waiting (default 100 ≈ 25 min; hard deadline is 60 min).
+# CLORO_STALL_POLL_LIMIT=100

--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -291,9 +291,12 @@ export async function processTrackingJob({ brandId, promptId, promptIds, source,
         const drainDeadline = Date.now() + 60 * 60 * 1000;
         const drainPollMs = 15_000;
         // Give up early if delivery stalls — no new result for this many
-        // consecutive polls (~10 min) means the rest were almost certainly
-        // dropped, so don't hold the bar (and a concurrency slot) for an hour.
-        const stallPollLimit = 40;
+        // consecutive polls. Cloro delivers in bursts with quiet gaps: a real
+        // run went silent for 10+ minutes after the first ~600 results and
+        // then delivered the remaining ~1000, so the old ~10-min limit cut a
+        // healthy run in half. ~25 min tolerates those gaps while the 60-min
+        // drain deadline stays the hard cap on a truly stuck queue.
+        const stallPollLimit = Number(process.env.CLORO_STALL_POLL_LIMIT) || 100;
 
         let lastPending = expectedSubmitted;
         let stalledPolls = 0;
@@ -538,9 +541,21 @@ export async function processTrackingJob({ brandId, promptId, promptIds, source,
       .eq('brand_id', brandId)
       .gte('created_at', trackingRunStartedAt);
 
+    // Partial-run guard: a run that produced far fewer results than it
+    // planned tasks (Cloro delivered late/never) must not become the 24h
+    // anchor — a half-empty window reads as a visibility crash in the
+    // dashboard and the pulse mail. The ratio compares against THIS run's
+    // own planned task count, never against history, so a brand that
+    // legitimately shrinks its prompt set can't wedge the guard. Late
+    // results that land after the previous anchor stay visible in the next
+    // stamped window — nothing is lost, the anchor just refuses to move
+    // onto partial data.
+    const MIN_STAMP_RATIO = 0.5;
+    const isPartial = totalTasks > 0 && (runResultCount ?? 0) < totalTasks * MIN_STAMP_RATIO;
+
     if (countErr) {
       logger.error({ err: countErr, brandId, trackingRunId }, 'failed to count run results');
-    } else if ((runResultCount ?? 0) > 0) {
+    } else if ((runResultCount ?? 0) > 0 && !isPartial) {
       const { error: stampErr } = await supabaseAdmin
         .from('tracking_runs')
         .update({ completed_at: new Date().toISOString(), result_count: runResultCount })
@@ -550,6 +565,12 @@ export async function processTrackingJob({ brandId, promptId, promptIds, source,
       } else {
         logger.info({ brandId, trackingRunId, runResultCount }, 'tracking run stamped');
       }
+    } else if ((runResultCount ?? 0) > 0) {
+      logger.warn(
+        { brandId, trackingRunId, runResultCount, totalTasks },
+        'tracking run partial — below stamp ratio, row removed; window stays on previous run',
+      );
+      await supabaseAdmin.from('tracking_runs').delete().eq('id', trackingRunId);
     } else {
       logger.warn({ brandId, trackingRunId }, 'tracking run produced no results — row removed');
       await supabaseAdmin.from('tracking_runs').delete().eq('id', trackingRunId);


### PR DESCRIPTION
## Summary

This morning's cron run for a production brand stamped with only 619 of 1,960 planned results, dragging the anchored 24h window — and the Daily Pulse mail — down to a visibility of 9 (real value ~14) and a "135 tracked prompts" reading (real: 279). Root cause from the logs and DB:

- All 1,960 Cloro tasks were submitted successfully.
- Cloro delivered ~600 results, then went quiet for 10+ minutes; the worker's stall guard (40 × 15s ≈ 10 min of no new results) gave up and stamped the run.
- The remaining 1,058 results arrived minutes after the stamp — nothing was lost, but they fell outside the stamped window.

Two-part fix:

1. **Stall tolerance raised to ~25 min** (`stallPollLimit` 40 → 100, env-overridable via `CLORO_STALL_POLL_LIMIT`). Cloro delivers in bursts with quiet gaps; the 60-min drain deadline remains the hard cap on a truly stuck queue.
2. **Partial-run stamp guard**: a full run that produced fewer than 50% of its own planned task count is not stamped (row removed, warning logged) — the 24h anchor stays on the previous complete run, so the dashboard and pulse keep showing consistent full-run data instead of a half-empty window. The ratio compares against the run's *own* plan, never history, so legitimately shrinking a prompt set can't wedge the guard. Late results remain in the DB and surface in the next stamped window.

## Related issue

None — production incident fix (diagnosed from today's cron run).

## Type of change

- [x] `fix` — Bug fix

## How to test

1. Normal run: results ≥ 50% of planned tasks → stamped exactly as before (`tracking run stamped` log).
2. Simulate partial delivery (or set `CLORO_STALL_POLL_LIMIT=1` against a slow queue): run ends below the ratio → `tracking run partial — below stamp ratio` warning, no `tracking_runs` row, dashboard 24h window stays anchored to the previous complete run.
3. Zero-result run behavior unchanged (row removed).

## Checklist

- [x] Branch follows the naming convention (`fix/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
