### PR TITLE
fix: improve content page accessibility and i18n coverage

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -260,6 +260,9 @@
     "noOpportunitiesHint": "Generate opportunities to get AI-powered content recommendations based on your prompt data.",
     "noPromptsHint": "Add prompts and run volume analysis first to generate content opportunities.",
     "available": "{count} Available",
+    "search": "Search opportunities...",
+    "send": "Send",
+    "noResults": "No opportunities match your filters.",
     "status": {
       "new": "New",
       "sent": "Sent to Workflow",
@@ -280,7 +283,11 @@
       "total": "Total Opportunities",
       "highImpact": "High Impact",
       "sentToWorkflow": "Sent to Workflow",
-      "avgScore": "Avg. Score"
+      "avgScore": "Avg. Score",
+      "shownSub": "{count} shown",
+      "opportunitiesUnit": "opportunities",
+      "outOf100": "out of 100",
+      "sentOrInProgress": "sent or in progress"
     },
     "filters": {
       "allStatuses": "All Statuses",
@@ -290,9 +297,10 @@
     "bulk": {
       "selected": "{count} selected",
       "sendAll": "Send All",
+      "markDone": "Done",
       "dismissAll": "Dismiss All",
       "dismissAllTitle": "Dismiss opportunities?",
-     "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} This can't be undone."
+      "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} This can't be undone."
     },
     "table": {
       "action": "Action",

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -470,20 +470,25 @@ export default function ContentPage() {
               title={t('kpi.total')}
               icon={Lightbulb}
               value={total}
-              sub={`${filtered.length} shown`}
+              sub={t('kpi.shownSub', { count: filtered.length })}
             />
             <KpiCard
               title={t('kpi.highImpact')}
               icon={Zap}
               value={highImpact}
-              sub="opportunities"
+              sub={t('kpi.opportunitiesUnit')}
             />
-            <KpiCard title={t('kpi.avgScore')} icon={BarChart3} value={avgScore} sub="out of 100" />
+            <KpiCard
+              title={t('kpi.avgScore')}
+              icon={BarChart3}
+              value={avgScore}
+              sub={t('kpi.outOf100')}
+            />
             <KpiCard
               title={t('kpi.sentToWorkflow')}
               icon={Send}
               value={sentCount}
-              sub="sent or in progress"
+              sub={t('kpi.sentOrInProgress')}
             />
           </div>
 
@@ -496,14 +501,15 @@ export default function ContentPage() {
                     variant="outline"
                     className="text-xs border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
                   >
-                    {total} Available
+                    {t('available', { count: total })}
                   </Badge>
                 </div>
                 <div className="flex items-center gap-2 flex-wrap">
                   <div className="relative w-48">
                     <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
                     <Input
-                      placeholder="Search..."
+                      aria-label={t('search')}
+                      placeholder={t('search')}
                       value={search}
                       onChange={(e) => setSearch(e.target.value)}
                       className="pl-8 h-8 text-xs"
@@ -585,7 +591,7 @@ export default function ContentPage() {
                     disabled={bulkSending}
                   >
                     <Check className="h-3 w-3" />
-                    Done
+                    {t('bulk.markDone')}
                   </Button>
 
                   <Dialog>
@@ -722,20 +728,26 @@ export default function ContentPage() {
                                 ) : (
                                   <Send className="h-3 w-3" />
                                 )}
-                                Send
+                                {t('send')}
                               </Button>
                               <Button
                                 variant="ghost"
                                 size="sm"
                                 className="h-7 px-2 text-xs text-muted-foreground"
                                 onClick={() => handleDismiss(opp.id)}
+                                aria-label={t('dismiss')}
                               >
                                 <X className="h-3 w-3" />
                               </Button>
                             </>
                           )}
                           <Link href={`/dashboard/content/${opp.id}`}>
-                            <Button variant="ghost" size="sm" className="h-7 px-2 text-xs">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 px-2 text-xs"
+                              aria-label={t('viewDetails')}
+                            >
                               <ExternalLink className="h-3 w-3" />
                             </Button>
                           </Link>
@@ -747,7 +759,7 @@ export default function ContentPage() {
               </Table>
               {filtered.length === 0 && (
                 <div className="py-10 text-center text-sm text-muted-foreground">
-                  No opportunities match your filters.
+                  {t('noResults')}
                 </div>
               )}
               <TablePager


### PR DESCRIPTION
## Summary
- Adds `aria-label` to the icon-only dismiss and view-details row actions, and labels the search input, using the existing `dismiss` / `viewDetails` translation keys.
- Replaces hardcoded strings (`{total} Available`, `Done`, `Send`, `No opportunities match your filters.`, the four KPI subtexts) with i18n keys, adding the few missing ones to the `content` namespace.

Fixes #665

## Test plan
- [x] `tsc --noEmit` - clean
- [x] `eslint` on the changed file - clean
- [x] `vitest run` - 80/80 passing
- [ ] Manually verified in a running browser - not done, the app needs Supabase and other env vars not set up in this environment

Note: `content.noPromptsHint` stays unused. Wiring it in would need a way to tell "no prompts yet" apart from "no opportunities yet," which this page doesn't track today; that felt like a separate issue from what's described here.