### PR TITLE
fix: group audit trend points by local date

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/page.tsx
@@ -121,7 +121,14 @@ export default function SiteAuditPage() {
   const dailyPoints = useMemo(() => {
     const byDay = new Map<string, (typeof rangePoints)[number]>();
     for (const p of rangePoints) {
-      byDay.set(new Date(p.createdAt).toISOString().slice(0, 10), p);
+      const date = new Date(p.createdAt);
+      const localDay = [
+        date.getFullYear(),
+        String(date.getMonth() + 1).padStart(2, '0'),
+        String(date.getDate()).padStart(2, '0'),
+      ].join('-');
+
+      byDay.set(localDay, p);
     }
     return [...byDay.values()];
   }, [rangePoints]);


### PR DESCRIPTION
## Summary

Fix audit trend chart date grouping to use the user's local calendar day instead of UTC day.

Changes:
- Replaced UTC-based date grouping using `toISOString()` with local date parts (`getFullYear`, `getMonth`, `getDate`).
- Ensured trend points are grouped using the same calendar as the x-axis labels.
- Fixed incorrect latest point and delta calculations caused by UTC/local date mismatches.

## Related issue

Closes #668 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR