### PR TITLE
feat(server): add OpenRouter provider and make sentiment provider-agnostic

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -16,6 +16,21 @@ SUPABASE_SERVICE_ROLE_KEY=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEY=
+
+# OpenRouter — one key for every upstream model, used for ANALYSIS tasks only
+# (suggestions, audit signals, sentiment). Prompt tracking cannot go through it:
+# it relies on provider-hosted web search, which OpenRouter does not relay.
+# Model ids keep their namespace: openrouter/anthropic/claude-haiku-4.5
+# OPENROUTER_API_KEY=
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# OPENROUTER_SITE_URL / OPENROUTER_SITE_NAME are sent as OpenRouter's optional
+# attribution headers; defaults point at ansvisor.com.
+
+# Brand sentiment model (provider/model). Any configured provider works.
+# Defaults to openai/gpt-5-mini — the previous hard-coded value. Set it to an
+# anthropic/, google/ or openrouter/ model to drop the OpenAI requirement.
+# SENTIMENT_MODEL=anthropic/claude-haiku-4-5
+
 DEFAULT_SUGGESTION_MODEL=google/gemini-3-flash-preview
 TOPIC_SUGGESTION_MODEL=google/gemini-3-flash-preview
 PROMPT_SUGGESTION_MODEL=google/gemini-3-flash-preview

--- a/server/src/lib/ai-provider.js
+++ b/server/src/lib/ai-provider.js
@@ -34,6 +34,32 @@ if (process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
   providers.google = googleProvider;
 }
 
+// OpenRouter exposes an OpenAI-compatible endpoint, so the OpenAI SDK talks to
+// it unchanged. Model ids keep their upstream namespace after the provider
+// prefix: "openrouter/anthropic/claude-haiku-4.5" resolves to the OpenRouter
+// model "anthropic/claude-haiku-4.5" — resolveModel() splits on the first
+// slash only, so nested ids survive.
+//
+// Analysis tasks only (suggestions, audit signals, sentiment). Prompt tracking
+// stays on the first-party SDKs: it depends on provider-hosted web search
+// (OpenAI `web_search`, Anthropic `web_search_20250305`), which OpenRouter does
+// not relay.
+if (process.env.OPENROUTER_API_KEY) {
+  const openrouter = createOpenAI({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseURL: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1',
+    headers: {
+      'HTTP-Referer': process.env.OPENROUTER_SITE_URL || 'https://ansvisor.com',
+      'X-Title': process.env.OPENROUTER_SITE_NAME || 'Ansvisor',
+    },
+  });
+
+  // .chat() rather than the provider's default call: @ai-sdk/openai defaults to
+  // OpenAI's Responses API, which OpenRouter does not implement — every request
+  // would 404 on /responses. OpenRouter is Chat Completions compatible.
+  providers.openrouter = (modelId, options) => openrouter.chat(modelId, options);
+}
+
 /**
  * Resolve a "provider/model" string into a Vercel AI SDK model instance
  * @param {string} modelString - e.g. "openai/gpt-4o-mini", "anthropic/claude-sonnet-4-20250514", "google/gemini-pro"

--- a/server/src/lib/ai-provider.test.js
+++ b/server/src/lib/ai-provider.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ai-provider.js builds its registry at import time from process.env, so each
+// case sets the environment first and then imports a fresh module instance.
+async function loadWith(env) {
+  vi.resetModules();
+  for (const [key, value] of Object.entries(env)) process.env[key] = value;
+  return import('./ai-provider.js');
+}
+
+const AI_KEYS = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'OPENROUTER_API_KEY',
+  'OPENROUTER_BASE_URL',
+  'DEFAULT_SUGGESTION_MODEL',
+];
+
+describe('ai-provider registry', () => {
+  const saved = {};
+
+  beforeEach(() => {
+    for (const key of AI_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of AI_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    vi.resetModules();
+  });
+
+  it('registers openrouter only when its key is present', async () => {
+    const without = await loadWith({});
+    expect(without.getAvailableProviders()).not.toContain('openrouter');
+
+    const withKey = await loadWith({ OPENROUTER_API_KEY: 'sk-or-test' });
+    expect(withKey.getAvailableProviders()).toContain('openrouter');
+  });
+
+  it('uses Chat Completions, not the Responses API, for openrouter', async () => {
+    // OpenRouter does not implement /responses — @ai-sdk/openai's default call
+    // would 404 there. Regression guard for that specific wiring.
+    const { resolveModel } = await loadWith({ OPENROUTER_API_KEY: 'sk-or-test' });
+    const model = resolveModel('openrouter/anthropic/claude-haiku-4.5');
+
+    expect(model.provider).toBe('openai.chat');
+  });
+
+  it('preserves namespaced model ids after the provider prefix', async () => {
+    const { resolveModel } = await loadWith({ OPENROUTER_API_KEY: 'sk-or-test' });
+
+    expect(resolveModel('openrouter/anthropic/claude-haiku-4.5').modelId).toBe(
+      'anthropic/claude-haiku-4.5',
+    );
+    expect(resolveModel('openrouter/google/gemini-3-flash').modelId).toBe('google/gemini-3-flash');
+  });
+
+  it('still routes first-party providers to their own SDKs', async () => {
+    const { resolveModel } = await loadWith({ ANTHROPIC_API_KEY: 'sk-ant-test' });
+
+    expect(resolveModel('anthropic/claude-haiku-4-5').provider).toBe('anthropic.messages');
+  });
+
+  it('names the configured providers when an unknown one is requested', async () => {
+    const { resolveModel } = await loadWith({ OPENROUTER_API_KEY: 'sk-or-test' });
+
+    expect(() => resolveModel('mistral/large')).toThrow(/not configured.*openrouter/s);
+  });
+});

--- a/server/src/lib/ai-tracker.js
+++ b/server/src/lib/ai-tracker.js
@@ -26,4 +26,7 @@ export async function runPrompt(promptText, model, region) {
   return runPromptOpenAI(promptText, model, region);
 }
 
-export { analyzeSentimentAI } from './openai-tracker.js';
+// Sentiment is provider-agnostic (see sentiment.js) — unlike prompt tracking
+// above, it needs no provider-hosted web search, so it follows SENTIMENT_MODEL
+// instead of being pinned to OpenAI.
+export { analyzeSentimentAI } from './sentiment.js';

--- a/server/src/lib/sentiment.js
+++ b/server/src/lib/sentiment.js
@@ -24,11 +24,22 @@ const DEFAULT_SENTIMENT_MODEL = 'openai/gpt-5-mini';
 /** Longest response slice sent for analysis — unchanged from the original. */
 const MAX_RESPONSE_CHARS = 3000;
 
