### PR TITLE
fix: gate content dismiss actions behind confirmation and undo

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -274,7 +274,7 @@
       "sendAll": "Send All",
       "dismissAll": "Dismiss All",
       "dismissAllTitle": "Dismiss opportunities?",
-      "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} You can restore them individually afterward."
+     "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} This can't be undone."
     },
     "table": {
       "action": "Action",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -232,6 +232,10 @@
     "sendToWorkflow": "Send to Workflow",
     "sending": "Sending...",
     "dismiss": "Dismiss",
+    "dismissedToast": "Opportunity dismissed",
+    "undo": "Undo",
+    "undoFailed": "Failed to undo",
+    "cancel": "Cancel",
     "viewDetails": "View Details",
     "configureWebhook": "Configure Webhook",
     "noOpportunities": "No content opportunities yet",
@@ -268,7 +272,9 @@
     "bulk": {
       "selected": "{count} selected",
       "sendAll": "Send All",
-      "dismissAll": "Dismiss All"
+      "dismissAll": "Dismiss All",
+      "dismissAllTitle": "Dismiss opportunities?",
+      "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} You can restore them individually afterward."
     },
     "table": {
       "action": "Action",

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx
@@ -143,9 +143,22 @@ export default function ContentDetailPage() {
   const handleDismiss = async () => {
     try {
       await updateOpportunityStatus(id, 'dismissed');
-      toast.success('Opportunity dismissed');
       const updated = await getOpportunity(id);
       setOpportunity(updated);
+      toast.success(t('dismissedToast'), {
+        action: {
+          label: t('undo'),
+          onClick: async () => {
+            try {
+              await updateOpportunityStatus(id, 'new');
+              const restored = await getOpportunity(id);
+              setOpportunity(restored);
+            } catch {
+              toast.error(t('undoFailed'));
+            }
+          },
+        },
+      });
     } catch {
       toast.error('Failed to dismiss');
     }

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -15,6 +15,16 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
   Table,
   TableBody,
   TableCell,
@@ -292,8 +302,20 @@ export default function ContentPage() {
   const handleDismiss = async (id: string) => {
     try {
       await updateOpportunityStatus(id, 'dismissed');
-      toast.success('Opportunity dismissed');
       await loadData(true);
+      toast.success(t('dismissedToast'), {
+        action: {
+          label: t('undo'),
+          onClick: async () => {
+            try {
+              await updateOpportunityStatus(id, 'new');
+              await loadData(true);
+            } catch {
+              toast.error(t('undoFailed'));
+            }
+          },
+        },
+      });
     } catch (err) {
       console.error('Dismiss failed:', err);
       toast.error('Failed to dismiss');
@@ -566,16 +588,39 @@ export default function ContentPage() {
                     Done
                   </Button>
 
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 text-xs gap-1.5 text-muted-foreground"
-                    onClick={handleBulkDismiss}
-                    disabled={bulkSending}
-                  >
-                    <X className="h-3 w-3" />
-                    {t('bulk.dismissAll')}
-                  </Button>
+                  <Dialog>
+                    <DialogTrigger
+                      render={
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs gap-1.5 text-muted-foreground"
+                          disabled={bulkSending}
+                        />
+                      }
+                    >
+                      <X className="h-3 w-3" />
+                      {t('bulk.dismissAll')}
+                    </DialogTrigger>
+                    <DialogContent className="sm:max-w-sm">
+                      <DialogHeader>
+                        <DialogTitle>{t('bulk.dismissAllTitle')}</DialogTitle>
+                        <DialogDescription>
+                          {t('bulk.dismissAllConfirm', { count: selectedIds.size })}
+                        </DialogDescription>
+                      </DialogHeader>
+                      <DialogFooter>
+                        <DialogClose render={<Button variant="outline" />}>
+                          {t('cancel')}
+                        </DialogClose>
+                        <DialogClose
+                          render={<Button variant="destructive" onClick={handleBulkDismiss} />}
+                        >
+                          {t('bulk.dismissAll')}
+                        </DialogClose>
+                      </DialogFooter>
+                    </DialogContent>
+                  </Dialog>
                 </div>
               </div>
             )}


### PR DESCRIPTION
Summary

Content Opportunities dismiss actions previously mutated state immediately with no confirmation — both single-row dismiss and bulk "Dismiss All" fired on first click with an irreversible optimistic update.

This PR:

Gates Dismiss All (bulk) behind a confirm Dialog (same pattern as audit/[id]/page.tsx) showing the exact count of opportunities being dismissed. Cancelling leaves all rows untouched.
Gives single-row dismiss (list page + detail page) an undo-toast: the dismiss still fires immediately to keep the flow fast, but the success toast includes an Undo action that restores the opportunity back to new status.

Bulk actions get the harder confirm gate since the blast radius is higher and there's no undo; single dismiss uses the lighter undo-toast pattern per the issue's suggested fix.

Related issue

Closes #611

Type of change
 fix — Bug fix
How to test
Go to /dashboard/content with a brand that has new opportunities
Click the dismiss (X) button on a single row → toast shows "Opportunity dismissed" with an Undo button → click Undo → row returns to new status
Select multiple rows → click "Dismiss All" → confirm dialog shows the exact count → Cancel leaves rows untouched → confirming dismisses them
Repeat the single-dismiss check on /dashboard/content/[id] detail page
Checklist
 Branch follows the naming convention (feature/, fix/, chore/, docs/) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
 yarn lint passes (run from web/)
 yarn typecheck passes (run from web/)
 yarn format:check passes (run from web/)
 Changes are focused — one concern per PR

Note on format:check: yarn format:check fails repo-wide on this branch due to CRLF line endings introduced by a Windows checkout — pre-existing and unrelated to this change, affecting files this PR doesn't touch. The three files this PR actually modifies (web/messages/en.json, content/page.tsx, content/[id]/page.tsx) are individually Prettier-clean, verified via:

npx prettier --check web/messages/en.json "web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx" "web/src/app/[locale]/(dashboard)/dashboard/content/[id]/page.tsx"