### PR TITLE
fix(db): recover the prompt_suggestions table definition

### DIFF
--- a/supabase/migrations/00048_gsc_suggestion_support.sql
+++ b/supabase/migrations/00048_gsc_suggestion_support.sql
@@ -9,6 +9,96 @@
 --    repeat suggestion refreshes cost zero new DataForSEO calls. Service
 --    role only (RLS enabled, no policies).
 
+-- ── Recovered table definition (#709) ────────────────────────────────────────
+--
+-- prompt_suggestions was created directly against the hosted database and
+-- never written back into a migration, so the ALTERs below had nothing to
+-- alter on a clean one: `supabase db reset` failed here with 42P01, and
+-- schema.sql inherited the same gap. Every documented fresh-install path was
+-- broken from the moment this migration shipped.
+--
+-- The definition belongs *here* rather than in a later numbered file, because
+-- the very next statement alters this table — a migration appended at the end
+-- would never be reached. Editing a shipped migration is normally off-limits;
+-- this one is safe because every clause is idempotent and any database that
+-- already ran 00048 will not run it again.
+--
+-- Deliberately the table as it was BEFORE the ALTERs below: no source_data
+-- column, and the two-value source check. Transcribing a live database's
+-- current shape instead would leave a fresh install failing one line later on
+-- "column source_data already exists".
+CREATE TABLE IF NOT EXISTS "public"."prompt_suggestions" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "brand_id" "uuid" NOT NULL,
+    "suggested_text" "text" NOT NULL,
+    "topic_name" "text",
+    "topic_id" "uuid",
+    "reason" "text",
+    "est_volume" integer,
+    "source" "text" DEFAULT 'llm'::"text" NOT NULL,
+    "status" "text" DEFAULT 'new'::"text" NOT NULL,
+    "added_prompt_id" "uuid",
+    "generated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "expires_at" timestamp with time zone DEFAULT ("now"() + '48:00:00'::interval) NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "prompt_suggestions_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "prompt_suggestions_source_check" CHECK (
+        "source" = ANY (ARRAY['llm'::"text", 'heuristic'::"text"])
+    ),
+    CONSTRAINT "prompt_suggestions_status_check" CHECK (
+        "status" = ANY (ARRAY['new'::"text", 'added'::"text", 'dismissed'::"text"])
+    ),
+    CONSTRAINT "prompt_suggestions_brand_id_fkey" FOREIGN KEY ("brand_id")
+        REFERENCES "public"."brands"("id") ON DELETE CASCADE,
+    CONSTRAINT "prompt_suggestions_topic_id_fkey" FOREIGN KEY ("topic_id")
+        REFERENCES "public"."topics"("id") ON DELETE SET NULL,
+    CONSTRAINT "prompt_suggestions_added_prompt_id_fkey" FOREIGN KEY ("added_prompt_id")
+        REFERENCES "public"."prompts"("id") ON DELETE SET NULL
+);
+
+ALTER TABLE "public"."prompt_suggestions" OWNER TO "postgres";
+
+CREATE INDEX IF NOT EXISTS "idx_prompt_suggestions_brand_status"
+    ON "public"."prompt_suggestions" ("brand_id", "status", "generated_at" DESC);
+
+-- One live suggestion per brand per text, case-insensitively. Partial on
+-- 'new' so an accepted or dismissed suggestion never blocks a later one.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_prompt_suggestions_brand_text_active"
+    ON "public"."prompt_suggestions" ("brand_id", "lower"("suggested_text"))
+    WHERE ("status" = 'new'::"text");
+
+ALTER TABLE "public"."prompt_suggestions" ENABLE ROW LEVEL SECURITY;
+
+-- Writes go through the Express server's service-role client; these cover the
+-- web app's direct reads and the accept/dismiss updates it performs.
+CREATE POLICY "prompt_suggestions: member select" ON "public"."prompt_suggestions"
+    FOR SELECT USING (
+        "brand_id" IN (
+            SELECT "b"."id"
+            FROM "public"."brands" "b"
+            JOIN "public"."profiles" "p" ON "p"."organization_id" = "b"."organization_id"
+            WHERE "p"."id" = "auth"."uid"()
+        )
+    );
+
+CREATE POLICY "prompt_suggestions: admin/manager/analyst update" ON "public"."prompt_suggestions"
+    FOR UPDATE USING (
+        "brand_id" IN (
+            SELECT "b"."id"
+            FROM "public"."brands" "b"
+            JOIN "public"."profiles" "p" ON "p"."organization_id" = "b"."organization_id"
+            WHERE "p"."id" = "auth"."uid"()
+              AND "p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role", 'analyst'::"public"."user_role"])
+        )
+    );
+
+GRANT ALL ON TABLE "public"."prompt_suggestions" TO "anon";
+GRANT ALL ON TABLE "public"."prompt_suggestions" TO "authenticated";
+GRANT ALL ON TABLE "public"."prompt_suggestions" TO "service_role";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+
 ALTER TABLE public.prompt_suggestions ADD COLUMN source_data jsonb;
 
 -- The live table's source check predates 'gsc' — extend it.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5021,6 +5021,96 @@ GRANT SELECT ON public.gsc_query_stats TO authenticated;
 --    repeat suggestion refreshes cost zero new DataForSEO calls. Service
 --    role only (RLS enabled, no policies).
 
