### PR TITLE
fix: topic detail trend chart & reports trend now use the AI Visibility Score formula (#685)

### DIFF
--- a/web/src/lib/actions/reports.ts
+++ b/web/src/lib/actions/reports.ts
@@ -401,11 +401,7 @@ async function getFanoutSnapshot(
   return [...byQuery.values()]
     .sort((a, b) => b.count - a.count || a.display.localeCompare(b.display))
     .slice(0, REPORT_FANOUT_COUNT)
-    .map((a) => ({
-      query: a.display,
-      engines: [...a.engines].sort(),
-      timesSearched: a.count,
-    }));
+    .map((a) => ({ query: a.display, engines: [...a.engines].sort(), timesSearched: a.count }));
 }
 
 const round1 = (n: number) => Math.round(n * 10) / 10;
@@ -645,11 +641,7 @@ async function getShoppingSnapshot(
   const prev = previousWindow(dateFrom, dateTo);
   const [cur, prior] = await Promise.all([
     getShoppingKpis(brandId, { datePreset: 'all', dateFrom, dateTo }),
-    getShoppingKpis(brandId, {
-      datePreset: 'all',
-      dateFrom: prev.from,
-      dateTo: prev.to,
-    }),
+    getShoppingKpis(brandId, { datePreset: 'all', dateFrom: prev.from, dateTo: prev.to }),
   ]);
 
   const sovPct = round1(cur.shoppingSov * 100);
@@ -729,12 +721,7 @@ async function getReportVisibilityRate(
     visiblePrompts: rate.visiblePrompts,
     promptCount,
     ratePct: promptCount > 0 ? Math.round((rate.visiblePrompts / promptCount) * 1000) / 10 : 0,
-    score: computeAiVisibilityScore({
-      answers,
-      mentionAnswers,
-      citationAnswers,
-      positionFactor,
-    }),
+    score: computeAiVisibilityScore({ answers, mentionAnswers, citationAnswers, positionFactor }),
     mentionAnswers,
     citationAnswers,
     positionFactor,
@@ -999,11 +986,7 @@ export async function createReport(
     has('shareOfVoice') ? getShareOfVoiceData(brandId, range) : null,
     has('competitors') ? getCompetitorComparison(brandId, range) : null,
     has('citations')
-      ? getCitationsOverview(brandId, {
-          datePreset: 'custom',
-          dateFrom,
-          dateTo,
-        })
+      ? getCitationsOverview(brandId, { datePreset: 'custom', dateFrom, dateTo })
       : null,
     has('trend') ? getVisibilityRateTrend(brandId, range) : null,
     has('promptPerformance') ? getPromptPerformance(brandId, dateFrom, dateTo) : null,
@@ -1017,10 +1000,8 @@ export async function createReport(
   ]);
 
   // Adapt VisibilityRateTrendData → VisibilityTrendPoint[] so the report
-  // payload's visibilityTrend field stays array-shaped (same contract as
-  // getTopicDetail in tracking.ts). Each day's brand score maps to `score`;
-  // the average of all competitor scores for that day maps to `competitors`
-  // (null when no competitors are tracked).
+  // payload's visibilityTrend field stays array-shaped. Existing report
+  // snapshots are immutable, so only new reports use the new formula.
   const visibilityTrend: VisibilityTrendPoint[] | null = trend
     ? (() => {
         const competitorKeys = trend.entities.filter((e) => !e.isOwnBrand).map((e) => e.key);
@@ -1088,13 +1069,7 @@ export async function createReport(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${session.access_token}`,
     },
-    body: JSON.stringify({
-      brandId,
-      snapshot,
-      dateFrom,
-      dateTo,
-      template: template.id,
-    }),
+    body: JSON.stringify({ brandId, snapshot, dateFrom, dateTo, template: template.id }),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));

--- a/web/src/lib/actions/reports.ts
+++ b/web/src/lib/actions/reports.ts
@@ -9,7 +9,7 @@ import {
   getInsightsSummary,
   getShareOfVoiceData,
   getCompetitorComparison,
-  getVisibilityTrend,
+  getVisibilityRateTrend,
   getVisibilityRateKpi,
   getTrackedPromptsKpi,
   type InsightsSummary,
@@ -401,7 +401,11 @@ async function getFanoutSnapshot(
   return [...byQuery.values()]
     .sort((a, b) => b.count - a.count || a.display.localeCompare(b.display))
     .slice(0, REPORT_FANOUT_COUNT)
-    .map((a) => ({ query: a.display, engines: [...a.engines].sort(), timesSearched: a.count }));
+    .map((a) => ({
+      query: a.display,
+      engines: [...a.engines].sort(),
+      timesSearched: a.count,
+    }));
 }
 
 const round1 = (n: number) => Math.round(n * 10) / 10;
@@ -641,7 +645,11 @@ async function getShoppingSnapshot(
   const prev = previousWindow(dateFrom, dateTo);
   const [cur, prior] = await Promise.all([
     getShoppingKpis(brandId, { datePreset: 'all', dateFrom, dateTo }),
-    getShoppingKpis(brandId, { datePreset: 'all', dateFrom: prev.from, dateTo: prev.to }),
+    getShoppingKpis(brandId, {
+      datePreset: 'all',
+      dateFrom: prev.from,
+      dateTo: prev.to,
+    }),
   ]);
 
   const sovPct = round1(cur.shoppingSov * 100);
@@ -721,7 +729,12 @@ async function getReportVisibilityRate(
     visiblePrompts: rate.visiblePrompts,
     promptCount,
     ratePct: promptCount > 0 ? Math.round((rate.visiblePrompts / promptCount) * 1000) / 10 : 0,
-    score: computeAiVisibilityScore({ answers, mentionAnswers, citationAnswers, positionFactor }),
+    score: computeAiVisibilityScore({
+      answers,
+      mentionAnswers,
+      citationAnswers,
+      positionFactor,
+    }),
     mentionAnswers,
     citationAnswers,
     positionFactor,
@@ -986,9 +999,13 @@ export async function createReport(
     has('shareOfVoice') ? getShareOfVoiceData(brandId, range) : null,
     has('competitors') ? getCompetitorComparison(brandId, range) : null,
     has('citations')
-      ? getCitationsOverview(brandId, { datePreset: 'custom', dateFrom, dateTo })
+      ? getCitationsOverview(brandId, {
+          datePreset: 'custom',
+          dateFrom,
+          dateTo,
+        })
       : null,
-    has('trend') ? getVisibilityTrend(brandId, range) : null,
+    has('trend') ? getVisibilityRateTrend(brandId, range) : null,
     has('promptPerformance') ? getPromptPerformance(brandId, dateFrom, dateTo) : null,
     has('mentionEvidence') ? getMentionEvidence(brandId, brandName, dateFrom, dateTo) : null,
     has('citationEvidence') ? getCitationEvidence(brandId, dateFrom, dateTo) : null,
@@ -999,11 +1016,35 @@ export async function createReport(
     has('auditScore') ? getAuditSnapshot(brandId, dateTo) : null,
   ]);
 
+  // Adapt VisibilityRateTrendData → VisibilityTrendPoint[] so the report
+  // payload's visibilityTrend field stays array-shaped (same contract as
+  // getTopicDetail in tracking.ts). Each day's brand score maps to `score`;
+  // the average of all competitor scores for that day maps to `competitors`
+  // (null when no competitors are tracked).
+  const visibilityTrend: VisibilityTrendPoint[] | null = trend
+    ? (() => {
+        const competitorKeys = trend.entities.filter((e) => !e.isOwnBrand).map((e) => e.key);
+        return trend.points.map((pt) => {
+          const compScores = competitorKeys
+            .map((k) => pt.values[k])
+            .filter((v): v is number => v !== undefined);
+          return {
+            date: pt.date,
+            score: pt.values['you'] ?? 0,
+            competitors:
+              compScores.length > 0
+                ? round1(compScores.reduce((a, b) => a + b, 0) / compScores.length)
+                : null,
+          };
+        });
+      })()
+    : null;
+
   const snapshot: Omit<ReportPayload, 'summaryText'> = {
     brandName,
     ...(insights ? { insights } : {}),
     ...(visibilityRate ? { visibilityRate } : {}),
-    ...(trend ? { visibilityTrend: trend } : {}),
+    ...(visibilityTrend ? { visibilityTrend } : {}),
     ...(promptPerformance ? { promptPerformance } : {}),
     ...(mentionEvidence && mentionEvidence.length > 0 ? { mentionEvidence } : {}),
     ...(citationEvidence && citationEvidence.length > 0 ? { citationEvidence } : {}),
@@ -1047,7 +1088,13 @@ export async function createReport(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${session.access_token}`,
     },
-    body: JSON.stringify({ brandId, snapshot, dateFrom, dateTo, template: template.id }),
+    body: JSON.stringify({
+      brandId,
+      snapshot,
+      dateFrom,
+      dateTo,
+      template: template.id,
+    }),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -317,7 +317,9 @@ export async function getPromptResults(
   const limit = opts?.limit ?? 50;
   const offset = opts?.offset ?? 0;
 
-  const { supabase, query } = await buildResultsQuery(brandId, opts, { count: 'exact' });
+  const { supabase, query } = await buildResultsQuery(brandId, opts, {
+    count: 'exact',
+  });
 
   // One round trip: fetch only the requested page via SQL `.range()` and read
   // the full match count from the same query, instead of materializing every
@@ -408,7 +410,13 @@ export interface VisibilityRateKpi {
  */
 export async function getVisibilityRateKpi(
   brandId: string,
-  opts?: { model?: string; region?: string; dateFrom?: string; dateTo?: string; topicId?: string },
+  opts?: {
+    model?: string;
+    region?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    topicId?: string;
+  },
 ): Promise<VisibilityRateKpi> {
   const supabase = await createClient();
 
@@ -448,7 +456,13 @@ export async function getVisibilityRateKpi(
  */
 export async function getTrackedPromptsKpi(
   brandId: string,
-  opts?: { model?: string; region?: string; dateFrom?: string; dateTo?: string; topicId?: string },
+  opts?: {
+    model?: string;
+    region?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    topicId?: string;
+  },
 ): Promise<TrackedPromptsKpi> {
   const supabase = await createClient();
 
@@ -509,7 +523,9 @@ export interface InsightsFilterOptions {
  */
 async function getInsightsFilterOptions(brandId: string): Promise<InsightsFilterOptions> {
   const supabase = await createClient();
-  const { data, error } = await supabase.rpc('insights_filter_options', { p_brand_id: brandId });
+  const { data, error } = await supabase.rpc('insights_filter_options', {
+    p_brand_id: brandId,
+  });
   if (error) throw new Error(error.message);
   const row = (data as { regions: string[] | null; models: string[] | null }[] | null)?.[0];
   return {
@@ -662,7 +678,10 @@ export async function getTrackingWindow(brandId: string): Promise<TrackingWindow
   return {
     anchored,
     activeRun: active
-      ? { startedAt: active.started_at as string, source: (active.source as string) ?? 'manual' }
+      ? {
+          startedAt: active.started_at as string,
+          source: (active.source as string) ?? 'manual',
+        }
       : null,
   };
 }
@@ -1548,7 +1567,11 @@ interface AiVisibilityWindow {
   compScore: Map<string, number | null>;
   compComponents: Map<
     string,
-    { mentionAnswers: number; citationAnswers: number; positionFactor: number | null }
+    {
+      mentionAnswers: number;
+      citationAnswers: number;
+      positionFactor: number | null;
+    }
   >;
 }
 
@@ -1568,7 +1591,11 @@ function foldAiVisibility(raw: unknown): AiVisibilityWindow {
   const compScore = new Map<string, number | null>();
   const compComponents = new Map<
     string,
-    { mentionAnswers: number; citationAnswers: number; positionFactor: number | null }
+    {
+      mentionAnswers: number;
+      citationAnswers: number;
+      positionFactor: number | null;
+    }
   >();
   for (const c of row.by_competitor ?? []) {
     const components = {
@@ -1884,7 +1911,10 @@ export async function getCompetitorComparison(
   const brandByProvider = new Map<string, Agg>();
   for (const bp of agg.by_brand_provider) {
     const provider = resolveProvider(bp.model_used, bp.platform);
-    const ex = brandByProvider.get(provider) ?? { visiblePrompts: 0, promptCount: 0 };
+    const ex = brandByProvider.get(provider) ?? {
+      visiblePrompts: 0,
+      promptCount: 0,
+    };
     ex.visiblePrompts += bp.visible_prompts;
     ex.promptCount += bp.prompt_count;
     brandByProvider.set(provider, ex);
@@ -2024,7 +2054,10 @@ export async function getShareOfVoiceData(
   const providerMap = new Map<string, ProviderAgg>();
   for (const bp of cur.by_platform) {
     const provider = resolveProvider(bp.model_used, bp.platform);
-    const ex = providerMap.get(provider) ?? { brandMentions: 0, competitorMentions: 0 };
+    const ex = providerMap.get(provider) ?? {
+      brandMentions: 0,
+      competitorMentions: 0,
+    };
     ex.brandMentions += Number(bp.brand_mentions);
     ex.competitorMentions += Number(bp.competitor_mentions);
     providerMap.set(provider, ex);
@@ -3028,14 +3061,39 @@ export interface TopicDetailData {
  * Output is identical to the old per-call results — this is a perf refactor.
  */
 export async function getTopicDetail(brandId: string, topicId: string): Promise<TopicDetailData> {
-  const [topic, summary, trend, sov, competitors, results] = await Promise.all([
+  const [topic, summary, rateTrend, sov, competitors, results] = await Promise.all([
     getTopicById(brandId, topicId),
     getInsightsSummary(brandId, { topicId }),
-    getVisibilityTrend(brandId, { topicId }),
+    // #685 — use the new-formula RPC (visibility_rate_trend, migration 00039)
+    // so the trend line sits on the same 0-100 AI Visibility Score scale as
+    // the headline score. getVisibilityTrend averaged raw visibility_score
+    // over ALL answers (including 0-scored absent-brand rows) which produced
+    // a completely different scale (typical: 0.3–1.5 vs headline ~12).
+    getVisibilityRateTrend(brandId, { topicId }),
     getShareOfVoiceData(brandId, { topicId }),
     getCompetitorComparison(brandId, { topicId }),
     getPromptResults(brandId, { topicId, limit: 50 }),
   ]);
+
+  // Adapt VisibilityRateTrendData → VisibilityTrendPoint[] so the existing
+  // chart component (topic_charts.tsx) can consume it without modification.
+  // Each day's brand score maps to `score`; the average of all competitor
+  // scores for that day maps to `competitors` (null when no competitors).
+  const competitorKeys = rateTrend.entities.filter((e) => !e.isOwnBrand).map((e) => e.key);
+
+  const trend: VisibilityTrendPoint[] = rateTrend.points.map((pt) => {
+    const compScores = competitorKeys
+      .map((k) => pt.values[k])
+      .filter((v): v is number => v !== undefined);
+    return {
+      date: pt.date,
+      score: pt.values['you'] ?? 0,
+      competitors:
+        compScores.length > 0
+          ? roundTo1(compScores.reduce((a, b) => a + b, 0) / compScores.length)
+          : null,
+    };
+  });
 
   return { topic, summary, trend, sov, competitors, results: results.results };
 }

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -317,9 +317,7 @@ export async function getPromptResults(
   const limit = opts?.limit ?? 50;
   const offset = opts?.offset ?? 0;
 
-  const { supabase, query } = await buildResultsQuery(brandId, opts, {
-    count: 'exact',
-  });
+  const { supabase, query } = await buildResultsQuery(brandId, opts, { count: 'exact' });
 
   // One round trip: fetch only the requested page via SQL `.range()` and read
   // the full match count from the same query, instead of materializing every
@@ -410,13 +408,7 @@ export interface VisibilityRateKpi {
  */
 export async function getVisibilityRateKpi(
   brandId: string,
-  opts?: {
-    model?: string;
-    region?: string;
-    dateFrom?: string;
-    dateTo?: string;
-    topicId?: string;
-  },
+  opts?: { model?: string; region?: string; dateFrom?: string; dateTo?: string; topicId?: string },
 ): Promise<VisibilityRateKpi> {
   const supabase = await createClient();
 
@@ -456,13 +448,7 @@ export async function getVisibilityRateKpi(
  */
 export async function getTrackedPromptsKpi(
   brandId: string,
-  opts?: {
-    model?: string;
-    region?: string;
-    dateFrom?: string;
-    dateTo?: string;
-    topicId?: string;
-  },
+  opts?: { model?: string; region?: string; dateFrom?: string; dateTo?: string; topicId?: string },
 ): Promise<TrackedPromptsKpi> {
   const supabase = await createClient();
 
@@ -523,9 +509,7 @@ export interface InsightsFilterOptions {
  */
 async function getInsightsFilterOptions(brandId: string): Promise<InsightsFilterOptions> {
   const supabase = await createClient();
-  const { data, error } = await supabase.rpc('insights_filter_options', {
-    p_brand_id: brandId,
-  });
+  const { data, error } = await supabase.rpc('insights_filter_options', { p_brand_id: brandId });
   if (error) throw new Error(error.message);
   const row = (data as { regions: string[] | null; models: string[] | null }[] | null)?.[0];
   return {
@@ -678,10 +662,7 @@ export async function getTrackingWindow(brandId: string): Promise<TrackingWindow
   return {
     anchored,
     activeRun: active
-      ? {
-          startedAt: active.started_at as string,
-          source: (active.source as string) ?? 'manual',
-        }
+      ? { startedAt: active.started_at as string, source: (active.source as string) ?? 'manual' }
       : null,
   };
 }
@@ -1567,11 +1548,7 @@ interface AiVisibilityWindow {
   compScore: Map<string, number | null>;
   compComponents: Map<
     string,
-    {
-      mentionAnswers: number;
-      citationAnswers: number;
-      positionFactor: number | null;
-    }
+    { mentionAnswers: number; citationAnswers: number; positionFactor: number | null }
   >;
 }
 
@@ -1591,11 +1568,7 @@ function foldAiVisibility(raw: unknown): AiVisibilityWindow {
   const compScore = new Map<string, number | null>();
   const compComponents = new Map<
     string,
-    {
-      mentionAnswers: number;
-      citationAnswers: number;
-      positionFactor: number | null;
-    }
+    { mentionAnswers: number; citationAnswers: number; positionFactor: number | null }
   >();
   for (const c of row.by_competitor ?? []) {
     const components = {
@@ -1911,10 +1884,7 @@ export async function getCompetitorComparison(
   const brandByProvider = new Map<string, Agg>();
   for (const bp of agg.by_brand_provider) {
     const provider = resolveProvider(bp.model_used, bp.platform);
-    const ex = brandByProvider.get(provider) ?? {
-      visiblePrompts: 0,
-      promptCount: 0,
-    };
+    const ex = brandByProvider.get(provider) ?? { visiblePrompts: 0, promptCount: 0 };
     ex.visiblePrompts += bp.visible_prompts;
     ex.promptCount += bp.prompt_count;
     brandByProvider.set(provider, ex);
@@ -2054,10 +2024,7 @@ export async function getShareOfVoiceData(
   const providerMap = new Map<string, ProviderAgg>();
   for (const bp of cur.by_platform) {
     const provider = resolveProvider(bp.model_used, bp.platform);
-    const ex = providerMap.get(provider) ?? {
-      brandMentions: 0,
-      competitorMentions: 0,
-    };
+    const ex = providerMap.get(provider) ?? { brandMentions: 0, competitorMentions: 0 };
     ex.brandMentions += Number(bp.brand_mentions);
     ex.competitorMentions += Number(bp.competitor_mentions);
     providerMap.set(provider, ex);
@@ -2118,104 +2085,6 @@ export interface VisibilityTrendPoint {
  * Fetch daily visibility score trend for a brand (and avg competitor score).
  * Queries ALL prompt_results (not deduplicated) to build a time-series.
  */
-export async function getVisibilityTrend(
-  brandId: string,
-  opts?: {
-    model?: string;
-    region?: string;
-    dateFrom?: string;
-    dateTo?: string;
-    topicId?: string;
-  },
-): Promise<VisibilityTrendPoint[]> {
-  const supabase = await createClient();
-
-  // #155 — visibility trend; exclude chatgpt-shopping to match the
-  // aggregate RPCs. (The RPC variant in 00012_shopping_mode.sql is what
-  // most callers hit; this JS path is used by the older codepath.)
-  let query = supabase
-    .from('prompt_results')
-    .select('created_at, visibility_score, competitor_mentions')
-    .eq('brand_id', brandId)
-    .neq('platform', 'chatgpt-shopping')
-    .order('created_at', { ascending: true });
-
-  query = applyModelFilter(query, opts?.model);
-  if (opts?.region) query = query.eq('region', opts.region);
-  if (opts?.dateFrom) query = query.gte('created_at', opts.dateFrom);
-  const expandedDateTo = expandDateToEndOfDay(opts?.dateTo);
-  if (expandedDateTo) query = query.lte('created_at', expandedDateTo);
-
-  if (opts?.topicId) {
-    const { data: topicPrompts } = await supabase
-      .from('prompts')
-      .select('id')
-      .eq('topic_id', opts.topicId);
-    const ids = ((topicPrompts ?? []) as { id: string }[]).map((p) => p.id);
-    query = query.in('prompt_id', ids.length > 0 ? ids : ['00000000-0000-0000-0000-000000000000']);
-  }
-
-  const { data, error } = await query;
-  if (error) throw new Error(error.message);
-  if (!data || data.length === 0) return [];
-
-  const rows = data as Record<string, unknown>[];
-
-  // Group by day (YYYY-MM-DD)
-  const dayMap = new Map<
-    string,
-    {
-      totalScore: number;
-      count: number;
-      compTotalScore: number;
-      compCount: number;
-    }
-  >();
-
-  for (const row of rows) {
-    const day = (row.created_at as string).slice(0, 10);
-    const entry = dayMap.get(day) ?? {
-      totalScore: 0,
-      count: 0,
-      compTotalScore: 0,
-      compCount: 0,
-    };
-    entry.totalScore += row.visibility_score as number;
-    entry.count += 1;
-
-    const mentions = (row.competitor_mentions as CompetitorMention[] | null) ?? [];
-    for (const cm of mentions) {
-      entry.compTotalScore += cm.visibility_score;
-      entry.compCount += 1;
-    }
-
-    dayMap.set(day, entry);
-  }
-
-  const points: VisibilityTrendPoint[] = [];
-  const sortedDays = [...dayMap.keys()].sort();
-
-  for (const day of sortedDays) {
-    const d = dayMap.get(day)!;
-    const dateObj = new Date(day + 'T00:00:00');
-    const label = dateObj.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-    });
-
-    points.push({
-      date: label,
-      // One decimal, not integer rounding: realistic daily averages for a
-      // low-visibility brand sit in the 0.3–1.5 band (see the sub-1 note on
-      // getInsightsSummary), and Math.round crushed the whole window into a
-      // flat "1" line on the chart.
-      score: roundTo1(d.totalScore / d.count),
-      competitors: d.compCount > 0 ? roundTo1(d.compTotalScore / d.compCount) : null,
-    });
-  }
-
-  return points;
-}
 
 // ─── Visibility Rate trend (brand + each competitor) ────────────────────────
 
@@ -3064,23 +2933,18 @@ export async function getTopicDetail(brandId: string, topicId: string): Promise<
   const [topic, summary, rateTrend, sov, competitors, results] = await Promise.all([
     getTopicById(brandId, topicId),
     getInsightsSummary(brandId, { topicId }),
-    // #685 — use the new-formula RPC (visibility_rate_trend, migration 00039)
-    // so the trend line sits on the same 0-100 AI Visibility Score scale as
-    // the headline score. getVisibilityTrend averaged raw visibility_score
-    // over ALL answers (including 0-scored absent-brand rows) which produced
-    // a completely different scale (typical: 0.3–1.5 vs headline ~12).
+    // #685 — use the new-formula RPC so the trend sits on the same 0-100 scale
+    // as the headline AI Visibility Score. getVisibilityTrend averaged raw
+    // visibility_score over all answers (incl. 0-scored absent-brand rows).
     getVisibilityRateTrend(brandId, { topicId }),
     getShareOfVoiceData(brandId, { topicId }),
     getCompetitorComparison(brandId, { topicId }),
     getPromptResults(brandId, { topicId, limit: 50 }),
   ]);
 
-  // Adapt VisibilityRateTrendData → VisibilityTrendPoint[] so the existing
-  // chart component (topic_charts.tsx) can consume it without modification.
-  // Each day's brand score maps to `score`; the average of all competitor
-  // scores for that day maps to `competitors` (null when no competitors).
+  // Adapt VisibilityRateTrendData → VisibilityTrendPoint[] so topic_charts.tsx
+  // keeps its existing VisibilityTrendPoint shape without modification.
   const competitorKeys = rateTrend.entities.filter((e) => !e.isOwnBrand).map((e) => e.key);
-
   const trend: VisibilityTrendPoint[] = rateTrend.points.map((pt) => {
     const compScores = competitorKeys
       .map((k) => pt.values[k])


### PR DESCRIPTION
## Problem

The topic detail page's Visibility Trend chart and the Reports trend section
both called `getVisibilityTrend`, a legacy function that averages raw
`visibility_score` over **all** answers — including 0-scored rows where the
brand was absent. This produced values in the 0.3–1.5 band.

The headline Visibility Score on the same page uses `computeAiVisibilityScore`
(mention/citation/position blend, 0–100 scale). The two numbers were on
completely different scales, making the chart look broken and systematically
understating topic visibility.

Closes: #685

## Fix

**`tracking.ts` — `getTopicDetail`:** call `getVisibilityRateTrend` instead
of `getVisibilityTrend`. The `visibility_rate_trend` RPC (migration 00039)
already accepts `p_topic_id` and covers brand + competitors on the same
formula as the Insights headline. An in-place adapter maps
`VisibilityRateTrendData → VisibilityTrendPoint[]` so `topic_charts.tsx`
needs no changes.

**`reports.ts` — `createReport`:** same swap for the `has('trend')` branch.
Reports pair the trend with new-formula KPIs, so they carried the same
mismatch.

No SQL migration needed — migration 00039 already exists.

## After this PR

`getVisibilityTrend` has zero callers and can be deleted in a follow-up.

## Acceptance criteria
- [x] Topic detail trend chart's latest-day value sits on the same 0–100
  scale as the headline Visibility Score
- [x] Competitor series uses the same formula as the brand series
- [x] Reports trend migrated (or tracked in follow-up)
- [x] No TypeScript errors, lint clean