### PR TITLE
fix:content search pagination

### DIFF
--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -141,7 +141,7 @@ router.get('/brand/:brandId', async (req, res) => {
     if (type) query = query.eq('type', type);
 
     if (q) {
-      const search = String(q).replace(/([,()])/g, '\\$1');
+      const search = String(q).replace(/[,()]/g, ' ');
       query = query.or(`title.ilike.%${search}%,description.ilike.%${search}%`);
     }
 

--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -129,7 +129,7 @@ router.get('/job/:jobId', async (req, res) => {
 router.get('/brand/:brandId', async (req, res) => {
   try {
     const { brandId } = req.params;
-    const { status, impact, type, limit = 50, offset = 0, sort = 'score' } = req.query;
+    const { status, impact, type, q, limit = 50, offset = 0, sort = 'score' } = req.query;
 
     let query = supabaseAdmin
       .from('content_opportunities')
@@ -139,6 +139,11 @@ router.get('/brand/:brandId', async (req, res) => {
     if (status) query = query.eq('status', status);
     if (impact) query = query.eq('impact', impact);
     if (type) query = query.eq('type', type);
+
+    if (q) {
+      const search = String(q).replace(/([,()])/g, '\\$1');
+      query = query.or(`title.ilike.%${search}%,description.ilike.%${search}%`);
+    }
 
     if (sort === 'score') {
       query = query.order('opportunity_score', { ascending: false });

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -162,11 +162,15 @@ export default function ContentPage() {
 
   const [webhookOpen, setWebhookOpen] = useState(false);
   const pollRef = useRef(false);
+  const [debouncedSearch, setDebouncedSearch] = useState(search);
 
   // Server-side paging (#610) — the list can hold far more than one page's
   // worth of opportunities, so `total` (the exact server count) drives the
   // pager instead of the length of whatever page happens to be loaded.
-  const pager = usePagination(total, `${statusFilter}|${impactFilter}|${typeFilter}`);
+  const pager = usePagination(
+    total,
+    `${statusFilter}|${impactFilter}|${typeFilter}|${debouncedSearch}`,
+  );
 
   const loadData = useCallback(
     async (silent = false, isCancelled?: () => boolean) => {
@@ -184,6 +188,9 @@ export default function ContentPage() {
         if (statusFilter !== 'all') filters.status = statusFilter;
         if (impactFilter !== 'all') filters.impact = impactFilter;
         if (typeFilter !== 'all') filters.type = typeFilter;
+        if (debouncedSearch.trim()) {
+          filters.q = debouncedSearch.trim();
+        }
 
         const data = await getOpportunities(activeBrandId, {
           ...filters,
@@ -205,8 +212,16 @@ export default function ContentPage() {
         }
       }
     },
-    [activeBrandId, statusFilter, impactFilter, typeFilter, pager.start],
+    [activeBrandId, statusFilter, impactFilter, typeFilter, pager.start, debouncedSearch],
   );
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [search]);
 
   useEffect(() => {
     let cancelled = false;

--- a/web/src/lib/actions/content.ts
+++ b/web/src/lib/actions/content.ts
@@ -81,6 +81,7 @@ export async function getOpportunities(
   filters?: {
     status?: string;
     impact?: string;
+    q?: string;
     type?: string;
     limit?: number;
     offset?: number;
@@ -92,6 +93,7 @@ export async function getOpportunities(
   const params = new URLSearchParams();
   if (filters?.status) params.set('status', filters.status);
   if (filters?.impact) params.set('impact', filters.impact);
+  if (filters?.q) params.set('q', filters.q);
   if (filters?.type) params.set('type', filters.type);
   if (filters?.limit) params.set('limit', String(filters.limit));
   if (filters?.offset) params.set('offset', String(filters.offset));


### PR DESCRIPTION
## Summary

- Added server-side search for content opportunities using the `q` parameter.
- Search now matches opportunity titles and descriptions across all paginated results.
- Debounced the search input to avoid sending a request on every keystroke.
- Reset pagination when search or other filters change.
- Updated the pager to use the total returned for the current search/filter results, preventing contradictory pagination counts.

## Related issue

Closes #664 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR