### PR TITLE
fix(db): add the missing cloro_pending_tasks migration

### DIFF
--- a/supabase/migrations/00049_cloro_pending_tasks.sql
+++ b/supabase/migrations/00049_cloro_pending_tasks.sql
@@ -1,0 +1,35 @@
+-- Cloro pending-task queue (#652) — backfills DDL that was only ever applied
+-- to the hosted database and never committed here, so a fresh install created
+-- every other table and then failed on this one:
+--
+--   PGRST205: Could not find the table 'public.cloro_pending_tasks'
+--
+-- The table is a transient submit-queue: the tracking worker inserts a row per
+-- task handed to the scraper, /cloro/callback deletes it when the result
+-- arrives, and cleanupStalePendingTasks sweeps whatever the provider never
+-- delivered. It holds no history — a fresh install starting empty is correct.
+--
+-- Guarded with IF NOT EXISTS throughout so databases that already have the
+-- table (every deployment predating this file) apply it as a no-op.
+
+CREATE TABLE IF NOT EXISTS public.cloro_pending_tasks (
+    task_id text PRIMARY KEY,
+    prompt_id uuid NOT NULL REFERENCES public.prompts(id) ON DELETE CASCADE,
+    brand_id uuid NOT NULL REFERENCES public.brands(id) ON DELETE CASCADE,
+    scraper_id text NOT NULL,
+    region text,
+    submitted_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- brand_id: the drain loop polls "what is still pending for this brand" on
+-- every tick of a run. submitted_at: the stale sweep and the ghost-task exit
+-- both filter by age (#687).
+CREATE INDEX IF NOT EXISTS idx_cloro_pending_tasks_brand_id
+    ON public.cloro_pending_tasks (brand_id);
+CREATE INDEX IF NOT EXISTS idx_cloro_pending_tasks_submitted_at
+    ON public.cloro_pending_tasks (submitted_at);
+
+-- RLS on with no policies: only the service role touches this table, and it
+-- bypasses RLS. Anything reaching it through an anon/authenticated key gets
+-- nothing, which is the intent — task ids are provider-side handles.
+ALTER TABLE public.cloro_pending_tasks ENABLE ROW LEVEL SECURITY;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5062,3 +5062,42 @@ CREATE TABLE public.dataforseo_competition_cache (
 
 ALTER TABLE public.dataforseo_competition_cache ENABLE ROW LEVEL SECURITY;
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00049_cloro_pending_tasks.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Cloro pending-task queue (#652) — backfills DDL that was only ever applied
+-- to the hosted database and never committed here, so a fresh install created
+-- every other table and then failed on this one:
+--
+--   PGRST205: Could not find the table 'public.cloro_pending_tasks'
+--
+-- The table is a transient submit-queue: the tracking worker inserts a row per
+-- task handed to the scraper, /cloro/callback deletes it when the result
+-- arrives, and cleanupStalePendingTasks sweeps whatever the provider never
+-- delivered. It holds no history — a fresh install starting empty is correct.
+--
+-- Guarded with IF NOT EXISTS throughout so databases that already have the
+-- table (every deployment predating this file) apply it as a no-op.
+
+CREATE TABLE IF NOT EXISTS public.cloro_pending_tasks (
+    task_id text PRIMARY KEY,
+    prompt_id uuid NOT NULL REFERENCES public.prompts(id) ON DELETE CASCADE,
+    brand_id uuid NOT NULL REFERENCES public.brands(id) ON DELETE CASCADE,
+    scraper_id text NOT NULL,
+    region text,
+    submitted_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- brand_id: the drain loop polls "what is still pending for this brand" on
+-- every tick of a run. submitted_at: the stale sweep and the ghost-task exit
+-- both filter by age (#687).
+CREATE INDEX IF NOT EXISTS idx_cloro_pending_tasks_brand_id
+    ON public.cloro_pending_tasks (brand_id);
+CREATE INDEX IF NOT EXISTS idx_cloro_pending_tasks_submitted_at
+    ON public.cloro_pending_tasks (submitted_at);
+
+-- RLS on with no policies: only the service role touches this table, and it
+-- bypasses RLS. Anything reaching it through an anon/authenticated key gets
+-- nothing, which is the intent — task ids are provider-side handles.
+ALTER TABLE public.cloro_pending_tasks ENABLE ROW LEVEL SECURITY;
+

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -346,6 +346,48 @@ export type Database = {
           },
         ];
       };
+      cloro_pending_tasks: {
+        Row: {
+          brand_id: string;
+          prompt_id: string;
+          region: string | null;
+          scraper_id: string;
+          submitted_at: string;
+          task_id: string;
+        };
+        Insert: {
+          brand_id: string;
+          prompt_id: string;
+          region?: string | null;
+          scraper_id: string;
+          submitted_at?: string;
+          task_id: string;
+        };
+        Update: {
+          brand_id?: string;
+          prompt_id?: string;
+          region?: string | null;
+          scraper_id?: string;
+          submitted_at?: string;
+          task_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'cloro_pending_tasks_brand_id_fkey';
+            columns: ['brand_id'];
+            isOneToOne: false;
+            referencedRelation: 'brands';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'cloro_pending_tasks_prompt_id_fkey';
+            columns: ['prompt_id'];
+            isOneToOne: false;
+            referencedRelation: 'prompts';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       competitors: {
         Row: {
           brand_id: string;


### PR DESCRIPTION
## Summary

`cloro_pending_tasks` is written and read by four server modules (`server.js`, `job-manager.js`, `pulse/engine.js`, `tracking-worker.js`) but had no DDL anywhere in the repo — not in `supabase/migrations/`, not in `schema.sql`, not in the web types. It only ever existed because it was applied directly to the hosted database.

The consequence is that **fresh self-host installs are broken**: every other table is created, this one is not, and the server logs

```
PGRST205: Could not find the table 'public.cloro_pending_tasks' in the schema cache
```

The startup error is swallowed, so the failure surfaces later and more confusingly — `/cloro/callback` cannot resolve pending tasks, so scraper results are never stored and tracking silently produces nothing.

## What's in here

- `supabase/migrations/00049_cloro_pending_tasks.sql` — transcribed from the live database: both foreign keys (`prompt_id`, `brand_id`, each `ON DELETE CASCADE`), both indexes (`brand_id` for the drain loop's per-brand poll, `submitted_at` for the stale sweep and the ghost-task exit added in #687), and RLS enabled with **no policies** — only the service role touches this table and it bypasses RLS, so anything arriving with an anon/authenticated key correctly gets nothing.
- Regenerated `supabase/schema.sql`.
- Added the table to `web/src/types/supabase.ts`, which was also missing it.

Every statement is guarded with `IF NOT EXISTS`, so deployments that already have the table apply this as a no-op.

## Related issue

Closes #652 — reported by @Adarshhic

## Type of change

- [x] `fix` — Bug fix

## How to test

Fresh install (the path this fixes):

```
supabase db reset
cd server && npm run dev
```

No `PGRST205` on startup, and a Cloro callback resolves its pending task instead of failing to find the row.

Existing database: applying the migration changes nothing — it is entirely `IF NOT EXISTS`.

## Verification done

- The migration has been applied to the hosted database (no-op as expected): the table, all three indexes and `rowsecurity = true` are unchanged, and the row that was pending at the time survived untouched. This keeps the migration history aligned with the repo rather than leaving the file unrecorded.
- `bash supabase/build-schema.sh` is deterministic against the committed `schema.sql` — re-running it produces no diff, so the CI schema check passes.
- `yarn typecheck` clean in `web/`.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes — no source files touched
- [x] `yarn typecheck` passes
- [x] `yarn format:check` passes — `src/types/supabase.ts` is Prettier-ignored as generated
- [x] Changes are focused — one concern per PR