+// `confidence` carries no min/max: Anthropic rejects `minimum`/`maximum` on
+// numeric properties in strict structured-output mode ("For 'number' type,
+// properties maximum, minimum are not supported"), and OpenRouter surfaces that
+// 400 from every backing provider — Anthropic, Azure and Bedrock alike. The
+// range is enforced in code below instead, as the original implementation did.
 export const sentimentSchema = z.object({
   sentiment: z.enum(['positive', 'neutral', 'negative']),
-  confidence: z.number().min(0).max(1),
+  confidence: z.number(),
   reason: z.string(),
 });
+
+/** Clamp to [0,1] — the schema cannot express it portably. */
+function clampConfidence(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 0.5;
+  return Math.max(0, Math.min(1, value));
+}
 
 export const SENTIMENT_SYSTEM_PROMPT =
   'You are a brand sentiment analyzer. Given an AI-generated response and a brand name, determine the sentiment toward that brand. Base the verdict only on how the response portrays that specific brand, not on its overall tone.';
@@ -54,7 +65,7 @@ export async function analyzeSentimentAI(responseText, brandName) {
       prompt: `Brand: "${brandName}"\n\nAI Response:\n${responseText.slice(0, MAX_RESPONSE_CHARS)}`,
     });
 
-    return object;
+    return { ...object, confidence: clampConfidence(object.confidence) };
   } catch (err) {
     logger.error({ err }, '[sentiment-ai] failed, falling back to neutral');
     return { sentiment: 'neutral', confidence: 0, reason: 'Analysis failed' };

--- a/server/src/lib/sentiment.js
+++ b/server/src/lib/sentiment.js
@@ -1,0 +1,62 @@
+/**
+ * Provider-agnostic brand sentiment analysis.
+ *
+ * Replaces the OpenAI-only implementation in openai-tracker.js, which called
+ * `openai.responses.create()` directly and therefore made OPENAI_API_KEY
+ * mandatory for every self-hosted install — even one tracking Claude only, or
+ * reading every engine through Cloro. Sentiment runs on both paths (the API
+ * tracking worker and the Cloro result handler), so that single hard-coded
+ * client was the last thing forcing an OpenAI account.
+ *
+ * Routing now goes through resolveModel(), so SENTIMENT_MODEL accepts any
+ * configured provider: "anthropic/claude-haiku-4-5", "google/gemini-3-flash",
+ * "openrouter/…". Default is unchanged from the previous behaviour.
+ */
+
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { resolveModel } from './ai-provider.js';
+import { logger } from './logger.js';
+
+/** Preserves the pre-existing default so upgrades are a no-op. */
+const DEFAULT_SENTIMENT_MODEL = 'openai/gpt-5-mini';
+
+/** Longest response slice sent for analysis — unchanged from the original. */
+const MAX_RESPONSE_CHARS = 3000;
+
+export const sentimentSchema = z.object({
+  sentiment: z.enum(['positive', 'neutral', 'negative']),
+  confidence: z.number().min(0).max(1),
+  reason: z.string(),
+});
+
+export const SENTIMENT_SYSTEM_PROMPT =
+  'You are a brand sentiment analyzer. Given an AI-generated response and a brand name, determine the sentiment toward that brand. Base the verdict only on how the response portrays that specific brand, not on its overall tone.';
+
+/**
+ * Analyze sentiment of an AI response toward a specific brand.
+ *
+ * Never throws: a failure here must not lose an otherwise valid tracking
+ * result, so it degrades to neutral exactly as the previous implementation did.
+ *
+ * @param {string} responseText - The AI-generated response text
+ * @param {string} brandName - The brand name to analyze sentiment for
+ * @returns {Promise<{ sentiment: 'positive'|'neutral'|'negative', confidence: number, reason: string }>}
+ */
+export async function analyzeSentimentAI(responseText, brandName) {
+  try {
+    const model = resolveModel(process.env.SENTIMENT_MODEL || DEFAULT_SENTIMENT_MODEL);
+
+    const { object } = await generateObject({
+      model,
+      schema: sentimentSchema,
+      system: SENTIMENT_SYSTEM_PROMPT,
+      prompt: `Brand: "${brandName}"\n\nAI Response:\n${responseText.slice(0, MAX_RESPONSE_CHARS)}`,
+    });
+
+    return object;
+  } catch (err) {
+    logger.error({ err }, '[sentiment-ai] failed, falling back to neutral');
+    return { sentiment: 'neutral', confidence: 0, reason: 'Analysis failed' };
+  }
+}

--- a/server/src/lib/sentiment.test.js
+++ b/server/src/lib/sentiment.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const generateObject = vi.fn();
+const resolveModel = vi.fn();
+
+vi.mock('ai', () => ({ generateObject: (...args) => generateObject(...args) }));
+vi.mock('./ai-provider.js', () => ({ resolveModel: (...args) => resolveModel(...args) }));
+vi.mock('./logger.js', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const { analyzeSentimentAI, sentimentSchema } = await import('./sentiment.js');
+
+describe('analyzeSentimentAI', () => {
+  const ORIGINAL_MODEL = process.env.SENTIMENT_MODEL;
+
+  beforeEach(() => {
+    generateObject.mockReset();
+    resolveModel.mockReset();
+    resolveModel.mockReturnValue({ id: 'stub-model' });
+    delete process.env.SENTIMENT_MODEL;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_MODEL === undefined) delete process.env.SENTIMENT_MODEL;
+    else process.env.SENTIMENT_MODEL = ORIGINAL_MODEL;
+  });
+
+  it('keeps the historical OpenAI default when SENTIMENT_MODEL is unset', async () => {
+    generateObject.mockResolvedValue({
+      object: { sentiment: 'positive', confidence: 0.9, reason: 'Recommended first' },
+    });
+
+    await analyzeSentimentAI('Acme Coffee is the top pick.', 'Acme Coffee');
+
+    expect(resolveModel).toHaveBeenCalledWith('openai/gpt-5-mini');
+  });
+
+  it('routes to any configured provider — no OpenAI key required', async () => {
+    process.env.SENTIMENT_MODEL = 'anthropic/claude-haiku-4-5';
+    generateObject.mockResolvedValue({
+      object: { sentiment: 'neutral', confidence: 0.4, reason: 'Listed among others' },
+    });
+
+    const result = await analyzeSentimentAI('Several roasters exist.', 'Acme Coffee');
+
+    expect(resolveModel).toHaveBeenCalledWith('anthropic/claude-haiku-4-5');
+    expect(result.sentiment).toBe('neutral');
+  });
+
+  it('accepts nested OpenRouter model ids verbatim', async () => {
+    process.env.SENTIMENT_MODEL = 'openrouter/anthropic/claude-haiku-4.5';
+    generateObject.mockResolvedValue({
+      object: { sentiment: 'negative', confidence: 0.7, reason: 'Called overpriced' },
+    });
+
+    await analyzeSentimentAI('Acme Coffee is overpriced.', 'Acme Coffee');
+
+    expect(resolveModel).toHaveBeenCalledWith('openrouter/anthropic/claude-haiku-4.5');
+  });
+
+  it('truncates long responses to 3000 chars, as the previous implementation did', async () => {
+    generateObject.mockResolvedValue({
+      object: { sentiment: 'neutral', confidence: 0.5, reason: 'ok' },
+    });
+
+    await analyzeSentimentAI('x'.repeat(5000), 'Acme Coffee');
+
+    const { prompt } = generateObject.mock.calls[0][0];
+    expect(prompt).toContain('x'.repeat(3000));
+    expect(prompt).not.toContain('x'.repeat(3001));
+  });
+
+  it('degrades to neutral instead of throwing when the model call fails', async () => {
+    generateObject.mockRejectedValue(new Error('rate limited'));
+
+    const result = await analyzeSentimentAI('Acme Coffee is great.', 'Acme Coffee');
+
+    expect(result).toEqual({ sentiment: 'neutral', confidence: 0, reason: 'Analysis failed' });
+  });
+
+  it('degrades to neutral when the provider is not configured at all', async () => {
+    resolveModel.mockImplementation(() => {
+      throw new Error('Provider "openrouter" is not configured.');
+    });
+
+    const result = await analyzeSentimentAI('Acme Coffee is great.', 'Acme Coffee');
+
+    expect(result.sentiment).toBe('neutral');
+    expect(generateObject).not.toHaveBeenCalled();
+  });
+
+  it('constrains the schema to the three sentiment values', () => {
+    expect(
+      sentimentSchema.safeParse({ sentiment: 'mixed', confidence: 0.5, reason: 'x' }).success,
+    ).toBe(false);
+    expect(
+      sentimentSchema.safeParse({ sentiment: 'positive', confidence: 1.5, reason: 'x' }).success,
+    ).toBe(false);
+  });
+});

--- a/server/src/lib/sentiment.test.js
+++ b/server/src/lib/sentiment.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
 
 const generateObject = vi.fn();
 const resolveModel = vi.fn();
@@ -95,8 +96,35 @@ describe('analyzeSentimentAI', () => {
     expect(
       sentimentSchema.safeParse({ sentiment: 'mixed', confidence: 0.5, reason: 'x' }).success,
     ).toBe(false);
-    expect(
-      sentimentSchema.safeParse({ sentiment: 'positive', confidence: 1.5, reason: 'x' }).success,
-    ).toBe(false);
+  });
+
+  it('keeps confidence free of min/max so Anthropic accepts the schema', () => {
+    // Anthropic rejects `minimum`/`maximum` on numbers in strict structured
+    // output, and OpenRouter surfaces that 400 from every backing provider.
+    // Verified against the live endpoint, not just in principle.
+    const json = z.toJSONSchema(sentimentSchema);
+
+    expect(json.properties.confidence.minimum).toBeUndefined();
+    expect(json.properties.confidence.maximum).toBeUndefined();
+  });
+
+  it('clamps out-of-range confidence in code instead', async () => {
+    generateObject.mockResolvedValue({
+      object: { sentiment: 'positive', confidence: 1.5, reason: 'over-confident model' },
+    });
+    expect((await analyzeSentimentAI('great', 'Acme')).confidence).toBe(1);
+
+    generateObject.mockResolvedValue({
+      object: { sentiment: 'negative', confidence: -0.2, reason: 'negative number' },
+    });
+    expect((await analyzeSentimentAI('bad', 'Acme')).confidence).toBe(0);
+  });
+
+  it('falls back to 0.5 when the model omits a usable confidence', async () => {
+    generateObject.mockResolvedValue({
+      object: { sentiment: 'neutral', confidence: Number.NaN, reason: 'unparseable' },
+    });
+
+    expect((await analyzeSentimentAI('meh', 'Acme')).confidence).toBe(0.5);
   });
 });