+-- ── Recovered table definition (#709) ────────────────────────────────────────
+--
+-- prompt_suggestions was created directly against the hosted database and
+-- never written back into a migration, so the ALTERs below had nothing to
+-- alter on a clean one: `supabase db reset` failed here with 42P01, and
+-- schema.sql inherited the same gap. Every documented fresh-install path was
+-- broken from the moment this migration shipped.
+--
+-- The definition belongs *here* rather than in a later numbered file, because
+-- the very next statement alters this table — a migration appended at the end
+-- would never be reached. Editing a shipped migration is normally off-limits;
+-- this one is safe because every clause is idempotent and any database that
+-- already ran 00048 will not run it again.
+--
+-- Deliberately the table as it was BEFORE the ALTERs below: no source_data
+-- column, and the two-value source check. Transcribing a live database's
+-- current shape instead would leave a fresh install failing one line later on
+-- "column source_data already exists".
+CREATE TABLE IF NOT EXISTS "public"."prompt_suggestions" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "brand_id" "uuid" NOT NULL,
+    "suggested_text" "text" NOT NULL,
+    "topic_name" "text",
+    "topic_id" "uuid",
+    "reason" "text",
+    "est_volume" integer,
+    "source" "text" DEFAULT 'llm'::"text" NOT NULL,
+    "status" "text" DEFAULT 'new'::"text" NOT NULL,
+    "added_prompt_id" "uuid",
+    "generated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "expires_at" timestamp with time zone DEFAULT ("now"() + '48:00:00'::interval) NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "prompt_suggestions_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "prompt_suggestions_source_check" CHECK (
+        "source" = ANY (ARRAY['llm'::"text", 'heuristic'::"text"])
+    ),
+    CONSTRAINT "prompt_suggestions_status_check" CHECK (
+        "status" = ANY (ARRAY['new'::"text", 'added'::"text", 'dismissed'::"text"])
+    ),
+    CONSTRAINT "prompt_suggestions_brand_id_fkey" FOREIGN KEY ("brand_id")
+        REFERENCES "public"."brands"("id") ON DELETE CASCADE,
+    CONSTRAINT "prompt_suggestions_topic_id_fkey" FOREIGN KEY ("topic_id")
+        REFERENCES "public"."topics"("id") ON DELETE SET NULL,
+    CONSTRAINT "prompt_suggestions_added_prompt_id_fkey" FOREIGN KEY ("added_prompt_id")
+        REFERENCES "public"."prompts"("id") ON DELETE SET NULL
+);
+
+ALTER TABLE "public"."prompt_suggestions" OWNER TO "postgres";
+
+CREATE INDEX IF NOT EXISTS "idx_prompt_suggestions_brand_status"
+    ON "public"."prompt_suggestions" ("brand_id", "status", "generated_at" DESC);
+
+-- One live suggestion per brand per text, case-insensitively. Partial on
+-- 'new' so an accepted or dismissed suggestion never blocks a later one.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_prompt_suggestions_brand_text_active"
+    ON "public"."prompt_suggestions" ("brand_id", "lower"("suggested_text"))
+    WHERE ("status" = 'new'::"text");
+
+ALTER TABLE "public"."prompt_suggestions" ENABLE ROW LEVEL SECURITY;
+
+-- Writes go through the Express server's service-role client; these cover the
+-- web app's direct reads and the accept/dismiss updates it performs.
+CREATE POLICY "prompt_suggestions: member select" ON "public"."prompt_suggestions"
+    FOR SELECT USING (
+        "brand_id" IN (
+            SELECT "b"."id"
+            FROM "public"."brands" "b"
+            JOIN "public"."profiles" "p" ON "p"."organization_id" = "b"."organization_id"
+            WHERE "p"."id" = "auth"."uid"()
+        )
+    );
+
+CREATE POLICY "prompt_suggestions: admin/manager/analyst update" ON "public"."prompt_suggestions"
+    FOR UPDATE USING (
+        "brand_id" IN (
+            SELECT "b"."id"
+            FROM "public"."brands" "b"
+            JOIN "public"."profiles" "p" ON "p"."organization_id" = "b"."organization_id"
+            WHERE "p"."id" = "auth"."uid"()
+              AND "p"."role" = ANY (ARRAY['admin'::"public"."user_role", 'manager'::"public"."user_role", 'analyst'::"public"."user_role"])
+        )
+    );
+
+GRANT ALL ON TABLE "public"."prompt_suggestions" TO "anon";
+GRANT ALL ON TABLE "public"."prompt_suggestions" TO "authenticated";
+GRANT ALL ON TABLE "public"."prompt_suggestions" TO "service_role";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+
 ALTER TABLE public.prompt_suggestions ADD COLUMN source_data jsonb;
 
 -- The live table's source check predates 'gsc' — extend it.


