### PR TITLE
feat(prompts): add a 7d / 30d / 90d range selector

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/_fanout-tab.tsx
@@ -11,6 +11,7 @@ import {
   type FanoutSubQuery,
 } from '@/lib/actions/fanout';
 import { INTENT_LABELS, INTENT_COLORS } from '@/config/intent-labels';
+import type { PromptRangeDays } from '@/config/prompt-options';
 import { PlatformsCell } from '@/components/citations/source-cells';
 import { cn } from '@/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -42,6 +43,8 @@ interface PromptGroup {
 
 type QueryFanoutTabProps = {
   brandId: string;
+  /** Window shared with the rest of the Prompts page (#686). */
+  days: PromptRangeDays;
   onTracked?: () => void | Promise<void>;
 };
 
@@ -73,7 +76,7 @@ function userErrorMessage(err: unknown, fallback: string): string {
   return fallback;
 }
 
-export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
+export function QueryFanoutTab({ brandId, days, onTracked }: QueryFanoutTabProps) {
   const [data, setData] = useState<QueryFanoutData | null>(null);
   const [loading, setLoading] = useState(true);
   const [addingKey, setAddingKey] = useState<string | null>(null);
@@ -140,7 +143,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
         setLoading(true);
       }
       try {
-        const result = await getQueryFanout(brandId, { days: 30 });
+        const result = await getQueryFanout(brandId, { days });
         setData(result);
         void classifyProgressively(result.subQueries.map((s) => s.query));
       } catch (err) {
@@ -153,7 +156,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
         }
       }
     },
-    [brandId, classifyProgressively],
+    [brandId, days, classifyProgressively],
   );
 
   useEffect(() => {
@@ -166,7 +169,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
 
   useEffect(() => {
     setSearchText('');
-  }, [brandId]);
+  }, [brandId, days]);
 
   useEffect(() => {
     setSearchText('');
@@ -297,7 +300,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
         <p className="text-xs text-muted-foreground">
           {view === 'by-prompt'
             ? 'Your tracked prompts grouped by the sub-queries their answers actually triggered — expand a prompt to see its observed fan-out. "Answers with fan-out" is how many of that prompt’s tracked answers ran a live search at all.'
-            : 'The sub-queries answer engines actually ran while building your answers (last 30 days) — observed, never predicted. Sorted by how often they were searched. Track any of them with the + to measure its own visibility.'}
+            : `The sub-queries answer engines actually ran while building your answers (last ${days} days) — observed, never predicted. Sorted by how often they were searched. Track any of them with the + to measure its own visibility.`}
         </p>
       </CardHeader>
       <CardContent>
@@ -325,6 +328,7 @@ export function QueryFanoutTab({ brandId, onTracked }: QueryFanoutTabProps) {
             intents={intents}
             addingKey={addingKey}
             pager={byPromptPager}
+            days={days}
             onTrack={handleTrack}
             searchText={searchText}
             onSearchChange={setSearchText}
@@ -477,6 +481,7 @@ function ByPromptView({
   intents,
   addingKey,
   pager,
+  days,
   onTrack,
   searchText,
   onSearchChange,
@@ -485,6 +490,7 @@ function ByPromptView({
   intents: Record<string, string>;
   addingKey: string | null;
   pager: ReturnType<typeof usePagination>;
+  days: PromptRangeDays;
   onTrack: (query: string) => void;
   searchText: string;
   onSearchChange: (text: string) => void;
@@ -512,7 +518,7 @@ function ByPromptView({
         searchText ? (
           <NoMatches label="No prompts match your search" />
         ) : (
-          <NoMatches label="No tracked answers in the last 30 days" />
+          <NoMatches label={`No tracked answers in the last ${days} days`} />
         )
       ) : (
         <>

--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -76,7 +76,16 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { useUserRole } from '@/hooks/use-user-role';
 import { usePlanContext } from '@/components/providers/plan-provider';
-import { MODEL_GROUPS, ALL_MODELS, SCRAPER_GROUPS, ALL_SCRAPERS } from '@/config/prompt-options';
+import {
+  MODEL_GROUPS,
+  ALL_MODELS,
+  SCRAPER_GROUPS,
+  ALL_SCRAPERS,
+  PROMPT_RANGE_DAYS,
+  DEFAULT_PROMPT_RANGE_DAYS,
+  isPromptRangeDays,
+  type PromptRangeDays,
+} from '@/config/prompt-options';
 import { PLANS } from '@/config/plans';
 import { getTopics } from '@/lib/actions/topic';
 import { type PromptVisibilitySummary } from '@/lib/actions/tracking';
@@ -211,7 +220,13 @@ function SortableHead({
   );
 }
 
-const PROMPT_EXPORT_HEADERS = [
+/**
+ * CSV headers. The window-scoped columns carry the selected range in their
+ * name (`runs_7d`, `runs_90d`, …) rather than a hardcoded `_30d`, so an export
+ * taken at a different range can't be misread as 30-day data. At the default
+ * range the header row is byte-identical to what it has always been.
+ */
+const promptExportHeaders = (days: number) => [
   'text',
   'topic_id',
   'category',
@@ -223,13 +238,13 @@ const PROMPT_EXPORT_HEADERS = [
   'est_ai_volume',
   'total_google_volume',
   'intent',
-  'ai_visibility_score_30d',
-  'visibility_rate_30d',
-  'visible_runs_30d',
-  'avg_visibility_30d',
-  'total_mentions_30d',
-  'total_citations_30d',
-  'runs_30d',
+  `ai_visibility_score_${days}d`,
+  `visibility_rate_${days}d`,
+  `visible_runs_${days}d`,
+  `avg_visibility_${days}d`,
+  `total_mentions_${days}d`,
+  `total_citations_${days}d`,
+  `runs_${days}d`,
   'last_run_at',
 ];
 
@@ -905,6 +920,12 @@ export default function PromptsPage() {
   })();
   const [tab, setTab] = useState<TabId>(initialTab);
 
+  const initialRange: PromptRangeDays = (() => {
+    const raw = searchParams.get('range');
+    return isPromptRangeDays(raw) ? (Number(raw) as PromptRangeDays) : DEFAULT_PROMPT_RANGE_DAYS;
+  })();
+  const [rangeDays, setRangeDays] = useState<PromptRangeDays>(initialRange);
+
   // Keep the URL in sync with the active tab so deep links / refreshes land
   // back on the same view. Shallow history update on purpose: the tab is pure
   // client state, and `router.replace` here fired an RSC round-trip whose
@@ -913,14 +934,20 @@ export default function PromptsPage() {
   // dispatched (the "prompts table spins forever" bug). replaceState updates
   // the URL with no server request; Next's router syncs with the History API.
   useEffect(() => {
-    const current = searchParams.get('tab');
-    if (current === tab) return;
+    const currentTab = searchParams.get('tab');
+    const currentRange = searchParams.get('range');
+    // The default range stays out of the URL so shared links keep their
+    // existing shape unless the user actually picked a different window.
+    const wantRange = rangeDays === DEFAULT_PROMPT_RANGE_DAYS ? null : String(rangeDays);
+    if (currentTab === tab && currentRange === wantRange) return;
     const params = new URLSearchParams(Array.from(searchParams.entries()));
     params.set('tab', tab);
+    if (wantRange) params.set('range', wantRange);
+    else params.delete('range');
     // Keep the hash: deep links like #prompt-opportunities arrive without a
     // tab param, and this sync must not strip their anchor from the URL.
     window.history.replaceState(null, '', `?${params.toString()}${window.location.hash}`);
-  }, [tab, searchParams]);
+  }, [tab, rangeDays, searchParams]);
 
   // Deep link from the Insights Recommendations row (#459): the target card
   // only exists once the Insights tab's volume data has rendered, so a bare
@@ -948,7 +975,7 @@ export default function PromptsPage() {
         // One consolidated server action: Next.js queues client-fired server
         // actions sequentially, so the old three separate calls cost their
         // SUM on a cold load — the main culprit behind the slow first paint.
-        const page = await getPromptsPageData(activeBrandId);
+        const page = await getPromptsPageData(activeBrandId, { days: rangeDays });
         if (isCancelled?.()) return;
         setVolumes(page.volumes);
         if (page.quota) setQuota(page.quota);
@@ -966,7 +993,7 @@ export default function PromptsPage() {
         if (!isCancelled?.()) setLoading(false);
       }
     },
-    [activeBrandId],
+    [activeBrandId, rangeDays],
   );
 
   useEffect(() => {
@@ -1130,17 +1157,17 @@ export default function PromptsPage() {
       est_ai_volume: volumeByPromptId.get(p.id)?.estAiVolume ?? '',
       total_google_volume: volumeByPromptId.get(p.id)?.totalGoogleVolume ?? '',
       intent: volumeByPromptId.get(p.id)?.intent ?? '',
-      ai_visibility_score_30d: visibility[p.id]?.score ?? '',
-      visibility_rate_30d: visibility[p.id]?.visibilityRate ?? '',
-      visible_runs_30d: visibility[p.id]?.visibleRuns ?? '',
-      avg_visibility_30d: visibility[p.id]?.avgVisibility ?? '',
-      total_mentions_30d: visibility[p.id]?.totalMentions ?? '',
-      total_citations_30d: visibility[p.id]?.totalCitations ?? '',
-      runs_30d: visibility[p.id]?.runs ?? '',
+      [`ai_visibility_score_${rangeDays}d`]: visibility[p.id]?.score ?? '',
+      [`visibility_rate_${rangeDays}d`]: visibility[p.id]?.visibilityRate ?? '',
+      [`visible_runs_${rangeDays}d`]: visibility[p.id]?.visibleRuns ?? '',
+      [`avg_visibility_${rangeDays}d`]: visibility[p.id]?.avgVisibility ?? '',
+      [`total_mentions_${rangeDays}d`]: visibility[p.id]?.totalMentions ?? '',
+      [`total_citations_${rangeDays}d`]: visibility[p.id]?.totalCitations ?? '',
+      [`runs_${rangeDays}d`]: visibility[p.id]?.runs ?? '',
       last_run_at: visibility[p.id]?.lastRunAt ?? '',
     }));
 
-    const csv = toCsv(rows, PROMPT_EXPORT_HEADERS);
+    const csv = toCsv(rows, promptExportHeaders(rangeDays));
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -1152,7 +1179,7 @@ export default function PromptsPage() {
     link.click();
 
     URL.revokeObjectURL(url);
-  }, [activeBrand?.slug, canExport, allPrompts, visibility, volumeByPromptId]);
+  }, [activeBrand?.slug, canExport, allPrompts, visibility, volumeByPromptId, rangeDays]);
 
   if (!activeBrandId) {
     return (
@@ -1186,6 +1213,29 @@ export default function PromptsPage() {
             <TabsTrigger value="insights">Insights</TabsTrigger>
           </TabsList>
           <div className="flex items-center gap-2">
+            {/* Hidden on Insights: that tab shows keyword volume estimates,
+                which carry no date dimension, so a range there would be a
+                control that changes nothing. */}
+            {tab !== 'insights' && (
+              <div className="flex items-center rounded-md border p-0.5" role="group">
+                {PROMPT_RANGE_DAYS.map((days) => (
+                  <button
+                    key={days}
+                    type="button"
+                    onClick={() => setRangeDays(days)}
+                    aria-pressed={rangeDays === days}
+                    className={cn(
+                      'rounded-sm px-2.5 py-1 text-xs font-medium transition-colors',
+                      rangeDays === days
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    {days}d
+                  </button>
+                ))}
+              </div>
+            )}
             {tab === 'all' && canManage && (
               <Button
                 type="button"
@@ -1269,6 +1319,7 @@ export default function PromptsPage() {
             activeBrandId={activeBrandId}
             volumeByPromptId={volumeByPromptId}
             visibility={visibility}
+            days={rangeDays}
             onAddPrompt={canManage ? () => setAddPromptOpen(true) : undefined}
             onEditPrompt={canManage ? setEditingPrompt : undefined}
           />
@@ -1276,7 +1327,9 @@ export default function PromptsPage() {
 
         {/* ─── Query Fan-out tab ───────────────────────────────────────── */}
         <TabsContent value="fanout" className="mt-4">
-          {activeBrandId && <QueryFanoutTab brandId={activeBrandId} onTracked={loadData} />}
+          {activeBrandId && (
+            <QueryFanoutTab brandId={activeBrandId} days={rangeDays} onTracked={loadData} />
+          )}
         </TabsContent>
 
         {/* ─── Insights tab ────────────────────────────────────────────── */}
@@ -1662,6 +1715,7 @@ function AllPromptsTab({
   activeBrandId,
   volumeByPromptId,
   visibility,
+  days,
   onAddPrompt,
   onEditPrompt,
 }: {
@@ -1670,6 +1724,8 @@ function AllPromptsTab({
   activeBrandId: string;
   volumeByPromptId: Map<string, PromptVolume>;
   visibility: Record<string, PromptVisibilitySummary>;
+  /** Selected window, so the column tooltips describe the data on screen. */
+  days: PromptRangeDays;
   /** Opens the Add Prompt dialog; undefined when the user can't write (member role). */
   onAddPrompt?: () => void;
   /** Opens the Edit Prompt dialog for a row; undefined hides the pencil (member role). */
@@ -1868,7 +1924,7 @@ function AllPromptsTab({
               </ColHead>
               <SortableHead
                 className="text-right"
-                tooltip="AI Visibility Score (0-100) for this prompt over the last 30 days: how often answers mention the brand (60%), cite its site (25%) and how early it's named (15%). Hover a value for the components."
+                tooltip={`AI Visibility Score (0-100) for this prompt over the last ${days} days: how often answers mention the brand (60%), cite its site (25%) and how early it's named (15%). Hover a value for the components.`}
                 sortKey="visibility"
                 activeSort={activeSort}
                 dir={dir}
@@ -1878,7 +1934,7 @@ function AllPromptsTab({
               </SortableHead>
               <SortableHead
                 className="text-right"
-                tooltip="Total times the brand was mentioned across AI answers for this prompt over the last 30 days."
+                tooltip={`Total times the brand was mentioned across AI answers for this prompt over the last ${days} days.`}
                 sortKey="mentions"
                 activeSort={activeSort}
                 dir={dir}
@@ -1888,7 +1944,7 @@ function AllPromptsTab({
               </SortableHead>
               <SortableHead
                 className="text-right"
-                tooltip="Total times your pages were cited in AI answers for this prompt over the last 30 days."
+                tooltip={`Total times your pages were cited in AI answers for this prompt over the last ${days} days.`}
                 sortKey="citations"
                 activeSort={activeSort}
                 dir={dir}
@@ -1914,7 +1970,7 @@ function AllPromptsTab({
               </ColHead>
               <SortableHead
                 className="text-right"
-                tooltip="Number of tracking runs for this prompt over the last 30 days (one per platform per day)."
+                tooltip={`Number of tracking runs for this prompt over the last ${days} days (one per platform per day).`}
                 sortKey="runs"
                 activeSort={activeSort}
                 dir={dir}
@@ -1992,7 +2048,7 @@ function AllPromptsTab({
                     {vis ? (
                       <div
                         className="inline-flex items-center gap-2 justify-end min-w-[110px]"
-                        title={`Mentioned in ${vis.mentionAnswers} of ${vis.runs} answers (30d) · cited in ${vis.citationAnswers}${
+                        title={`Mentioned in ${vis.mentionAnswers} of ${vis.runs} answers (${days}d) · cited in ${vis.citationAnswers}${
                           vis.positionFactor !== null
                             ? ` · position factor ${vis.positionFactor.toFixed(2)}`
                             : ''

--- a/web/src/config/prompt-options.ts
+++ b/web/src/config/prompt-options.ts
@@ -131,3 +131,21 @@ export const SCRAPER_GROUPS = [
 export const ALL_SCRAPERS = SCRAPER_GROUPS.flatMap((g) =>
   g.scrapers.map((s) => ({ ...s, provider: g.provider })),
 );
+
+/**
+ * Date-range presets for the Prompts page (#686).
+ *
+ * No 24h option: a single day gives one or two runs per prompt, so the scores
+ * would be noise and most of the table would read zero. No "all time" either —
+ * the visibility summaries scan every result row in the window, so an
+ * unbounded range has unbounded cost, and 90 days matches the fan-out cap.
+ */
+export const PROMPT_RANGE_DAYS = [7, 30, 90] as const;
+
+export type PromptRangeDays = (typeof PROMPT_RANGE_DAYS)[number];
+
+export const DEFAULT_PROMPT_RANGE_DAYS: PromptRangeDays = 30;
+
+export function isPromptRangeDays(value: unknown): value is PromptRangeDays {
+  return PROMPT_RANGE_DAYS.includes(Number(value) as PromptRangeDays);
+}

--- a/web/src/lib/actions/prompt.ts
+++ b/web/src/lib/actions/prompt.ts
@@ -4,7 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { revalidatePath } from 'next/cache';
 import type { PromptSet, Prompt, AIPlatform, PromptVolume } from '@/types';
 import { enforceLimit, getOrgPlan, PlanLimitError } from '@/lib/guards/plan-guard';
-import { ALL_MODELS, ALL_SCRAPERS } from '@/config/prompt-options';
+import { ALL_MODELS, ALL_SCRAPERS, DEFAULT_PROMPT_RANGE_DAYS } from '@/config/prompt-options';
 import type { Plan } from '@/config/plans';
 import { getPromptVolumes, type VolumeQuota } from '@/lib/actions/volumes';
 import { getPromptVisibilitySummaries, type PromptVisibilitySummary } from '@/lib/actions/tracking';
@@ -547,10 +547,17 @@ export interface PromptsPageData {
  * their failure degrades to an empty list instead of blanking the prompt
  * table — the page's core content must never be hostage to the volumes API.
  */
-export async function getPromptsPageData(brandId: string): Promise<PromptsPageData> {
+export async function getPromptsPageData(
+  brandId: string,
+  opts?: { days?: number },
+): Promise<PromptsPageData> {
+  // Only the visibility summaries are window-scoped. Prompt sets are the
+  // roster itself, and volumes are keyword-level estimates with no date
+  // dimension, so neither changes with the selected range.
+  const days = opts?.days ?? DEFAULT_PROMPT_RANGE_DAYS;
   const [promptSets, visibility, volumesResult] = await Promise.all([
     getPromptSets(brandId),
-    getPromptVisibilitySummaries(brandId, { days: 30 }),
+    getPromptVisibilitySummaries(brandId, { days }),
     getPromptVolumes(brandId).then(
       (r) => ({ volumes: r.volumes, quota: r.quota ?? null, degraded: false }),
       (err) => {


### PR DESCRIPTION
## Summary

Every metric on the Prompts page was pinned to 30 days, so "what changed this week" was invisible inside a monthly average — and Prompts was the only major analytics page without a date control.

The selector sits beside the tabs and drives the **All Prompts** table and the **Query Fan-out** tab.

**It is hidden on Insights.** The issue assumed all three tabs, but that tab renders keyword volume estimates, which have no date dimension — a range control there would change nothing, so showing one would be a lie about what it does.

Beyond the data itself, every window-scoped label now follows the selection instead of claiming 30 days regardless:

- the four column tooltips and the per-row hover text
- the fan-out tab's description and its empty state
- **the CSV headers** — exporting 7-day data under a `runs_30d` column would have quietly shipped wrong numbers, so the window-scoped columns carry the selected range (`runs_7d`, `visibility_rate_90d`, …). At the default the header row is unchanged.

The selection is mirrored in the URL as `?range=`, omitted at the default so existing links keep their shape.

## Design decisions

- **No 24h preset:** one day yields one or two runs per prompt, so scores would be noise and most of the table would read zero.
- **No "all time":** the visibility summaries scan every result row in the window, so an unbounded range has unbounded cost. 90 days also matches the fan-out row cap.
- **The suggestions card is untouched** — it runs on its own 28-day Search Console window, which is part of its logic rather than a display range.

## Related issue

Closes #686

## Type of change

- [x] `feat` — New feature

## How to test

Verified against a local instance with real data. Note when picking a prompt to check: rows added within the last week show the **same** counts at every range, correctly — their entire history already falls inside 7 days. Use an older prompt to see the difference.

1. Search for an older prompt (e.g. one tracked since before the last week) and watch its **Runs** column: it changed from **42** at 7d to **176** at 30d on the instance this was tested against.
2. `?range=7` appears in the URL on selection and disappears when returning to 30d; loading `?range=90` directly starts on 90d.
3. The selector is absent on the Insights tab.

Not yet exercised by hand: the CSV header change and the suggestions card staying put across ranges — both are covered by code (the card takes no range prop and calls its own action), but worth a glance on review.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes — no new warnings
- [x] `yarn typecheck` passes
- [x] `yarn format:check` passes
- [x] Changes are focused — one concern per PR