### PR TITLE
fix: prevent duplicate audit reruns

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/audit/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/audit/[id]/page.tsx
@@ -34,6 +34,7 @@ export default function AuditDetailPage() {
   const [timedOut, setTimedOut] = useState(false);
   const genRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [rerunning, setRerunning] = useState(false);
 
   const loadAndPoll = useCallback(async () => {
     const gen = ++genRef.current;
@@ -115,11 +116,15 @@ export default function AuditDetailPage() {
   // Re-run the audit on the same URL → navigate to the new audit's detail page.
   const handleRefresh = async () => {
     if (!audit) return;
+    setRerunning(true);
+
     try {
       const started = await runAudit(audit.brandId, audit.url);
       router.push(`/dashboard/audit/${started.id}`);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : tFailed);
+    } finally {
+      setRerunning(false);
     }
   };
 
@@ -138,10 +143,15 @@ export default function AuditDetailPage() {
               variant="ghost"
               size="icon"
               className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              disabled={rerunning}
               onClick={handleRefresh}
               aria-label={t('reaudit')}
             >
-              <RefreshCw className="h-3.5 w-3.5" />
+              {rerunning ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
             </Button>
             <Dialog>
               <DialogTrigger


### PR DESCRIPTION
## Summary

Prevent duplicate audit re-runs by adding a pending state to the audit detail page.

Changes:
- Added `rerunning` state to track when a re-run request is in progress.
- Disabled the Re-run button while the request is pending.
- Added a loading spinner using `Loader2` while the audit re-run is being triggered.
- Prevented users from accidentally starting multiple audits through double-clicks.

## Related issue

Closes #667 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR