### PR TITLE
fix(web): prevent stale responses from overwriting results

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -168,7 +168,7 @@ export default function ContentPage() {
   const pager = usePagination(total, `${statusFilter}|${impactFilter}|${typeFilter}`);
 
   const loadData = useCallback(
-    async (silent = false) => {
+    async (silent = false, isCancelled?: () => boolean) => {
       if (!activeBrandId) {
         setOpportunities([]);
         setTotal(0);
@@ -190,6 +190,7 @@ export default function ContentPage() {
           offset: pager.start,
           sort: 'score',
         });
+        if (isCancelled?.()) return;
         setOpportunities(data.opportunities);
         setTotal(data.total);
         return data.total;
@@ -198,14 +199,22 @@ export default function ContentPage() {
         toast.error('Failed to load content opportunities');
         return 0;
       } finally {
-        setLoading(false);
+        if (!isCancelled?.()) {
+          setLoading(false);
+        }
       }
     },
     [activeBrandId, statusFilter, impactFilter, typeFilter, pager.start],
   );
 
   useEffect(() => {
-    loadData();
+    let cancelled = false;
+
+    loadData(false, () => cancelled);
+
+    return () => {
+      cancelled = true;
+    };
   }, [loadData]);
 
   const pollJob = useCallback(


### PR DESCRIPTION
## Summary

Prevent stale content opportunity requests from overwriting the table when filters change rapidly.

The content data loader now uses an effect-scoped cancellation flag to ensure that only the latest request can update the opportunities and pagination state. Stale requests are also prevented from changing the loading state after they become outdated.

## Related issue

Closes #663 

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR