### PR TITLE
fix(citations): don't toast a load failure after leaving the page

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -875,11 +875,19 @@ export default function CitationsPage() {
       .catch(() => {});
   }, [activeBrandId]);
 
+  // Each load claims a generation. The effect's cleanup bumps the counter, so
+  // a response arriving after the filters changed — or after the user left the
+  // page — can recognise itself as stale instead of writing state or toasting.
+  const loadGen = useRef(0);
+
   const loadData = useCallback(async () => {
     if (!activeBrandId) {
       setIsLoading(false);
       return;
     }
+    const gen = ++loadGen.current;
+    const stale = () => loadGen.current !== gen;
+
     setIsLoading(true);
     setLoadFailed(false);
     try {
@@ -887,6 +895,7 @@ export default function CitationsPage() {
         getCitationsOverview(activeBrandId, apiFilters),
         getCitationsTotal(activeBrandId),
       ]);
+      if (stale()) return;
       setData(overview);
       setHasAnyCitations(total > 0);
 
@@ -907,16 +916,31 @@ export default function CitationsPage() {
         );
       }
     } catch (err) {
+      // Leaving the page aborts the in-flight request. That rejection is not a
+      // failure worth reporting — and the toast is global, so it would surface
+      // on whichever page the user navigated to.
+      if (stale()) return;
       console.error('[citations] load failed', err);
       setLoadFailed(true);
       toast.error('Failed to load citation data');
     } finally {
-      setIsLoading(false);
+      if (!stale()) setIsLoading(false);
     }
   }, [activeBrandId, apiFilters]);
 
   useEffect(() => {
     loadData();
+    // Invalidate whatever is in flight when the filters change or the page
+    // unmounts, so a slow earlier response can't overwrite newer data.
+    //
+    // The exhaustive-deps warning about reading a ref in cleanup doesn't apply
+    // here: this ref is a counter, not a node, and a value that moved on since
+    // the effect ran is exactly what we want to invalidate — incrementing is
+    // correct whether the last load came from this effect or from a Retry.
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      loadGen.current++;
+    };
   }, [loadData]);
 
   // Lazy-load Competitor Gaps only when its tab is active; re-fetch when the


### PR DESCRIPTION
## Summary

Leaving the Citations page mid-load aborted the request, and the `catch` treated that rejection as a real failure — setting the failed state and firing a **global** toast, which then appeared on whatever page the user had navigated to. The effect also had no cleanup, so a slow response could write state after unmount or overwrite newer data after a rapid filter change.

Each load now claims a generation. The effect's cleanup increments the counter, so a response landing after the filters changed — or after the user left — recognises itself as stale and skips the state writes, the `console.error` and the toast. A genuine failure with the page still open behaves exactly as before.

**Why a generation counter rather than a `cancelled` flag:** `loadData` is also passed directly as `onRetry` / `onAdded` to child components, so its signature has to stay parameterless — the counter keeps the callers untouched and additionally covers the Retry-then-navigate case. Same shape as `genRef` in the audit detail page.

## Related issue

Closes #684

## Type of change

- [x] `fix` — Bug fix

## How to test

Reproduced and verified in the browser against a local instance:

1. Open **Citations** and navigate away (Prompts, Topics) before it finishes loading — the overview scan takes seconds, so this is easy to hit.
2. Before: "Failed to load citation data" appeared on the destination page. After: no toast, and no `[citations] load failed` entry in the console.
3. With the page open, a real failure still shows the error state and the toast.

## Note on the lint directive

The cleanup carries an `eslint-disable-next-line react-hooks/exhaustive-deps`. The rule warns about reading a ref in cleanup because it assumes the ref points at a rendered node; here it is a counter, and a value that moved on since the effect ran is precisely what we want to invalidate. Without the directive this file gains a warning it didn't have before, so the suppression is scoped to the single line and explained in a comment above it.

## Coordination

#656 (@tomatotomata) reworks the same `loadData` for the refetch-loading state. If that lands first I'll rebase; if this lands first, the cancellation guard is already in place and should make that change smaller.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes — no new warnings in this file
- [x] `yarn typecheck` passes
- [x] `yarn format:check` passes
- [x] Changes are focused — one concern per PR