### PR TITLE
fix(citations): answer "has any citations" without counting every row

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -39,7 +39,7 @@ import {
 import {
   getCitationsOverview,
   getCitationGaps,
-  getCitationsTotal,
+  brandHasCitations,
   type CitationsFilters,
   type CitationsOverview,
   type CitationDomainRow,
@@ -435,7 +435,7 @@ const UrlsTable = memo(function UrlsTable({
 /**
  * Period-aware empty state for the Domains / URLs tables (#485).
  *
- * hasAnyCitations is fetched once in loadData (via getCitationsTotal) and
+ * hasAnyCitations is fetched once in loadData (via brandHasCitations) and
  * passed down, so both keepMounted panels share a single server call instead
  * of each firing their own (#313 action queue note).
  *
@@ -891,13 +891,13 @@ export default function CitationsPage() {
     setIsLoading(true);
     setLoadFailed(false);
     try {
-      const [overview, total] = await Promise.all([
+      const [overview, hasAny] = await Promise.all([
         getCitationsOverview(activeBrandId, apiFilters),
-        getCitationsTotal(activeBrandId),
+        brandHasCitations(activeBrandId),
       ]);
       if (stale()) return;
       setData(overview);
-      setHasAnyCitations(total > 0);
+      setHasAnyCitations(hasAny);
 
       // Surface filter options from the observed models/regions.
       const platformOptions = buildPlatformOptions(overview.rows);

--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -671,23 +671,38 @@ export async function getCitationGaps(
 // ─── Existence check (#485) ───────────────────────────────────────────────────
 
 /**
- * Cheap unfiltered existence check — counts prompt_results rows for a brand
- * with no date/filter constraints, so the Citations page can distinguish
- * "no data in this window" from "no data at all".
+ * Unfiltered existence check — does this brand have any cited answer at all,
+ * ignoring the page's date and filter selection? Lets the Citations page
+ * distinguish "no data in this window" from "no data at all".
  *
- * Mirrors getBrandResultsTotal in tracking.ts (used by the Insights page).
- * Uses `head: true` so Supabase returns only the count, not any rows.
+ * Deliberately not a count (#706). `citations <> '[]'` can't use an index, so
+ * an exact count made Postgres read and detoast every citation payload the
+ * brand has ever produced — ~1.8s and 780 MB of buffers on a large brand with
+ * a warm cache, and past the 8s statement timeout once the nightly run had
+ * churned the cache, which failed the whole page load. Only the yes/no answer
+ * was ever used. Stopping at the first match answers it in ~0.1ms.
+ *
+ * The ordering is load-bearing: without it the planner picks a sequential scan
+ * over the entire table, which is unbounded for a brand whose answers never
+ * cite anything. Ordering by created_at keeps the scan on this brand's rows
+ * via idx_prompt_results_brand_created.
+ *
+ * Note that prompt_results.citation_count is NOT a substitute for the
+ * `citations <> '[]'` predicate — it counts something narrower, and disagrees
+ * on the overwhelming majority of rows.
  */
-export async function getCitationsTotal(brandId: string): Promise<number> {
+export async function brandHasCitations(brandId: string): Promise<boolean> {
   const supabase = await createClient();
-  const { count, error } = await supabase
+  const { data, error } = await supabase
     .from('prompt_results')
-    .select('id', { count: 'exact', head: true })
+    .select('id')
     .eq('brand_id', brandId)
     .neq('platform', 'chatgpt-shopping')
-    .neq('citations', '[]');
+    .neq('citations', '[]')
+    .order('created_at', { ascending: false })
+    .limit(1);
   if (error) throw new Error(error.message);
-  return count ?? 0;
+  return (data ?? []).length > 0;
 }
 
 // ─── Per-URL detail (#535) ────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

The Citations page failed intermittently with a "Failed to load citation data" toast, most visibly right after a refresh — the same page then loaded fine seconds later.

The culprit was the unfiltered has-any-citations lookup, which ran an exact count with a `citations <> '[]'` predicate. That predicate can't use an index, so the count made Postgres read every result the brand had ever produced and detoast each citation payload:

```
Aggregate  (actual time=1773.205..1773.206 rows=1)
  Buffers: shared hit=95371 read=2063
  ->  Bitmap Heap Scan  (actual time=6.285..1767.799 rows=39385)
Execution Time: 1773.544 ms
```

1.8s and ~780 MB of buffers with a warm cache — and past PostgREST's 8s statement timeout once the nightly tracking run had churned that cache, which is why it looked random. The API log caught it plainly: the same `HEAD` returning 500 at 16:13:04 and 206 at 16:13:28. Because the call sits in a `Promise.all` with the real data load, its failure took down a page whose actual query had already succeeded.

The count was never rendered anywhere — its only consumer was `total > 0`, feeding the empty-state copy. So the action now returns that boolean and stops at the first match: **0.102 ms**, 4 buffers, on the same brand.

Two things worth knowing for review:

- **The `order by` is load-bearing.** Without it the planner picks a sequential scan over the whole table — 22 ms when a match turns up early, but unbounded for a brand whose answers never cite anything. Ordering by `created_at` keeps the scan on the brand's own rows via the existing `idx_prompt_results_brand_created`.
- **`prompt_results.citation_count` is not a substitute** for the `citations <> '[]'` predicate, despite looking like one. It counts something narrower: on the brand measured, 39,385 rows have a non-empty `citations` array while only 1,895 have `citation_count > 0`.

## Related issue

Closes #706

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open the Citations page for a brand with tens of thousands of results and refresh repeatedly — no failure toast, and the page settles noticeably faster.
2. Filter down to a window with no citations: the empty state still says "no citations match these filters" rather than "this brand has no citations yet".
3. On a brand that genuinely has no citations at all, the empty state still reports that correctly.
4. The Retry button in the failed state still works.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