### PR DESCRIPTION
<!-- Thanks for contributing to Ansvisor! Please fill out the sections below. -->

## Summary

`prompt_suggestions` was created directly against the hosted database and never written back into a migration, so `00048`'s `ALTER TABLE` statements had nothing to alter on a clean one:

```
ERROR: relation "public.prompt_suggestions" does not exist (SQLSTATE 42P01)
```

`schema.sql` inherits the same gap, being a concatenation of the migrations, so **both documented fresh-install paths have been broken since 00048 shipped** — including in the v0.2.0 tag. Existing deployments were never affected: they already had the table.

This recovers the definition from the live database. Two decisions worth reviewing:

**It goes into `00048` itself, not a new numbered migration.** The very next statement alters this table, so anything appended at the end would never be reached. Editing a shipped migration is normally off-limits — `build-schema.sh` says as much — but every clause here is idempotent, and any database that already applied `00048` will not run it again, so this is a no-op for every existing install and the only change that makes the file self-consistent for a new one.

**It is deliberately the table as it was *before* the ALTERs that follow** — no `source_data` column, and the two-value source check. Transcribing a live database's current shape is the obvious move and is wrong: the live table has `source_data` and the three-value check precisely *because* `00048` already ran, so a fresh install would fail one line later on "column source_data already exists".

I also compared every table in a live database against the `CREATE TABLE` statements in all 50 migrations: this is the only one missing, so there is no second failure waiting behind it.

## Related issue

Closes #709

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

Verified end to end against a real local stack, both directions.

**On `main`, `supabase db reset` still fails exactly as reported:**

```
Applying migration 00048_gsc_suggestion_support.sql...
ERROR: relation "public.prompt_suggestions" does not exist (SQLSTATE 42P01)
At statement: 0 ... ALTER TABLE public.prompt_suggestions ADD COLUMN source_data jsonb
```

**On this branch it completes:**

```
Applying migration 00048_gsc_suggestion_support.sql...
Applying migration 00049_cloro_pending_tasks.sql...
Applying migration 00050_content_opportunity_aggregates.sql...
Applying migration 00051_brand_ga_property.sql...
Finished supabase db reset.
```

All 50 migrations apply on a clean database, and the resulting table matches production exactly: 15 columns, 6 constraints, 3 indexes, 2 policies, RLS enabled — including the three-value source check, which confirms the recovered two-value constraint is correctly replaced by the `ALTER` that follows it.

Independently of the local stack, the same migration was replayed against a clean table in an isolated schema on a production-shaped database and diffed column by column: every column matches on type, nullability and default, and all six constraints match.

To reproduce:

```bash
git checkout fix/709-prompt-suggestions-migration
npx supabase start          # or: npx supabase db reset
```

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