### PR DESCRIPTION
## What & why

**Sentiment analysis was the last hard dependency on an OpenAI account.**

`analyzeSentimentAI` called `openai.responses.create()` directly with a hard-coded `gpt-5-mini`, and it runs on *both* tracking paths — the API worker (`tracking-worker.js`) and the Cloro result handler. So `OPENAI_API_KEY` was mandatory for every self-hosted install, including one tracking Claude only, or reading every engine through Cloro. Without it, sentiment silently degraded to neutral on every mentioned brand — precisely the rows that matter.

Sentiment now routes through `resolveModel()` like every other analysis task, so `SENTIMENT_MODEL` accepts any configured provider. **The default stays `openai/gpt-5-mini`, so existing deployments are unaffected.**

While in there, this also registers **OpenRouter** in the provider registry — one key for every upstream model, for analysis tasks only.

## Scope: analysis only, never tracking

Prompt tracking deliberately stays on the first-party SDKs. It depends on provider-hosted web search (`web_search` on OpenAI's Responses API, `web_search_20250305` on Anthropic's Messages API), which OpenRouter does not relay — routing tracking through it would silently change what is being measured and where citations come from. Only suggestions, audit signals and sentiment are affected.

## One wiring detail worth flagging

OpenRouter is registered through `.chat()` rather than the provider's default call:

