### PR TITLE
fix: recover pulses lost to process death with a daily catch-up sweep

### DIFF
--- a/server/src/lib/pulse/engine.js
+++ b/server/src/lib/pulse/engine.js
@@ -100,10 +100,13 @@ async function recentWarningKeys(brandId, now) {
   return keys;
 }
 
-export async function generatePulseForBrand(brandId) {
+export async function generatePulseForBrand(brandId, { pulseDate: pulseDateOverride } = {}) {
   try {
     const now = new Date();
-    const pulseDate = now.toISOString().slice(0, 10);
+    // The catch-up sweep passes the missed run's completion date so a
+    // recovered pulse claims THAT day's dedupe slot — today's real pulse
+    // (fired when today's run completes) keeps its own date.
+    const pulseDate = pulseDateOverride ?? now.toISOString().slice(0, 10);
 
     const { data: brand } = await supabaseAdmin
       .from('brands')
@@ -236,6 +239,62 @@ export async function generatePulseForBrand(brandId) {
     return { generated: true, emailSent, webhooksSent: sent };
   } catch (err) {
     logger.error({ err, brandId }, 'daily pulse generation failed');
+    return { error: true };
+  }
+}
+
+/**
+ * Catch-up sweep (#missed-pulse incident): the per-brand pulse trigger is
+ * fire-and-forget at the end of a tracking job — a process death, deploy, or
+ * OOM in that window silently eats the mail while the run's stamp survives.
+ * This sweep runs at the start of the daily cycle: any brand whose latest
+ * completed run (last 36h) has no pulse row created after it gets a recovery
+ * pulse, dated to that run's completion day so today's real pulse keeps its
+ * own dedupe slot. The sent_pulses unique key makes double-sends impossible.
+ */
+export async function runPulseCatchUp() {
+  try {
+    const since = new Date(Date.now() - 36 * 60 * 60 * 1000).toISOString();
+    const { data: runs, error } = await supabaseAdmin
+      .from('tracking_runs')
+      .select('brand_id, completed_at')
+      .not('completed_at', 'is', null)
+      .gte('completed_at', since)
+      .order('completed_at', { ascending: false });
+    if (error) throw new Error(error.message);
+
+    const latestByBrand = new Map();
+    for (const r of runs || []) {
+      if (!latestByBrand.has(r.brand_id)) latestByBrand.set(r.brand_id, r.completed_at);
+    }
+
+    let sent = 0;
+    let skipped = 0;
+    for (const [brandId, completedAt] of latestByBrand) {
+      const { count, error: countErr } = await supabaseAdmin
+        .from('sent_pulses')
+        .select('*', { count: 'exact', head: true })
+        .eq('brand_id', brandId)
+        .gte('created_at', completedAt);
+      if (countErr || (count ?? 0) > 0) continue; // run already pulsed (or unknowable)
+
+      const result = await generatePulseForBrand(brandId, {
+        pulseDate: completedAt.slice(0, 10),
+      });
+      if (result?.generated) {
+        logger.info({ brandId, runCompletedAt: completedAt }, '[pulse] catch-up pulse sent');
+        sent++;
+      } else {
+        skipped++;
+      }
+    }
+
+    if (sent > 0 || skipped > 0) {
+      logger.info({ sent, skipped }, '[pulse] catch-up sweep completed');
+    }
+    return { sent, skipped };
+  } catch (err) {
+    logger.error({ err }, '[pulse] catch-up sweep failed');
     return { error: true };
   }
 }

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -31,6 +31,7 @@ import supabaseAdmin from './config/supabase.js';
 import { getPlan, hasFeature, isCloud, isSubscriptionActive } from './config/plans.js';
 import { analyzeBrandVolumes } from './lib/volume-analysis.js';
 import { runGscSync } from './lib/gsc-sync.js';
+import { runPulseCatchUp } from './lib/pulse/engine.js';
 
 const app = express();
 app.set('trust proxy', 1);
@@ -111,6 +112,13 @@ async function runDailyTracking() {
   // Sweep orphaned Cloro pending tasks daily (runs in both cloud and
   // self-hosted, since both paths funnel through here).
   await cleanupStalePendingTasks();
+
+  // Recover pulses whose fire-and-forget trigger died with the process
+  // (OOM, deploy, crash) after the run had already stamped. Non-blocking —
+  // today's runs and their own pulses are independent of this sweep.
+  runPulseCatchUp().catch((err) => {
+    logger.error({ err }, '[pulse] catch-up sweep crashed');
+  });
 
   // Skip paused brands (is_active = false): the user has explicitly suspended
   // tracking for them, so they should not spend Cloro / LLM credits daily.


### PR DESCRIPTION
## Summary

A production brand's Daily Pulse silently disappeared for a day: its tracking run completed and stamped, but the per-brand pulse trigger — fire-and-forget at the end of the tracking job — died with the process (memory pressure on a 1 GB host). The stamp survives in the DB; the in-memory trigger doesn't. No error, no mail, nothing to retry.

Fix: a **catch-up sweep** at the start of every daily cycle.

- `runPulseCatchUp()` scans the last 36h of completed `tracking_runs`; any brand whose latest completed run has **no `sent_pulses` row created after it** gets a recovery pulse.
- The recovered pulse is dated to the missed run's **completion day** (`generatePulseForBrand` gains an optional `pulseDate` override), so it claims that day's dedupe slot — today's real pulse, fired when today's run completes, keeps its own date and is never suppressed.
- Double-sends are impossible: the existing `sent_pulses (brand_id, pulse_date)` unique constraint remains the race-safe claim.
- Non-blocking (fire-and-forget with logging), mirroring the GSC sync step: the sweep can never delay or fail the tracking cycle. All existing eligibility skips (inactive brand/subscription, frequency off/weekly-day, no fresh results) apply unchanged.

## Related issue

None — production incident fix (missed pulse after an OOM-killed trigger).

## Type of change

- [x] `fix` — Bug fix

## How to test

1. Simulate a missed pulse: complete a run for a brand, delete its `sent_pulses` row for that date, then invoke `runPulseCatchUp()` — a recovery pulse is generated dated to the run's completion day (`[pulse] catch-up pulse sent` log).
2. Run the sweep again — the brand is skipped (`already_sent` via the unique key).
3. Brands whose latest run was already pulsed are untouched; the daily cycle timing is unaffected (sweep is fire-and-forget).

## Checklist

- [x] Branch follows the naming convention (`fix/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
