### PR TITLE
fix: improve content list accessibility and i18n

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -229,8 +229,10 @@
     "generate": "Generate Opportunities",
     "regenerate": "Refresh Opportunities",
     "generating": "Analyzing...",
+    "send": "Send",
     "sendToWorkflow": "Send to Workflow",
     "sending": "Sending...",
+    "noResults": "No opportunities match your filters.",
     "dismiss": "Dismiss",
     "viewDetails": "View Details",
     "configureWebhook": "Configure Webhook",
@@ -258,7 +260,11 @@
       "total": "Total Opportunities",
       "highImpact": "High Impact",
       "sentToWorkflow": "Sent to Workflow",
-      "avgScore": "Avg. Score"
+      "avgScore": "Avg. Score",
+      "shown": "{count} shown",
+      "opportunities": "opportunities",
+      "outOf100": "out of 100",
+      "sentOrInProgress": "sent or in progress"
     },
     "filters": {
       "allStatuses": "All Statuses",

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -132,6 +132,7 @@ function KpiCard({
 
 export default function ContentPage() {
   const t = useTranslations('content');
+  const tCommon = useTranslations('common');
   const activeBrandId = useBrandStore((s) => s.activeBrandId);
   const { isCloud } = usePlanContext();
 
@@ -448,20 +449,25 @@ export default function ContentPage() {
               title={t('kpi.total')}
               icon={Lightbulb}
               value={total}
-              sub={`${filtered.length} shown`}
+              sub={t('kpi.shown', { count: filtered.length })}
             />
             <KpiCard
               title={t('kpi.highImpact')}
               icon={Zap}
               value={highImpact}
-              sub="opportunities"
+              sub={t('kpi.opportunities')}
             />
-            <KpiCard title={t('kpi.avgScore')} icon={BarChart3} value={avgScore} sub="out of 100" />
+            <KpiCard
+              title={t('kpi.avgScore')}
+              icon={BarChart3}
+              value={avgScore}
+              sub={t('kpi.outOf100')}
+            />
             <KpiCard
               title={t('kpi.sentToWorkflow')}
               icon={Send}
               value={sentCount}
-              sub="sent or in progress"
+              sub={t('kpi.sentOrInProgress')}
             />
           </div>
 
@@ -474,16 +480,17 @@ export default function ContentPage() {
                     variant="outline"
                     className="text-xs border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
                   >
-                    {total} Available
+                    {t('available', { count: total })}
                   </Badge>
                 </div>
                 <div className="flex items-center gap-2 flex-wrap">
                   <div className="relative w-48">
                     <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
                     <Input
-                      placeholder="Search..."
+                      placeholder={tCommon('search')}
                       value={search}
                       onChange={(e) => setSearch(e.target.value)}
+                      aria-label={tCommon('search')}
                       className="pl-8 h-8 text-xs"
                     />
                   </div>
@@ -563,7 +570,7 @@ export default function ContentPage() {
                     disabled={bulkSending}
                   >
                     <Check className="h-3 w-3" />
-                    Done
+                    {t('status.done')}
                   </Button>
 
                   <Button
@@ -677,20 +684,26 @@ export default function ContentPage() {
                                 ) : (
                                   <Send className="h-3 w-3" />
                                 )}
-                                Send
+                                {t('send')}
                               </Button>
                               <Button
                                 variant="ghost"
                                 size="sm"
                                 className="h-7 px-2 text-xs text-muted-foreground"
                                 onClick={() => handleDismiss(opp.id)}
+                                aria-label={t('dismiss')}
                               >
                                 <X className="h-3 w-3" />
                               </Button>
                             </>
                           )}
                           <Link href={`/dashboard/content/${opp.id}`}>
-                            <Button variant="ghost" size="sm" className="h-7 px-2 text-xs">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 px-2 text-xs"
+                              aria-label={t('viewDetails')}
+                            >
                               <ExternalLink className="h-3 w-3" />
                             </Button>
                           </Link>
@@ -702,7 +715,7 @@ export default function ContentPage() {
               </Table>
               {filtered.length === 0 && (
                 <div className="py-10 text-center text-sm text-muted-foreground">
-                  No opportunities match your filters.
+                  {t('noResults')}
                 </div>
               )}
               <TablePager


### PR DESCRIPTION
## Summary

- Improve accessibility for the Content Opportunities list page by adding accessible names to icon-only action buttons and labeling the search input.
- Replace hardcoded user-facing strings with translated values from the `content` and `common` namespaces.
- Reuse existing translation keys where available and add missing keys for KPI subtexts and other list page labels.

## Related issue

Closes #665 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
```