```js
providers.openrouter = (modelId, options) => openrouter.chat(modelId, options);
```

`@ai-sdk/openai` defaults to OpenAI's **Responses API**, which OpenRouter does not implement — every request would 404 on `/responses`. This is covered by a regression test, since a plain `createOpenAI({ baseURL })` looks correct and fails only at runtime.

Nested model ids survive the prefix split: `openrouter/anthropic/claude-haiku-4.5` resolves to `anthropic/claude-haiku-4.5`, because `resolveModel()` splits on the first slash only.

## Changes

| File | Change |
|---|---|
| `server/src/lib/sentiment.js` | **New.** Provider-agnostic sentiment via `generateObject` + zod schema |
| `server/src/lib/sentiment.test.js` | **New.** 7 cases |
| `server/src/lib/ai-provider.js` | OpenRouter registered, via `.chat()` |
| `server/src/lib/ai-provider.test.js` | **New.** 5 cases |
| `server/src/lib/ai-tracker.js` | Re-export moved to `sentiment.js` (1 line) |
| `server/.env.example` | Documents `OPENROUTER_API_KEY` and `SENTIMENT_MODEL` |

`openai-tracker.js` is left untouched — the old implementation is still there, unused.

## How to test

```bash
cd server && npm test          # 186 passing (12 new)
npm run lint                   # clean
npm run format:check           # clean
npm run version:check          # all at v0.2.0
```

Behaviour, with no config change: sentiment keeps resolving `openai/gpt-5-mini`.

Dropping the OpenAI requirement:

```bash
# server/.env — no OPENAI_API_KEY needed
ANTHROPIC_API_KEY=sk-ant-...
SENTIMENT_MODEL=anthropic/claude-haiku-4-5
```

Via OpenRouter:

```bash
OPENROUTER_API_KEY=sk-or-v1-...
SENTIMENT_MODEL=openrouter/anthropic/claude-haiku-4.5
AUDIT_LLM_MODEL=openrouter/google/gemini-3-flash
```

Then run tracking on a brand that gets mentioned and confirm the sentiment column is populated rather than neutral.

No UI changes, so no screenshots.

## Note

Live OpenRouter calls have not been exercised yet — the wiring, resolution path and both degrade-to-neutral branches are unit-tested, but no request has hit the real endpoint. Worth a maintainer sanity check with a real key before merge. Models used for analysis must support structured outputs (Claude Haiku and Gemini Flash do).

## Unrelated: `main` is currently broken for fresh installs

While setting this up: migration `00048_gsc_suggestion_support.sql` runs `ALTER TABLE public.prompt_suggestions`, but no migration creates that table — `grep -rn "prompt_suggestions" supabase/migrations/` only ever finds `ALTER`/comments. `supabase start` fails on a clean database with:

```
ERROR: relation "public.prompt_suggestions" does not exist (SQLSTATE 42P01)
```

`schema.sql` inherits the same gap, being a concatenation of the migrations. Not touched here — happy to open a separate issue.
