### PR TITLE
fix: improve audit page accessibility attributes

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
@@ -203,6 +203,7 @@ export default function SiteAuditPage() {
                   key={p}
                   type="button"
                   onClick={() => setRange(p)}
+                  aria-pressed={range === p}
                   className={cn(
                     'px-2.5 py-1 text-xs font-medium transition-colors',
                     range === p
@@ -296,6 +297,7 @@ export default function SiteAuditPage() {
             type="url"
             inputMode="url"
             placeholder="https://example.com/page"
+            aria-label="Website URL"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && !running && !quotaExhausted && handleRun()}

--- a/web/src/components/audit/audit-report.tsx
+++ b/web/src/components/audit/audit-report.tsx
@@ -147,6 +147,7 @@ function SignalRow({
         onClick={() => setOpen((v) => !v)}
         className="flex w-full items-center gap-3 py-3 text-left hover:bg-muted/40"
         aria-expanded={open}
+        aria-controls={`signal-panel-${signal.key}`}
       >
         <Icon className={cn('h-4 w-4 shrink-0', STATUS_COLOR[signal.status])} />
         <span className="flex-1 text-sm font-medium">{signal.label}</span>
@@ -163,7 +164,10 @@ function SignalRow({
         />
       </button>
       {open && (
-        <div className="space-y-2 pb-4 pl-7 text-sm text-muted-foreground">
+        <div
+          id={`signal-panel-${signal.key}`}
+          className="space-y-2 pb-4 pl-7 text-sm text-muted-foreground"
+        >
           {typeof signal.evidence?.reason === 'string' && signal.evidence.reason && (
             <p>
               <span className="font-medium text-foreground">Finding: </span>


### PR DESCRIPTION
## Summary

Improve accessibility support on the audit page by adding missing ARIA attributes.

Changes:
- Added `aria-pressed` to the 7d / 30d / 90d / All range toggle buttons so screen readers can identify the active range.
- Added an accessible label to the URL input so its purpose is announced correctly.
- Added `aria-controls` and matching panel ids to expandable audit signal rows to connect the toggle buttons with their expanded content.

## Related issue

Closes #671 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR