### PR TITLE
fix(web): cover messages/*.json in the format check

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -299,7 +299,7 @@
       "sendAll": "Send All",
       "dismissAll": "Dismiss All",
       "dismissAllTitle": "Dismiss opportunities?",
-     "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} This can't be undone."
+      "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} This can't be undone."
     },
     "table": {
       "action": "Action",

--- a/web/package.json
+++ b/web/package.json
@@ -15,8 +15,8 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --write \"src/**/*.{ts,tsx}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --write \"src/**/*.{ts,tsx}\" \"messages/**/*.json\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"messages/**/*.json\"",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary

The format scripts only globbed `src/**/*.{ts,tsx}`, so the translation files were never checked. An indentation slip had already landed through that gap — `bulk.dismissAllConfirm` in `en.json` sits at 5 spaces instead of 6, introduced by #653 — with CI green the entire time.

Two changes:

- Reformat the offending line (formatting only, no translation value touched).
- Widen both `format` and `format:check` to include `messages/**/*.json`, so the same class of drift can't land silently again.

Spotted by @jonsuguiyama in #680.

## Related issue

Closes #683

## Type of change

- [x] `fix` — Bug fix

## How to test

The point of this PR is that the check now *catches* something, so testing it means proving the gap is closed rather than merely currently clean:

```
cd web
yarn format:check                  # passes

# break it on purpose, then re-run
# (e.g. remove one space of indentation from a key in messages/en.json)
yarn format:check                  # now fails on messages/en.json

# restore
yarn format
yarn format:check                  # passes again
```

I ran exactly that sequence: clean → deliberately misindented → check failed on `messages/en.json` → restored → check passed.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes — no source files touched
- [x] `yarn typecheck` passes — no source files touched
- [x] `yarn format:check` passes, now including the translation files
- [x] Changes are focused — one concern per PR