### PR TITLE
fix: refresh audit stats after deleting audit

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
@@ -166,6 +166,7 @@ export default function SiteAuditPage() {
     setHistory((h) => h.filter((a) => a.id !== id));
     try {
       await deleteAudit(id);
+      refetch();
     } catch (err) {
       setHistory(prev);
       toast.error(err instanceof Error ? err.message : t('failed'));


### PR DESCRIPTION
## Summary

Refresh audit hub data after deleting an audit so the trend card, chart, and quota counter stay in sync with the audit history.

Changes:
- Kept the existing optimistic history list update.
- Triggered the existing `refetch()` flow after a successful `deleteAudit`.
- Preserved rollback behavior when deletion fails by restoring the previous history state.

## Related issue

Closes #669 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR