### PR TITLE
feat(traffic): show the pages AI engines aren't sending traffic to

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/_opportunities-card.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/_opportunities-card.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Target } from 'lucide-react';
+import { getPageOpportunities, type PageOpportunity } from '@/lib/actions/traffic';
+
+/**
+ * Pages that carry weight and get nothing from AI engines (#719).
+ *
+ * Reads the nightly detection run rather than computing anything: the
+ * ranking, the signal and the evidence were decided server-side, and
+ * recomputing them here would let the card disagree with what the engine
+ * stored.
+ *
+ * Renders nothing at all when there are no findings — a brand without a
+ * mapped Analytics property should not meet an empty card explaining a
+ * feature it has not connected.
+ */
+
+/**
+ * How the ranking is described, in the words of the metric that produced it.
+ *
+ * The engine ranks on whatever the property reports — money where there is
+ * money, engagement where there is not — and this is the half that keeps the
+ * page honest about which. Calling an engagement rank "your most valuable
+ * page" would be a true sentence about the wrong thing.
+ */
+const SIGNAL_COPY: Record<
+  PageOpportunity['valueSignal'],
+  { label: string; column: string; explain: string }
+> = {
+  revenue: {
+    label: 'by revenue',
+    column: 'Revenue',
+    explain: 'Ranked by the revenue these pages produced.',
+  },
+  transactions: {
+    label: 'by orders',
+    column: 'Orders',
+    explain: 'Ranked by how many orders started on these pages.',
+  },
+  key_events: {
+    label: 'by conversions',
+    column: 'Conversions',
+    explain: 'Ranked by the conversions Analytics records on these pages.',
+  },
+  engagement: {
+    label: 'by engagement',
+    column: 'Engagement',
+    explain:
+      'Ranked by time on page, because this property reports no revenue or conversions. Set up key events in Analytics to rank these by what they earn instead.',
+  },
+};
+
+function signalValue(row: PageOpportunity): string {
+  if (row.valueSignal === 'revenue') return row.revenue.toLocaleString();
+  if (row.valueSignal === 'transactions') return row.transactions.toLocaleString();
+  if (row.valueSignal === 'key_events') return row.keyEvents.toLocaleString();
+  const minutes = Math.round(row.engagementSeconds / 60);
+  return `${minutes.toLocaleString()} min`;
+}
+
+export function PageOpportunitiesCard({ brandId }: { brandId: string }) {
+  // The loaded rows carry the brand they belong to, rather than a separate
+  // loading flag reset inside the effect: resetting state synchronously there
+  // costs a cascading render, and comparing the stored brand answers the same
+  // question — whose data is this — without one.
+  const [loaded, setLoaded] = useState<{ brandId: string; rows: PageOpportunity[] } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getPageOpportunities(brandId)
+      .then((rows) => {
+        if (!cancelled) setLoaded({ brandId, rows });
+      })
+      .catch((err) => {
+        // Best effort: this card is an addition to the page, and a failure
+        // here must not take the traffic analytics down with it.
+        console.error('Failed to load page opportunities:', err);
+        if (!cancelled) setLoaded({ brandId, rows: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [brandId]);
+
+  // While a brand switch is in flight the previous brand's findings must not
+  // render under the new brand's name.
+  if (loaded?.brandId !== brandId || loaded.rows.length === 0) return null;
+
+  const rows = loaded.rows;
+  const copy = SIGNAL_COPY[rows[0].valueSignal];
+  const windowDays = rows[0].windowDays;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <Target className="h-4 w-4 text-muted-foreground" />
+            Pages AI engines aren&apos;t sending traffic to
+          </CardTitle>
+          <Badge variant="outline" className="text-xs">
+            Google Analytics · last {windowDays} days
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {copy.explain} None of these received a visit from an AI assistant in the window.
+        </p>
+      </CardHeader>
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-6">Page</TableHead>
+              <TableHead className="text-right">Sessions</TableHead>
+              <TableHead className="text-right">{copy.column}</TableHead>
+              <TableHead className="text-right pr-6">Rank {copy.label}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.landingPage} className="hover:bg-muted/50">
+                <TableCell className="pl-6 max-w-[280px]">
+                  <span className="font-mono text-xs text-muted-foreground line-clamp-1">
+                    {row.landingPage}
+                  </span>
+                </TableCell>
+                <TableCell className="text-right tabular-nums text-sm">
+                  {row.sessions.toLocaleString()}
+                </TableCell>
+                <TableCell className="text-right font-semibold tabular-nums text-sm">
+                  {signalValue(row)}
+                </TableCell>
+                <TableCell className="text-right pr-6 tabular-nums text-sm text-muted-foreground">
+                  #{row.valueRank}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/traffic/page.tsx
@@ -33,6 +33,7 @@ import {
   DateRangeFilter,
   type DateRangePreset,
 } from '@/components/filters/date-range-filter';
+import { PageOpportunitiesCard } from './_opportunities-card';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -823,6 +824,13 @@ function TrafficPageContent({ brand }: { brand: Brand }) {
               </CardContent>
             </Card>
           </div>
+
+          {/* Findings from the Analytics connection (#719). Renders nothing
+              for brands without a mapped property, so the page is unchanged
+              for everyone who has not connected one. Kept visually distinct
+              from the tables above, which count the tracking snippet's own
+              visits — the two origins are never summed. */}
+          <PageOpportunitiesCard brandId={brand.id} />
 
           {/* Recent Visit Log with filtering and pagination*/}
           <Card>

--- a/web/src/lib/actions/reports.ts
+++ b/web/src/lib/actions/reports.ts
@@ -697,13 +697,13 @@ async function getReportVisibilityRate(
     getTrackedPromptsKpi(brandId, range),
     supabase.rpc('ai_visibility_aggregates', {
       p_brand_id: brandId,
-      p_platform: null,
-      p_models: null,
-      p_region: null,
+      p_platform: undefined,
+      p_models: undefined,
+      p_region: undefined,
       p_date_from: range.dateFrom,
       p_date_to: range.dateTo,
-      p_prompt_id: null,
-      p_topic_id: null,
+      p_prompt_id: undefined,
+      p_topic_id: undefined,
     }),
   ]);
   const promptCount = tracked.activeInPeriod;

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -165,13 +165,13 @@ export interface InsightsSummary {
  * applyModelFilter does for the buildResultsQuery path so the two callers
  * stay equivalent.
  */
-function modelFilterArray(model: string | undefined): string[] | null {
-  if (!model) return null;
+function modelFilterArray(model: string | undefined): string[] | undefined {
+  if (!model) return undefined;
   const list = model
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
-  return list.length > 0 ? list : null;
+  return list.length > 0 ? list : undefined;
 }
 
 // ── RPC return shapes (mirror supabase/migrations/00031_insights_sentiment_denominator.sql) ─
@@ -414,12 +414,12 @@ export async function getVisibilityRateKpi(
 
   const { data, error } = await supabase.rpc('visible_prompt_stats', {
     p_brand_id: brandId,
-    p_platform: null,
+    p_platform: undefined,
     p_models: modelFilterArray(opts?.model),
-    p_region: opts?.region ?? null,
-    p_date_from: opts?.dateFrom ?? null,
-    p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? null,
-    p_topic_id: opts?.topicId ?? null,
+    p_region: opts?.region ?? undefined,
+    p_date_from: opts?.dateFrom ?? undefined,
+    p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? undefined,
+    p_topic_id: opts?.topicId ?? undefined,
   });
   if (error) throw new Error(error.message);
 
@@ -474,12 +474,12 @@ export async function getTrackedPromptsKpi(
   const [rpcResult, plan, quotaUsed] = await Promise.all([
     supabase.rpc('tracked_prompt_count', {
       p_brand_id: brandId,
-      p_platform: null,
+      p_platform: undefined,
       p_models: modelFilterArray(opts?.model),
-      p_region: opts?.region ?? null,
-      p_date_from: opts?.dateFrom ?? null,
-      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? null,
-      p_topic_id: opts?.topicId ?? null,
+      p_region: opts?.region ?? undefined,
+      p_date_from: opts?.dateFrom ?? undefined,
+      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? undefined,
+      p_topic_id: opts?.topicId ?? undefined,
     }),
     orgId ? getOrgPlan(orgId) : Promise.resolve(null),
     countOrgPrompts(),
@@ -1138,17 +1138,17 @@ export async function getInsightsSummary(
   // reducer math exactly (verified by the parity test in 00006).
   const baseArgs = {
     p_brand_id: brandId,
-    p_platform: null as string | null,
+    p_platform: undefined as string | undefined,
     p_models,
-    p_region: opts?.region ?? null,
-    p_prompt_id: null as string | null,
-    p_topic_id: opts?.topicId ?? null,
+    p_region: opts?.region ?? undefined,
+    p_prompt_id: undefined as string | undefined,
+    p_topic_id: opts?.topicId ?? undefined,
   };
 
   const { data: curData, error } = await supabase.rpc('insights_aggregates', {
     ...baseArgs,
-    p_date_from: opts?.dateFrom ?? null,
-    p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? null,
+    p_date_from: opts?.dateFrom ?? undefined,
+    p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? undefined,
   });
   if (error) throw new Error(error.message);
 
@@ -1229,7 +1229,7 @@ export async function getInsightsSummary(
       supabase.rpc('insights_aggregates', {
         ...baseArgs,
         p_date_from: opts?.dateFrom ?? currentFrom.toISOString(),
-        p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? null,
+        p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? undefined,
       }),
       supabase.rpc('insights_aggregates', {
         ...baseArgs,
@@ -1456,7 +1456,7 @@ export async function getPromptVisibilitySummaries(
   const { data, error } = await supabase.rpc('prompt_visibility_summaries', {
     p_brand_id: brandId,
     p_date_from: since,
-    p_date_to: opts?.to ?? null,
+    p_date_to: opts?.to ?? undefined,
   });
 
   if (error) throw new Error(error.message);
@@ -1698,11 +1698,11 @@ export async function getCompetitorComparison(
 
   const baseArgs = {
     p_brand_id: brandId,
-    p_platform: null as string | null,
+    p_platform: undefined as string | undefined,
     p_models,
-    p_region: opts?.region ?? null,
-    p_prompt_id: null as string | null,
-    p_topic_id: opts?.topicId ?? null,
+    p_region: opts?.region ?? undefined,
+    p_prompt_id: undefined as string | undefined,
+    p_topic_id: opts?.topicId ?? undefined,
   };
 
   // Brand name + the displayed-period aggregates fire in parallel — all
@@ -1711,13 +1711,13 @@ export async function getCompetitorComparison(
     supabase.from('brands').select('name').eq('id', brandId).single(),
     supabase.rpc('competitor_aggregates', {
       ...baseArgs,
-      p_date_from: opts?.dateFrom ?? null,
-      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? null,
+      p_date_from: opts?.dateFrom ?? undefined,
+      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? undefined,
     }),
     supabase.rpc('ai_visibility_aggregates', {
       ...baseArgs,
-      p_date_from: opts?.dateFrom ?? null,
-      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? null,
+      p_date_from: opts?.dateFrom ?? undefined,
+      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? undefined,
     }),
   ]);
   if (aggErr) throw new Error(aggErr.message);
@@ -1751,7 +1751,7 @@ export async function getCompetitorComparison(
     supabase.rpc('competitor_aggregates', {
       ...baseArgs,
       p_date_from: opts?.dateFrom ?? currentFrom.toISOString(),
-      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? null,
+      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? undefined,
     }),
     supabase.rpc('competitor_aggregates', {
       ...baseArgs,
@@ -1968,11 +1968,11 @@ export async function getShareOfVoiceData(
 
   const baseArgs = {
     p_brand_id: brandId,
-    p_platform: null as string | null,
+    p_platform: undefined as string | undefined,
     p_models,
-    p_region: opts?.region ?? null,
-    p_prompt_id: null as string | null,
-    p_topic_id: opts?.topicId ?? null,
+    p_region: opts?.region ?? undefined,
+    p_prompt_id: undefined as string | undefined,
+    p_topic_id: opts?.topicId ?? undefined,
   };
 
   // Current-period aggregate + previous-period aggregate run in parallel —
@@ -1995,8 +1995,8 @@ export async function getShareOfVoiceData(
   const [{ data: curData, error: curErr }, { data: prevData, error: prevErr }] = await Promise.all([
     supabase.rpc('share_of_voice_aggregates', {
       ...baseArgs,
-      p_date_from: opts?.dateFrom ?? null,
-      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? null,
+      p_date_from: opts?.dateFrom ?? undefined,
+      p_date_to: expandDateToEndOfDay(opts?.dateTo) ?? undefined,
     }),
     supabase.rpc('share_of_voice_aggregates', {
       ...baseArgs,
@@ -2167,7 +2167,10 @@ export async function getVisibilityRateTrend(
   // No explicit lower bound = the "All time" preset: the summary covers
   // everything (matching the leaderboard) and the chart plots an expanding
   // cumulative window instead of a fixed-length rolling one.
-  const boundedFrom = opts?.dateFrom ?? null;
+  // undefined rather than null: these flow straight into RPC arguments, where
+  // an omitted key takes the function's own DEFAULT NULL. "All time" is the
+  // absence of a bound, and undefined is how that is spelled at this boundary.
+  const boundedFrom = opts?.dateFrom ?? undefined;
   const dateTo = expandDateToEndOfDay(opts?.dateTo) ?? new Date().toISOString();
 
   // Equal-length window immediately before, for the headline delta
@@ -2178,17 +2181,17 @@ export async function getVisibilityRateTrend(
   const prevFrom =
     boundedFrom && windowMs !== null
       ? new Date(new Date(boundedFrom).getTime() - windowMs).toISOString()
-      : null;
+      : undefined;
   const prevTo = boundedFrom;
 
-  const rateArgs = (from: string | null, to: string) => ({
+  const rateArgs = (from: string | undefined, to: string) => ({
     p_brand_id: brandId,
-    p_platform: null as string | null,
+    p_platform: undefined as string | undefined,
     p_models: modelFilterArray(opts?.model),
-    p_region: opts?.region ?? null,
+    p_region: opts?.region ?? undefined,
     p_date_from: from,
     p_date_to: to,
-    p_topic_id: opts?.topicId ?? null,
+    p_topic_id: opts?.topicId ?? undefined,
   });
 
   const [

--- a/web/src/lib/actions/traffic.ts
+++ b/web/src/lib/actions/traffic.ts
@@ -334,3 +334,63 @@ export async function getTrafficLogs(
     total: count ?? 0,
   };
 }
+
+/**
+ * Pages that carry commercial weight and get nothing from AI engines (#719).
+ *
+ * Read straight from the detection engine's table — the ranking, the signal
+ * and the evidence were all decided server-side during the nightly run, so
+ * this reads them rather than recomputing anything.
+ *
+ * Deliberately unfiltered by the page's date range: the findings describe the
+ * engine's own 28-day window, and re-scoping them to an arbitrary range would
+ * mean showing a ranking that was never computed for it.
+ */
+export interface PageOpportunity {
+  landingPage: string;
+  /** Which metric ranked this page — never present it as anything else. */
+  valueSignal: 'revenue' | 'transactions' | 'key_events' | 'engagement';
+  valuePercentile: number;
+  valueRank: number;
+  sessions: number;
+  engagedSessions: number;
+  keyEvents: number;
+  transactions: number;
+  revenue: number;
+  engagementSeconds: number;
+  windowDays: number;
+  firstDetectedAt: string;
+}
+
+export async function getPageOpportunities(
+  brandId: string,
+  opts?: { limit?: number },
+): Promise<PageOpportunity[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('page_opportunities')
+    .select(
+      'landing_page, value_signal, value_percentile, value_rank, sessions, engaged_sessions, key_events, transactions, revenue, engagement_seconds, window_days, first_detected_at',
+    )
+    .eq('brand_id', brandId)
+    .is('resolved_at', null)
+    .order('value_percentile', { ascending: false })
+    .limit(opts?.limit ?? 10);
+
+  if (error) throw new Error(error.message);
+
+  return (data ?? []).map((row) => ({
+    landingPage: row.landing_page as string,
+    valueSignal: row.value_signal as PageOpportunity['valueSignal'],
+    valuePercentile: Number(row.value_percentile) || 0,
+    valueRank: Number(row.value_rank) || 0,
+    sessions: Number(row.sessions) || 0,
+    engagedSessions: Number(row.engaged_sessions) || 0,
+    keyEvents: Number(row.key_events) || 0,
+    transactions: Number(row.transactions) || 0,
+    revenue: Number(row.revenue) || 0,
+    engagementSeconds: Number(row.engagement_seconds) || 0,
+    windowDays: Number(row.window_days) || 0,
+    firstDetectedAt: row.first_detected_at as string,
+  }));
+}

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -4,1892 +4,2477 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: '14.1';
-  };
+    PostgrestVersion: "14.1"
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       agent_conversations: {
         Row: {
-          id: string;
-          user_id: string;
-          organization_id: string;
-          brand_id: string | null;
-          title: string;
-          created_at: string;
-          updated_at: string;
-        };
+          brand_id: string | null
+          created_at: string
+          id: string
+          organization_id: string
+          title: string
+          updated_at: string
+          user_id: string
+        }
         Insert: {
-          id?: string;
-          user_id: string;
-          organization_id: string;
-          brand_id?: string | null;
-          title?: string;
-          created_at?: string;
-          updated_at?: string;
-        };
+          brand_id?: string | null
+          created_at?: string
+          id?: string
+          organization_id: string
+          title?: string
+          updated_at?: string
+          user_id: string
+        }
         Update: {
-          id?: string;
-          user_id?: string;
-          organization_id?: string;
-          brand_id?: string | null;
-          title?: string;
-          created_at?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          brand_id?: string | null
+          created_at?: string
+          id?: string
+          organization_id?: string
+          title?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "agent_conversations_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "agent_conversations_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       agent_messages: {
         Row: {
-          id: string;
-          conversation_id: string;
-          role: 'user' | 'assistant' | 'tool';
-          content: string;
-          tool_calls: Json | null;
-          tool_call_id: string | null;
-          tool_name: string | null;
-          tool_result: Json | null;
-          prompt_tokens: number | null;
-          completion_tokens: number | null;
-          created_at: string;
-        };
+          completion_tokens: number | null
+          content: string
+          conversation_id: string
+          created_at: string
+          id: string
+          prompt_tokens: number | null
+          role: string
+          tool_call_id: string | null
+          tool_calls: Json | null
+          tool_name: string | null
+          tool_result: Json | null
+        }
         Insert: {
-          id?: string;
-          conversation_id: string;
-          role: 'user' | 'assistant' | 'tool';
-          content?: string;
-          tool_calls?: Json | null;
-          tool_call_id?: string | null;
-          tool_name?: string | null;
-          tool_result?: Json | null;
-          prompt_tokens?: number | null;
-          completion_tokens?: number | null;
-          created_at?: string;
-        };
+          completion_tokens?: number | null
+          content?: string
+          conversation_id: string
+          created_at?: string
+          id?: string
+          prompt_tokens?: number | null
+          role: string
+          tool_call_id?: string | null
+          tool_calls?: Json | null
+          tool_name?: string | null
+          tool_result?: Json | null
+        }
         Update: {
-          id?: string;
-          conversation_id?: string;
-          role?: 'user' | 'assistant' | 'tool';
-          content?: string;
-          tool_calls?: Json | null;
-          tool_call_id?: string | null;
-          tool_name?: string | null;
-          tool_result?: Json | null;
-          prompt_tokens?: number | null;
-          completion_tokens?: number | null;
-          created_at?: string;
-        };
-        Relationships: [];
-      };
+          completion_tokens?: number | null
+          content?: string
+          conversation_id?: string
+          created_at?: string
+          id?: string
+          prompt_tokens?: number | null
+          role?: string
+          tool_call_id?: string | null
+          tool_calls?: Json | null
+          tool_name?: string | null
+          tool_result?: Json | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "agent_messages_conversation_id_fkey"
+            columns: ["conversation_id"]
+            isOneToOne: false
+            referencedRelation: "agent_conversations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       agent_token_usage: {
         Row: {
-          id: string;
-          user_id: string;
-          organization_id: string;
-          year_month: string;
-          prompt_tokens: number;
-          completion_tokens: number;
-          created_at: string;
-          updated_at: string;
-        };
+          completion_tokens: number
+          created_at: string
+          id: string
+          organization_id: string
+          prompt_tokens: number
+          updated_at: string
+          user_id: string
+          year_month: string
+        }
         Insert: {
-          id?: string;
-          user_id: string;
-          organization_id: string;
-          year_month: string;
-          prompt_tokens?: number;
-          completion_tokens?: number;
-          created_at?: string;
-          updated_at?: string;
-        };
+          completion_tokens?: number
+          created_at?: string
+          id?: string
+          organization_id: string
+          prompt_tokens?: number
+          updated_at?: string
+          user_id: string
+          year_month: string
+        }
         Update: {
-          id?: string;
-          user_id?: string;
-          organization_id?: string;
-          year_month?: string;
-          prompt_tokens?: number;
-          completion_tokens?: number;
-          created_at?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
-      api_keys: {
-        Row: {
-          id: string;
-          user_id: string;
-          name: string;
-          prefix: string;
-          key_hash: string;
-          last_used_at: string | null;
-          revoked_at: string | null;
-          created_at: string;
-        };
-        Insert: {
-          id?: string;
-          user_id: string;
-          name: string;
-          prefix: string;
-          key_hash: string;
-          last_used_at?: string | null;
-          revoked_at?: string | null;
-          created_at?: string;
-        };
-        Update: {
-          id?: string;
-          user_id?: string;
-          name?: string;
-          prefix?: string;
-          key_hash?: string;
-          last_used_at?: string | null;
-          revoked_at?: string | null;
-          created_at?: string;
-        };
-        Relationships: [];
-      };
+          completion_tokens?: number
+          created_at?: string
+          id?: string
+          organization_id?: string
+          prompt_tokens?: number
+          updated_at?: string
+          user_id?: string
+          year_month?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "agent_token_usage_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       ai_traffic_logs: {
         Row: {
-          brand_id: string;
-          country: string | null;
-          created_at: string;
-          id: string;
-          ip_address: string | null;
-          language: string | null;
-          referrer: string | null;
-          screen: string | null;
-          source_platform: string | null;
-          url: string;
-          user_agent: string | null;
-        };
+          brand_id: string
+          country: string | null
+          created_at: string
+          id: string
+          ip_address: string | null
+          language: string | null
+          referrer: string | null
+          screen: string | null
+          source_platform: string | null
+          url: string
+          user_agent: string | null
+        }
         Insert: {
-          brand_id: string;
-          country?: string | null;
-          created_at?: string;
-          id?: string;
-          ip_address?: string | null;
-          language?: string | null;
-          referrer?: string | null;
-          screen?: string | null;
-          source_platform?: string | null;
-          url: string;
-          user_agent?: string | null;
-        };
+          brand_id: string
+          country?: string | null
+          created_at?: string
+          id?: string
+          ip_address?: string | null
+          language?: string | null
+          referrer?: string | null
+          screen?: string | null
+          source_platform?: string | null
+          url: string
+          user_agent?: string | null
+        }
         Update: {
-          brand_id?: string;
-          country?: string | null;
-          created_at?: string;
-          id?: string;
-          ip_address?: string | null;
-          language?: string | null;
-          referrer?: string | null;
-          screen?: string | null;
-          source_platform?: string | null;
-          url?: string;
-          user_agent?: string | null;
-        };
+          brand_id?: string
+          country?: string | null
+          created_at?: string
+          id?: string
+          ip_address?: string | null
+          language?: string | null
+          referrer?: string | null
+          screen?: string | null
+          source_platform?: string | null
+          url?: string
+          user_agent?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'ai_traffic_logs_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "ai_traffic_logs_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
+      api_keys: {
+        Row: {
+          created_at: string
+          id: string
+          key_hash: string
+          last_used_at: string | null
+          name: string
+          prefix: string
+          revoked_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          key_hash: string
+          last_used_at?: string | null
+          name: string
+          prefix: string
+          revoked_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          key_hash?: string
+          last_used_at?: string | null
+          name?: string
+          prefix?: string
+          revoked_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      audit_signal_results: {
+        Row: {
+          audit_id: string
+          category: string | null
+          created_at: string
+          evidence: Json
+          id: string
+          score: number | null
+          signal_key: string
+          status: string
+        }
+        Insert: {
+          audit_id: string
+          category?: string | null
+          created_at?: string
+          evidence?: Json
+          id?: string
+          score?: number | null
+          signal_key: string
+          status: string
+        }
+        Update: {
+          audit_id?: string
+          category?: string | null
+          created_at?: string
+          evidence?: Json
+          id?: string
+          score?: number | null
+          signal_key?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "audit_signal_results_audit_id_fkey"
+            columns: ["audit_id"]
+            isOneToOne: false
+            referencedRelation: "site_audits"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       brand_domains: {
         Row: {
-          brand_id: string;
-          country: string | null;
-          created_at: string;
-          domain: string;
-          id: string;
-          is_primary: boolean;
-        };
+          brand_id: string
+          country: string | null
+          created_at: string
+          domain: string
+          id: string
+          is_primary: boolean
+        }
         Insert: {
-          brand_id: string;
-          country?: string | null;
-          created_at?: string;
-          domain: string;
-          id?: string;
-          is_primary?: boolean;
-        };
+          brand_id: string
+          country?: string | null
+          created_at?: string
+          domain: string
+          id?: string
+          is_primary?: boolean
+        }
         Update: {
-          brand_id?: string;
-          country?: string | null;
-          created_at?: string;
-          domain?: string;
-          id?: string;
-          is_primary?: boolean;
-        };
+          brand_id?: string
+          country?: string | null
+          created_at?: string
+          domain?: string
+          id?: string
+          is_primary?: boolean
+        }
         Relationships: [
           {
-            foreignKeyName: 'brand_domains_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "brand_domains_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       brand_platforms: {
         Row: {
-          api_model: string | null;
-          brand_id: string;
-          check_frequency: string;
-          created_at: string;
-          id: string;
-          is_enabled: boolean;
-          last_checked_at: string | null;
-          platform: string;
-          updated_at: string;
-        };
+          api_model: string | null
+          brand_id: string
+          check_frequency: string
+          created_at: string
+          id: string
+          is_enabled: boolean
+          last_checked_at: string | null
+          platform: string
+          updated_at: string
+        }
         Insert: {
-          api_model?: string | null;
-          brand_id: string;
-          check_frequency?: string;
-          created_at?: string;
-          id?: string;
-          is_enabled?: boolean;
-          last_checked_at?: string | null;
-          platform: string;
-          updated_at?: string;
-        };
+          api_model?: string | null
+          brand_id: string
+          check_frequency?: string
+          created_at?: string
+          id?: string
+          is_enabled?: boolean
+          last_checked_at?: string | null
+          platform: string
+          updated_at?: string
+        }
         Update: {
-          api_model?: string | null;
-          brand_id?: string;
-          check_frequency?: string;
-          created_at?: string;
-          id?: string;
-          is_enabled?: boolean;
-          last_checked_at?: string | null;
-          platform?: string;
-          updated_at?: string;
-        };
+          api_model?: string | null
+          brand_id?: string
+          check_frequency?: string
+          created_at?: string
+          id?: string
+          is_enabled?: boolean
+          last_checked_at?: string | null
+          platform?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'brand_platforms_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "brand_platforms_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       brands: {
         Row: {
-          created_at: string;
-          description: string | null;
-          id: string;
-          ga_property_id: string | null;
-          gsc_property: string | null;
-          industry: string | null;
-          is_active: boolean;
-          language: string | null;
-          logo_url: string | null;
-          name: string;
-          organization_id: string;
-          region: string | null;
-          shopping_mode_enabled: boolean;
-          slug: string;
-          state: string | null;
-          tracking_code: string;
-          updated_at: string;
-        };
+          created_at: string
+          description: string | null
+          ga_property_id: string | null
+          gsc_property: string | null
+          id: string
+          industry: string | null
+          is_active: boolean
+          language: string | null
+          logo_url: string | null
+          name: string
+          organization_id: string
+          region: string | null
+          shopping_mode_enabled: boolean
+          slug: string
+          state: string | null
+          tracking_code: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          description?: string | null;
-          id?: string;
-          ga_property_id?: string | null;
-          gsc_property?: string | null;
-          industry?: string | null;
-          is_active?: boolean;
-          language?: string | null;
-          logo_url?: string | null;
-          name: string;
-          organization_id: string;
-          region?: string | null;
-          shopping_mode_enabled?: boolean;
-          slug: string;
-          state?: string | null;
-          tracking_code?: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          description?: string | null
+          ga_property_id?: string | null
+          gsc_property?: string | null
+          id?: string
+          industry?: string | null
+          is_active?: boolean
+          language?: string | null
+          logo_url?: string | null
+          name: string
+          organization_id: string
+          region?: string | null
+          shopping_mode_enabled?: boolean
+          slug: string
+          state?: string | null
+          tracking_code?: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          description?: string | null;
-          id?: string;
-          ga_property_id?: string | null;
-          gsc_property?: string | null;
-          industry?: string | null;
-          is_active?: boolean;
-          language?: string | null;
-          logo_url?: string | null;
-          name?: string;
-          organization_id?: string;
-          region?: string | null;
-          shopping_mode_enabled?: boolean;
-          slug?: string;
-          state?: string | null;
-          tracking_code?: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          description?: string | null
+          ga_property_id?: string | null
+          gsc_property?: string | null
+          id?: string
+          industry?: string | null
+          is_active?: boolean
+          language?: string | null
+          logo_url?: string | null
+          name?: string
+          organization_id?: string
+          region?: string | null
+          shopping_mode_enabled?: boolean
+          slug?: string
+          state?: string | null
+          tracking_code?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'brands_organization_id_fkey';
-            columns: ['organization_id'];
-            isOneToOne: false;
-            referencedRelation: 'organizations';
-            referencedColumns: ['id'];
+            foreignKeyName: "brands_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
+      brief_usage: {
+        Row: {
+          created_at: string | null
+          id: string
+          opportunity_id: string | null
+          organization_id: string
+          used_at: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          opportunity_id?: string | null
+          organization_id: string
+          used_at?: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          opportunity_id?: string | null
+          organization_id?: string
+          used_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "brief_usage_opportunity_id_fkey"
+            columns: ["opportunity_id"]
+            isOneToOne: false
+            referencedRelation: "content_opportunities"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "brief_usage_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       cloro_pending_tasks: {
         Row: {
-          brand_id: string;
-          prompt_id: string;
-          region: string | null;
-          scraper_id: string;
-          submitted_at: string;
-          task_id: string;
-        };
+          brand_id: string
+          prompt_id: string
+          region: string | null
+          scraper_id: string
+          submitted_at: string
+          task_id: string
+        }
         Insert: {
-          brand_id: string;
-          prompt_id: string;
-          region?: string | null;
-          scraper_id: string;
-          submitted_at?: string;
-          task_id: string;
-        };
+          brand_id: string
+          prompt_id: string
+          region?: string | null
+          scraper_id: string
+          submitted_at?: string
+          task_id: string
+        }
         Update: {
-          brand_id?: string;
-          prompt_id?: string;
-          region?: string | null;
-          scraper_id?: string;
-          submitted_at?: string;
-          task_id?: string;
-        };
+          brand_id?: string
+          prompt_id?: string
+          region?: string | null
+          scraper_id?: string
+          submitted_at?: string
+          task_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'cloro_pending_tasks_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "cloro_pending_tasks_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'cloro_pending_tasks_prompt_id_fkey';
-            columns: ['prompt_id'];
-            isOneToOne: false;
-            referencedRelation: 'prompts';
-            referencedColumns: ['id'];
+            foreignKeyName: "cloro_pending_tasks_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       competitors: {
         Row: {
-          brand_id: string;
-          created_at: string;
-          domain: string;
-          id: string;
-          name: string;
-        };
+          brand_id: string
+          created_at: string
+          domain: string
+          id: string
+          name: string
+        }
         Insert: {
-          brand_id: string;
-          created_at?: string;
-          domain?: string;
-          id?: string;
-          name: string;
-        };
+          brand_id: string
+          created_at?: string
+          domain?: string
+          id?: string
+          name: string
+        }
         Update: {
-          brand_id?: string;
-          created_at?: string;
-          domain?: string;
-          id?: string;
-          name?: string;
-        };
+          brand_id?: string
+          created_at?: string
+          domain?: string
+          id?: string
+          name?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'competitors_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "competitors_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       content_opportunities: {
         Row: {
-          brand_id: string;
-          created_at: string | null;
-          description: string | null;
-          id: string;
-          impact: string;
-          opportunity_score: number | null;
-          prompt_id: string | null;
-          source_data: Json | null;
-          status: string;
-          title: string;
-          type: string;
-          updated_at: string | null;
-          webhook_response: Json | null;
-          webhook_sent_at: string | null;
-        };
+          brand_id: string
+          brief: Json | null
+          created_at: string | null
+          description: string | null
+          id: string
+          impact: string
+          opportunity_score: number | null
+          prompt_id: string | null
+          source_data: Json | null
+          status: string
+          title: string
+          type: string
+          updated_at: string | null
+          webhook_response: Json | null
+          webhook_sent_at: string | null
+        }
         Insert: {
-          brand_id: string;
-          created_at?: string | null;
-          description?: string | null;
-          id?: string;
-          impact?: string;
-          opportunity_score?: number | null;
-          prompt_id?: string | null;
-          source_data?: Json | null;
-          status?: string;
-          title: string;
-          type?: string;
-          updated_at?: string | null;
-          webhook_response?: Json | null;
-          webhook_sent_at?: string | null;
-        };
+          brand_id: string
+          brief?: Json | null
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          impact?: string
+          opportunity_score?: number | null
+          prompt_id?: string | null
+          source_data?: Json | null
+          status?: string
+          title: string
+          type?: string
+          updated_at?: string | null
+          webhook_response?: Json | null
+          webhook_sent_at?: string | null
+        }
         Update: {
-          brand_id?: string;
-          created_at?: string | null;
-          description?: string | null;
-          id?: string;
-          impact?: string;
-          opportunity_score?: number | null;
-          prompt_id?: string | null;
-          source_data?: Json | null;
-          status?: string;
-          title?: string;
-          type?: string;
-          updated_at?: string | null;
-          webhook_response?: Json | null;
-          webhook_sent_at?: string | null;
-        };
+          brand_id?: string
+          brief?: Json | null
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          impact?: string
+          opportunity_score?: number | null
+          prompt_id?: string | null
+          source_data?: Json | null
+          status?: string
+          title?: string
+          type?: string
+          updated_at?: string | null
+          webhook_response?: Json | null
+          webhook_sent_at?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'content_opportunities_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "content_opportunities_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'content_opportunities_prompt_id_fkey';
-            columns: ['prompt_id'];
-            isOneToOne: false;
-            referencedRelation: 'prompts';
-            referencedColumns: ['id'];
+            foreignKeyName: "content_opportunities_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       dataforseo_competition_cache: {
         Row: {
-          competition: string | null;
-          competition_index: number | null;
-          fetched_at: string;
-          keyword: string;
-          language_code: string;
-          location_code: number;
-        };
+          competition: string | null
+          competition_index: number | null
+          fetched_at: string
+          keyword: string
+          language_code: string
+          location_code: number
+        }
         Insert: {
-          competition?: string | null;
-          competition_index?: number | null;
-          fetched_at?: string;
-          keyword: string;
-          language_code?: string;
-          location_code?: number;
-        };
+          competition?: string | null
+          competition_index?: number | null
+          fetched_at?: string
+          keyword: string
+          language_code?: string
+          location_code?: number
+        }
         Update: {
-          competition?: string | null;
-          competition_index?: number | null;
-          fetched_at?: string;
-          keyword?: string;
-          language_code?: string;
-          location_code?: number;
-        };
-        Relationships: [];
-      };
+          competition?: string | null
+          competition_index?: number | null
+          fetched_at?: string
+          keyword?: string
+          language_code?: string
+          location_code?: number
+        }
+        Relationships: []
+      }
+      fanout_query_intents: {
+        Row: {
+          created_at: string
+          intent: string
+          query: string
+        }
+        Insert: {
+          created_at?: string
+          intent: string
+          query: string
+        }
+        Update: {
+          created_at?: string
+          intent?: string
+          query?: string
+        }
+        Relationships: []
+      }
+      ga_ai_traffic_stats: {
+        Row: {
+          brand_id: string
+          created_at: string
+          date: string
+          engaged_sessions: number
+          engagement_duration_seconds: number
+          id: string
+          key_events: number
+          landing_page: string
+          landing_page_query: string
+          platform: string | null
+          purchase_revenue: number
+          sessions: number
+          source: string
+          total_users: number
+          transactions: number
+        }
+        Insert: {
+          brand_id: string
+          created_at?: string
+          date: string
+          engaged_sessions?: number
+          engagement_duration_seconds?: number
+          id?: string
+          key_events?: number
+          landing_page?: string
+          landing_page_query?: string
+          platform?: string | null
+          purchase_revenue?: number
+          sessions?: number
+          source: string
+          total_users?: number
+          transactions?: number
+        }
+        Update: {
+          brand_id?: string
+          created_at?: string
+          date?: string
+          engaged_sessions?: number
+          engagement_duration_seconds?: number
+          id?: string
+          key_events?: number
+          landing_page?: string
+          landing_page_query?: string
+          platform?: string | null
+          purchase_revenue?: number
+          sessions?: number
+          source?: string
+          total_users?: number
+          transactions?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ga_ai_traffic_stats_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      ga_item_stats: {
+        Row: {
+          brand_id: string
+          created_at: string
+          date: string
+          id: string
+          item_category: string
+          item_id: string
+          item_name: string
+          item_revenue: number
+          items_added_to_cart: number
+          items_purchased: number
+          items_viewed: number
+        }
+        Insert: {
+          brand_id: string
+          created_at?: string
+          date: string
+          id?: string
+          item_category?: string
+          item_id?: string
+          item_name?: string
+          item_revenue?: number
+          items_added_to_cart?: number
+          items_purchased?: number
+          items_viewed?: number
+        }
+        Update: {
+          brand_id?: string
+          created_at?: string
+          date?: string
+          id?: string
+          item_category?: string
+          item_id?: string
+          item_name?: string
+          item_revenue?: number
+          items_added_to_cart?: number
+          items_purchased?: number
+          items_viewed?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ga_item_stats_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      ga_page_stats: {
+        Row: {
+          brand_id: string
+          created_at: string
+          date: string
+          engaged_sessions: number
+          engagement_duration_seconds: number
+          id: string
+          key_events: number
+          landing_page: string
+          purchase_revenue: number
+          sessions: number
+          total_users: number
+          transactions: number
+        }
+        Insert: {
+          brand_id: string
+          created_at?: string
+          date: string
+          engaged_sessions?: number
+          engagement_duration_seconds?: number
+          id?: string
+          key_events?: number
+          landing_page?: string
+          purchase_revenue?: number
+          sessions?: number
+          total_users?: number
+          transactions?: number
+        }
+        Update: {
+          brand_id?: string
+          created_at?: string
+          date?: string
+          engaged_sessions?: number
+          engagement_duration_seconds?: number
+          id?: string
+          key_events?: number
+          landing_page?: string
+          purchase_revenue?: number
+          sessions?: number
+          total_users?: number
+          transactions?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ga_page_stats_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       gsc_query_stats: {
         Row: {
-          brand_id: string;
-          clicks: number;
-          created_at: string;
-          ctr: number;
-          date: string;
-          id: string;
-          impressions: number;
-          position: number;
-          query: string;
-        };
+          brand_id: string
+          clicks: number
+          created_at: string
+          ctr: number
+          date: string
+          id: string
+          impressions: number
+          position: number
+          query: string
+        }
         Insert: {
-          brand_id: string;
-          clicks?: number;
-          created_at?: string;
-          ctr?: number;
-          date: string;
-          id?: string;
-          impressions?: number;
-          position?: number;
-          query: string;
-        };
+          brand_id: string
+          clicks?: number
+          created_at?: string
+          ctr?: number
+          date: string
+          id?: string
+          impressions?: number
+          position?: number
+          query: string
+        }
         Update: {
-          brand_id?: string;
-          clicks?: number;
-          created_at?: string;
-          ctr?: number;
-          date?: string;
-          id?: string;
-          impressions?: number;
-          position?: number;
-          query?: string;
-        };
+          brand_id?: string
+          clicks?: number
+          created_at?: string
+          ctr?: number
+          date?: string
+          id?: string
+          impressions?: number
+          position?: number
+          query?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'gsc_query_stats_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "gsc_query_stats_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       integration_connections: {
         Row: {
-          composio_account_id: string | null;
-          composio_entity_id: string;
-          connected_by: string | null;
-          created_at: string;
-          id: string;
-          organization_id: string;
-          provider: string;
-          status: string;
-          updated_at: string;
-        };
+          composio_account_id: string | null
+          composio_entity_id: string
+          connected_by: string | null
+          created_at: string
+          id: string
+          organization_id: string
+          provider: string
+          status: string
+          updated_at: string
+        }
         Insert: {
-          composio_account_id?: string | null;
-          composio_entity_id: string;
-          connected_by?: string | null;
-          created_at?: string;
-          id?: string;
-          organization_id: string;
-          provider: string;
-          status?: string;
-          updated_at?: string;
-        };
+          composio_account_id?: string | null
+          composio_entity_id: string
+          connected_by?: string | null
+          created_at?: string
+          id?: string
+          organization_id: string
+          provider: string
+          status?: string
+          updated_at?: string
+        }
         Update: {
-          composio_account_id?: string | null;
-          composio_entity_id?: string;
-          connected_by?: string | null;
-          created_at?: string;
-          id?: string;
-          organization_id?: string;
-          provider?: string;
-          status?: string;
-          updated_at?: string;
-        };
+          composio_account_id?: string | null
+          composio_entity_id?: string
+          connected_by?: string | null
+          created_at?: string
+          id?: string
+          organization_id?: string
+          provider?: string
+          status?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'integration_connections_organization_id_fkey';
-            columns: ['organization_id'];
-            isOneToOne: false;
-            referencedRelation: 'organizations';
-            referencedColumns: ['id'];
+            foreignKeyName: "integration_connections_connected_by_fkey"
+            columns: ["connected_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'integration_connections_connected_by_fkey';
-            columns: ['connected_by'];
-            isOneToOne: false;
-            referencedRelation: 'profiles';
-            referencedColumns: ['id'];
+            foreignKeyName: "integration_connections_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       invitations: {
         Row: {
-          accepted_at: string | null;
-          created_at: string;
-          email: string;
-          expires_at: string;
-          id: string;
-          invited_by: string;
-          organization_id: string;
-          role: Database['public']['Enums']['user_role'];
-          status: Database['public']['Enums']['invitation_status'];
-          token: string;
-        };
+          accepted_at: string | null
+          created_at: string
+          email: string
+          expires_at: string
+          id: string
+          invited_by: string
+          organization_id: string
+          role: Database["public"]["Enums"]["user_role"]
+          status: Database["public"]["Enums"]["invitation_status"]
+          token: string
+        }
         Insert: {
-          accepted_at?: string | null;
-          created_at?: string;
-          email: string;
-          expires_at?: string;
-          id?: string;
-          invited_by: string;
-          organization_id: string;
-          role?: Database['public']['Enums']['user_role'];
-          status?: Database['public']['Enums']['invitation_status'];
-          token: string;
-        };
+          accepted_at?: string | null
+          created_at?: string
+          email: string
+          expires_at?: string
+          id?: string
+          invited_by: string
+          organization_id: string
+          role?: Database["public"]["Enums"]["user_role"]
+          status?: Database["public"]["Enums"]["invitation_status"]
+          token: string
+        }
         Update: {
-          accepted_at?: string | null;
-          created_at?: string;
-          email?: string;
-          expires_at?: string;
-          id?: string;
-          invited_by?: string;
-          organization_id?: string;
-          role?: Database['public']['Enums']['user_role'];
-          status?: Database['public']['Enums']['invitation_status'];
-          token?: string;
-        };
+          accepted_at?: string | null
+          created_at?: string
+          email?: string
+          expires_at?: string
+          id?: string
+          invited_by?: string
+          organization_id?: string
+          role?: Database["public"]["Enums"]["user_role"]
+          status?: Database["public"]["Enums"]["invitation_status"]
+          token?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'invitations_organization_id_fkey';
-            columns: ['organization_id'];
-            isOneToOne: false;
-            referencedRelation: 'organizations';
-            referencedColumns: ['id'];
+            foreignKeyName: "invitations_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
+      jobs: {
+        Row: {
+          attempts: number
+          brand_id: string
+          completed_at: string | null
+          created_at: string
+          data: Json
+          failed_reason: string | null
+          id: string
+          max_attempts: number
+          progress: Json | null
+          result: Json | null
+          started_at: string | null
+          status: string
+          type: string
+          updated_at: string
+        }
+        Insert: {
+          attempts?: number
+          brand_id: string
+          completed_at?: string | null
+          created_at?: string
+          data?: Json
+          failed_reason?: string | null
+          id?: string
+          max_attempts?: number
+          progress?: Json | null
+          result?: Json | null
+          started_at?: string | null
+          status?: string
+          type: string
+          updated_at?: string
+        }
+        Update: {
+          attempts?: number
+          brand_id?: string
+          completed_at?: string | null
+          created_at?: string
+          data?: Json
+          failed_reason?: string | null
+          id?: string
+          max_attempts?: number
+          progress?: Json | null
+          result?: Json | null
+          started_at?: string | null
+          status?: string
+          type?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "jobs_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       organizations: {
         Row: {
-          created_at: string;
-          id: string;
-          name: string;
-          plan: string;
-          plan_overrides: Record<string, unknown> | null;
-          slug: string;
-          stripe_customer_id: string | null;
-          stripe_subscription_id: string | null;
-          subscription_ends_at: string | null;
-          subscription_status: string;
-          updated_at: string;
-        };
+          anthropic_api_key_encrypted: string | null
+          anthropic_api_key_last4: string | null
+          anthropic_api_key_set_at: string | null
+          anthropic_api_key_set_by: string | null
+          created_at: string
+          id: string
+          name: string
+          plan: string
+          plan_overrides: Json | null
+          slug: string
+          stripe_customer_id: string | null
+          stripe_subscription_id: string | null
+          subscription_ends_at: string | null
+          subscription_status: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          name: string;
-          plan?: string;
-          plan_overrides?: Record<string, unknown> | null;
-          slug: string;
-          stripe_customer_id?: string | null;
-          stripe_subscription_id?: string | null;
-          subscription_ends_at?: string | null;
-          subscription_status?: string;
-          updated_at?: string;
-        };
+          anthropic_api_key_encrypted?: string | null
+          anthropic_api_key_last4?: string | null
+          anthropic_api_key_set_at?: string | null
+          anthropic_api_key_set_by?: string | null
+          created_at?: string
+          id?: string
+          name: string
+          plan?: string
+          plan_overrides?: Json | null
+          slug: string
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          subscription_ends_at?: string | null
+          subscription_status?: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          name?: string;
-          plan?: string;
-          plan_overrides?: Record<string, unknown> | null;
-          slug?: string;
-          stripe_customer_id?: string | null;
-          stripe_subscription_id?: string | null;
-          subscription_ends_at?: string | null;
-          subscription_status?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          anthropic_api_key_encrypted?: string | null
+          anthropic_api_key_last4?: string | null
+          anthropic_api_key_set_at?: string | null
+          anthropic_api_key_set_by?: string | null
+          created_at?: string
+          id?: string
+          name?: string
+          plan?: string
+          plan_overrides?: Json | null
+          slug?: string
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          subscription_ends_at?: string | null
+          subscription_status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "organizations_anthropic_api_key_set_by_fkey"
+            columns: ["anthropic_api_key_set_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      page_opportunities: {
+        Row: {
+          ai_platforms: string[]
+          ai_sessions: number
+          brand_id: string
+          engaged_sessions: number
+          engagement_seconds: number
+          first_detected_at: string
+          id: string
+          key_events: number
+          kind: string
+          landing_page: string
+          last_detected_at: string
+          resolved_at: string | null
+          revenue: number
+          sessions: number
+          transactions: number
+          value_percentile: number
+          value_rank: number
+          value_signal: string
+          window_days: number
+        }
+        Insert: {
+          ai_platforms?: string[]
+          ai_sessions?: number
+          brand_id: string
+          engaged_sessions?: number
+          engagement_seconds?: number
+          first_detected_at?: string
+          id?: string
+          key_events?: number
+          kind: string
+          landing_page: string
+          last_detected_at?: string
+          resolved_at?: string | null
+          revenue?: number
+          sessions?: number
+          transactions?: number
+          value_percentile: number
+          value_rank: number
+          value_signal: string
+          window_days: number
+        }
+        Update: {
+          ai_platforms?: string[]
+          ai_sessions?: number
+          brand_id?: string
+          engaged_sessions?: number
+          engagement_seconds?: number
+          first_detected_at?: string
+          id?: string
+          key_events?: number
+          kind?: string
+          landing_page?: string
+          last_detected_at?: string
+          resolved_at?: string | null
+          revenue?: number
+          sessions?: number
+          transactions?: number
+          value_percentile?: number
+          value_rank?: number
+          value_signal?: string
+          window_days?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "page_opportunities_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
-          avatar_url: string | null;
-          created_at: string;
-          full_name: string | null;
-          id: string;
-          onboarding_completed: boolean;
-          organization_id: string | null;
-          role: Database['public']['Enums']['user_role'];
-          updated_at: string;
-        };
+          avatar_url: string | null
+          created_at: string
+          full_name: string | null
+          id: string
+          onboarding_completed: boolean | null
+          organization_id: string | null
+          role: Database["public"]["Enums"]["user_role"]
+          updated_at: string
+        }
         Insert: {
-          avatar_url?: string | null;
-          created_at?: string;
-          full_name?: string | null;
-          id: string;
-          onboarding_completed?: boolean;
-          organization_id?: string | null;
-          role?: Database['public']['Enums']['user_role'];
-          updated_at?: string;
-        };
+          avatar_url?: string | null
+          created_at?: string
+          full_name?: string | null
+          id: string
+          onboarding_completed?: boolean | null
+          organization_id?: string | null
+          role?: Database["public"]["Enums"]["user_role"]
+          updated_at?: string
+        }
         Update: {
-          avatar_url?: string | null;
-          created_at?: string;
-          full_name?: string | null;
-          id?: string;
-          onboarding_completed?: boolean;
-          organization_id?: string | null;
-          role?: Database['public']['Enums']['user_role'];
-          updated_at?: string;
-        };
+          avatar_url?: string | null
+          created_at?: string
+          full_name?: string | null
+          id?: string
+          onboarding_completed?: boolean | null
+          organization_id?: string | null
+          role?: Database["public"]["Enums"]["user_role"]
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'profiles_organization_id_fkey';
-            columns: ['organization_id'];
-            isOneToOne: false;
-            referencedRelation: 'organizations';
-            referencedColumns: ['id'];
+            foreignKeyName: "profiles_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-      prompt_result_shopping_cards: {
-        Row: {
-          brand_id: string;
-          created_at: string;
-          id: string;
-          image_url: string | null;
-          matched_brand_id: string | null;
-          matched_brand_role: string;
-          merchant_domain: string | null;
-          merchant_url: string | null;
-          platform: string;
-          position: number;
-          price_amount: number | null;
-          price_currency: string | null;
-          product_brand: string | null;
-          product_title: string | null;
-          prompt_result_id: string;
-          rating: number | null;
-          raw: Json;
-          region: string | null;
-          review_count: number | null;
-        };
-        Insert: {
-          brand_id: string;
-          created_at?: string;
-          id?: string;
-          image_url?: string | null;
-          matched_brand_id?: string | null;
-          matched_brand_role?: string;
-          merchant_domain?: string | null;
-          merchant_url?: string | null;
-          platform: string;
-          position: number;
-          price_amount?: number | null;
-          price_currency?: string | null;
-          product_brand?: string | null;
-          product_title?: string | null;
-          prompt_result_id: string;
-          rating?: number | null;
-          raw: Json;
-          region?: string | null;
-          review_count?: number | null;
-        };
-        Update: {
-          brand_id?: string;
-          created_at?: string;
-          id?: string;
-          image_url?: string | null;
-          matched_brand_id?: string | null;
-          matched_brand_role?: string;
-          merchant_domain?: string | null;
-          merchant_url?: string | null;
-          platform?: string;
-          position?: number;
-          price_amount?: number | null;
-          price_currency?: string | null;
-          product_brand?: string | null;
-          product_title?: string | null;
-          prompt_result_id?: string;
-          rating?: number | null;
-          raw?: Json;
-          region?: string | null;
-          review_count?: number | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'prompt_result_shopping_cards_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
-          },
-          {
-            foreignKeyName: 'prompt_result_shopping_cards_prompt_result_id_fkey';
-            columns: ['prompt_result_id'];
-            isOneToOne: false;
-            referencedRelation: 'prompt_results';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
+        ]
+      }
       prompt_notes: {
         Row: {
-          author_id: string | null;
-          body: string;
-          created_at: string;
-          id: string;
-          prompt_id: string;
-        };
+          author_id: string | null
+          body: string
+          created_at: string
+          id: string
+          prompt_id: string
+        }
         Insert: {
-          author_id?: string | null;
-          body: string;
-          created_at?: string;
-          id?: string;
-          prompt_id: string;
-        };
+          author_id?: string | null
+          body: string
+          created_at?: string
+          id?: string
+          prompt_id: string
+        }
         Update: {
-          author_id?: string | null;
-          body?: string;
-          created_at?: string;
-          id?: string;
-          prompt_id?: string;
-        };
+          author_id?: string | null
+          body?: string
+          created_at?: string
+          id?: string
+          prompt_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'prompt_notes_author_id_fkey';
-            columns: ['author_id'];
-            isOneToOne: false;
-            referencedRelation: 'profiles';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_notes_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'prompt_notes_prompt_id_fkey';
-            columns: ['prompt_id'];
-            isOneToOne: false;
-            referencedRelation: 'prompts';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_notes_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
+      prompt_result_shopping_cards: {
+        Row: {
+          brand_id: string
+          created_at: string
+          id: string
+          image_url: string | null
+          matched_brand_id: string | null
+          matched_brand_role: string
+          merchant_domain: string | null
+          merchant_url: string | null
+          platform: string
+          position: number
+          price_amount: number | null
+          price_currency: string | null
+          product_brand: string | null
+          product_title: string | null
+          prompt_result_id: string
+          rating: number | null
+          raw: Json
+          region: string | null
+          review_count: number | null
+        }
+        Insert: {
+          brand_id: string
+          created_at?: string
+          id?: string
+          image_url?: string | null
+          matched_brand_id?: string | null
+          matched_brand_role?: string
+          merchant_domain?: string | null
+          merchant_url?: string | null
+          platform: string
+          position: number
+          price_amount?: number | null
+          price_currency?: string | null
+          product_brand?: string | null
+          product_title?: string | null
+          prompt_result_id: string
+          rating?: number | null
+          raw: Json
+          region?: string | null
+          review_count?: number | null
+        }
+        Update: {
+          brand_id?: string
+          created_at?: string
+          id?: string
+          image_url?: string | null
+          matched_brand_id?: string | null
+          matched_brand_role?: string
+          merchant_domain?: string | null
+          merchant_url?: string | null
+          platform?: string
+          position?: number
+          price_amount?: number | null
+          price_currency?: string | null
+          product_brand?: string | null
+          product_title?: string | null
+          prompt_result_id?: string
+          rating?: number | null
+          raw?: Json
+          region?: string | null
+          review_count?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "prompt_result_shopping_cards_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "prompt_result_shopping_cards_prompt_result_id_fkey"
+            columns: ["prompt_result_id"]
+            isOneToOne: false
+            referencedRelation: "prompt_results"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       prompt_results: {
         Row: {
-          brand_id: string;
-          citation_count: number;
-          citations: Json;
-          competitor_mentions: Json;
-          created_at: string;
-          id: string;
-          inline_products: Json;
-          mention_count: number;
-          mention_position: number | null;
-          mentioned_entity_count: number | null;
-          model_used: string | null;
-          platform: string;
-          prompt_id: string;
-          region: string | null;
-          response: string;
-          search_queries: Json;
-          sentiment: string;
-          shopping_cards: Json;
-          visibility_score: number;
-        };
+          brand_id: string
+          citation_count: number
+          citations: Json
+          competitor_mentions: Json
+          created_at: string
+          id: string
+          inline_products: Json
+          mention_count: number
+          mention_position: number | null
+          mentioned_entity_count: number | null
+          model_used: string | null
+          platform: string
+          prompt_id: string
+          region: string | null
+          response: string
+          search_queries: Json
+          sentiment: string
+          shopping_cards: Json
+          visibility_score: number
+        }
         Insert: {
-          brand_id: string;
-          citation_count?: number;
-          citations?: Json;
-          competitor_mentions?: Json;
-          created_at?: string;
-          id?: string;
-          inline_products?: Json;
-          mention_count?: number;
-          mention_position?: number | null;
-          mentioned_entity_count?: number | null;
-          model_used?: string | null;
-          platform: string;
-          prompt_id: string;
-          region?: string | null;
-          response?: string;
-          search_queries?: Json;
-          sentiment?: string;
-          shopping_cards?: Json;
-          visibility_score?: number;
-        };
+          brand_id: string
+          citation_count?: number
+          citations?: Json
+          competitor_mentions?: Json
+          created_at?: string
+          id?: string
+          inline_products?: Json
+          mention_count?: number
+          mention_position?: number | null
+          mentioned_entity_count?: number | null
+          model_used?: string | null
+          platform: string
+          prompt_id: string
+          region?: string | null
+          response?: string
+          search_queries?: Json
+          sentiment?: string
+          shopping_cards?: Json
+          visibility_score?: number
+        }
         Update: {
-          brand_id?: string;
-          citation_count?: number;
-          citations?: Json;
-          competitor_mentions?: Json;
-          created_at?: string;
-          id?: string;
-          inline_products?: Json;
-          mention_count?: number;
-          mention_position?: number | null;
-          mentioned_entity_count?: number | null;
-          model_used?: string | null;
-          platform?: string;
-          prompt_id?: string;
-          region?: string | null;
-          response?: string;
-          search_queries?: Json;
-          sentiment?: string;
-          shopping_cards?: Json;
-          visibility_score?: number;
-        };
+          brand_id?: string
+          citation_count?: number
+          citations?: Json
+          competitor_mentions?: Json
+          created_at?: string
+          id?: string
+          inline_products?: Json
+          mention_count?: number
+          mention_position?: number | null
+          mentioned_entity_count?: number | null
+          model_used?: string | null
+          platform?: string
+          prompt_id?: string
+          region?: string | null
+          response?: string
+          search_queries?: Json
+          sentiment?: string
+          shopping_cards?: Json
+          visibility_score?: number
+        }
         Relationships: [
           {
-            foreignKeyName: 'prompt_results_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_results_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'prompt_results_prompt_id_fkey';
-            columns: ['prompt_id'];
-            isOneToOne: false;
-            referencedRelation: 'prompts';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_results_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       prompt_sets: {
         Row: {
-          brand_id: string;
-          created_at: string;
-          id: string;
-          name: string;
-          updated_at: string;
-        };
+          brand_id: string
+          created_at: string
+          id: string
+          name: string
+          updated_at: string
+        }
         Insert: {
-          brand_id: string;
-          created_at?: string;
-          id?: string;
-          name: string;
-          updated_at?: string;
-        };
+          brand_id: string
+          created_at?: string
+          id?: string
+          name: string
+          updated_at?: string
+        }
         Update: {
-          brand_id?: string;
-          created_at?: string;
-          id?: string;
-          name?: string;
-          updated_at?: string;
-        };
+          brand_id?: string
+          created_at?: string
+          id?: string
+          name?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'prompt_sets_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_sets_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       prompt_suggestions: {
         Row: {
-          added_prompt_id: string | null;
-          brand_id: string;
-          created_at: string;
-          est_volume: number | null;
-          expires_at: string;
-          generated_at: string;
-          id: string;
-          reason: string | null;
-          source: string;
-          source_data: Json | null;
-          status: string;
-          suggested_text: string;
-          topic_id: string | null;
-          topic_name: string | null;
-          updated_at: string;
-        };
+          added_prompt_id: string | null
+          brand_id: string
+          created_at: string
+          est_volume: number | null
+          expires_at: string
+          generated_at: string
+          id: string
+          reason: string | null
+          source: string
+          source_data: Json | null
+          status: string
+          suggested_text: string
+          topic_id: string | null
+          topic_name: string | null
+          updated_at: string
+        }
         Insert: {
-          added_prompt_id?: string | null;
-          brand_id: string;
-          created_at?: string;
-          est_volume?: number | null;
-          expires_at?: string;
-          generated_at?: string;
-          id?: string;
-          reason?: string | null;
-          source?: string;
-          source_data?: Json | null;
-          status?: string;
-          suggested_text: string;
-          topic_id?: string | null;
-          topic_name?: string | null;
-          updated_at?: string;
-        };
+          added_prompt_id?: string | null
+          brand_id: string
+          created_at?: string
+          est_volume?: number | null
+          expires_at?: string
+          generated_at?: string
+          id?: string
+          reason?: string | null
+          source?: string
+          source_data?: Json | null
+          status?: string
+          suggested_text: string
+          topic_id?: string | null
+          topic_name?: string | null
+          updated_at?: string
+        }
         Update: {
-          added_prompt_id?: string | null;
-          brand_id?: string;
-          created_at?: string;
-          est_volume?: number | null;
-          expires_at?: string;
-          generated_at?: string;
-          id?: string;
-          reason?: string | null;
-          source?: string;
-          source_data?: Json | null;
-          status?: string;
-          suggested_text?: string;
-          topic_id?: string | null;
-          topic_name?: string | null;
-          updated_at?: string;
-        };
+          added_prompt_id?: string | null
+          brand_id?: string
+          created_at?: string
+          est_volume?: number | null
+          expires_at?: string
+          generated_at?: string
+          id?: string
+          reason?: string | null
+          source?: string
+          source_data?: Json | null
+          status?: string
+          suggested_text?: string
+          topic_id?: string | null
+          topic_name?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'prompt_suggestions_added_prompt_id_fkey';
-            columns: ['added_prompt_id'];
-            isOneToOne: false;
-            referencedRelation: 'prompts';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_suggestions_added_prompt_id_fkey"
+            columns: ["added_prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'prompt_suggestions_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_suggestions_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'prompt_suggestions_topic_id_fkey';
-            columns: ['topic_id'];
-            isOneToOne: false;
-            referencedRelation: 'topics';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_suggestions_topic_id_fkey"
+            columns: ["topic_id"]
+            isOneToOne: false
+            referencedRelation: "topics"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-      prompt_volumes: {
-        Row: {
-          ai_volume_multiplier: number;
-          competition: string | null;
-          competition_index: number | null;
-          created_at: string | null;
-          est_ai_volume: number;
-          fetched_at: string | null;
-          google_volumes: Json;
-          id: string;
-          intent: string;
-          keywords: Json;
-          language_code: string | null;
-          location_code: number | null;
-          prompt_id: string;
-          total_google_volume: number;
-        };
-        Insert: {
-          ai_volume_multiplier: number;
-          competition?: string | null;
-          competition_index?: number | null;
-          created_at?: string | null;
-          est_ai_volume: number;
-          fetched_at?: string | null;
-          google_volumes: Json;
-          id?: string;
-          intent: string;
-          keywords: Json;
-          language_code?: string | null;
-          location_code?: number | null;
-          prompt_id: string;
-          total_google_volume: number;
-        };
-        Update: {
-          ai_volume_multiplier?: number;
-          competition?: string | null;
-          competition_index?: number | null;
-          created_at?: string | null;
-          est_ai_volume?: number;
-          fetched_at?: string | null;
-          google_volumes?: Json;
-          id?: string;
-          intent?: string;
-          keywords?: Json;
-          language_code?: string | null;
-          location_code?: number | null;
-          prompt_id?: string;
-          total_google_volume?: number;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'prompt_volumes_prompt_id_fkey';
-            columns: ['prompt_id'];
-            isOneToOne: true;
-            referencedRelation: 'prompts';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
+        ]
+      }
       prompt_target_urls: {
         Row: {
-          added_by: string | null;
-          cited_count: number;
-          created_at: string;
-          first_cited_at: string | null;
-          id: string;
-          label: string | null;
-          last_cited_at: string | null;
-          prompt_id: string;
-          url: string;
-        };
+          added_by: string | null
+          cited_count: number
+          created_at: string
+          first_cited_at: string | null
+          id: string
+          label: string | null
+          last_cited_at: string | null
+          prompt_id: string
+          url: string
+        }
         Insert: {
-          added_by?: string | null;
-          cited_count?: number;
-          created_at?: string;
-          first_cited_at?: string | null;
-          id?: string;
-          label?: string | null;
-          last_cited_at?: string | null;
-          prompt_id: string;
-          url: string;
-        };
+          added_by?: string | null
+          cited_count?: number
+          created_at?: string
+          first_cited_at?: string | null
+          id?: string
+          label?: string | null
+          last_cited_at?: string | null
+          prompt_id: string
+          url: string
+        }
         Update: {
-          added_by?: string | null;
-          cited_count?: number;
-          created_at?: string;
-          first_cited_at?: string | null;
-          id?: string;
-          label?: string | null;
-          last_cited_at?: string | null;
-          prompt_id?: string;
-          url?: string;
-        };
+          added_by?: string | null
+          cited_count?: number
+          created_at?: string
+          first_cited_at?: string | null
+          id?: string
+          label?: string | null
+          last_cited_at?: string | null
+          prompt_id?: string
+          url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'prompt_target_urls_added_by_fkey';
-            columns: ['added_by'];
-            isOneToOne: false;
-            referencedRelation: 'profiles';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_target_urls_added_by_fkey"
+            columns: ["added_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'prompt_target_urls_prompt_id_fkey';
-            columns: ['prompt_id'];
-            isOneToOne: false;
-            referencedRelation: 'prompts';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompt_target_urls_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
+      prompt_volumes: {
+        Row: {
+          ai_volume_multiplier: number
+          competition: string | null
+          competition_index: number | null
+          created_at: string | null
+          est_ai_volume: number
+          fetched_at: string | null
+          google_volumes: Json
+          id: string
+          intent: string
+          keywords: Json
+          language_code: string | null
+          location_code: number | null
+          prompt_id: string
+          total_google_volume: number
+        }
+        Insert: {
+          ai_volume_multiplier: number
+          competition?: string | null
+          competition_index?: number | null
+          created_at?: string | null
+          est_ai_volume: number
+          fetched_at?: string | null
+          google_volumes: Json
+          id?: string
+          intent: string
+          keywords: Json
+          language_code?: string | null
+          location_code?: number | null
+          prompt_id: string
+          total_google_volume: number
+        }
+        Update: {
+          ai_volume_multiplier?: number
+          competition?: string | null
+          competition_index?: number | null
+          created_at?: string | null
+          est_ai_volume?: number
+          fetched_at?: string | null
+          google_volumes?: Json
+          id?: string
+          intent?: string
+          keywords?: Json
+          language_code?: string | null
+          location_code?: number | null
+          prompt_id?: string
+          total_google_volume?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "prompt_volumes_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: true
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       prompts: {
         Row: {
-          category: string | null;
-          created_at: string;
-          id: string;
-          is_active: boolean;
-          models: string[];
-          platforms: string[];
-          prompt_set_id: string;
-          regions: string[];
-          text: string;
-          topic_id: string | null;
-          work_status: string | null;
-        };
+          category: string | null
+          created_at: string
+          id: string
+          is_active: boolean
+          models: string[]
+          platforms: string[]
+          prompt_set_id: string
+          regions: string[]
+          text: string
+          topic_id: string | null
+          work_status: string | null
+        }
         Insert: {
-          category?: string | null;
-          created_at?: string;
-          id?: string;
-          is_active?: boolean;
-          models?: string[];
-          platforms?: string[];
-          prompt_set_id: string;
-          regions?: string[];
-          text: string;
-          work_status?: string | null;
-        };
+          category?: string | null
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          models?: string[]
+          platforms?: string[]
+          prompt_set_id: string
+          regions?: string[]
+          text: string
+          topic_id?: string | null
+          work_status?: string | null
+        }
         Update: {
-          category?: string | null;
-          created_at?: string;
-          id?: string;
-          is_active?: boolean;
-          models?: string[];
-          platforms?: string[];
-          prompt_set_id?: string;
-          regions?: string[];
-          text?: string;
-          work_status?: string | null;
-        };
+          category?: string | null
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          models?: string[]
+          platforms?: string[]
+          prompt_set_id?: string
+          regions?: string[]
+          text?: string
+          topic_id?: string | null
+          work_status?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'prompts_prompt_set_id_fkey';
-            columns: ['prompt_set_id'];
-            isOneToOne: false;
-            referencedRelation: 'prompt_sets';
-            referencedColumns: ['id'];
+            foreignKeyName: "prompts_prompt_set_id_fkey"
+            columns: ["prompt_set_id"]
+            isOneToOne: false
+            referencedRelation: "prompt_sets"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+          {
+            foreignKeyName: "prompts_topic_id_fkey"
+            columns: ["topic_id"]
+            isOneToOne: false
+            referencedRelation: "topics"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       pulse_settings: {
         Row: {
-          brand_id: string;
-          created_at: string;
-          frequency: string;
-          recipients: string[] | null;
-          updated_at: string;
-        };
+          brand_id: string
+          created_at: string
+          frequency: string
+          recipients: string[] | null
+          updated_at: string
+        }
         Insert: {
-          brand_id: string;
-          created_at?: string;
-          frequency?: string;
-          recipients?: string[] | null;
-          updated_at?: string;
-        };
+          brand_id: string
+          created_at?: string
+          frequency?: string
+          recipients?: string[] | null
+          updated_at?: string
+        }
         Update: {
-          brand_id?: string;
-          created_at?: string;
-          frequency?: string;
-          recipients?: string[] | null;
-          updated_at?: string;
-        };
+          brand_id?: string
+          created_at?: string
+          frequency?: string
+          recipients?: string[] | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'pulse_settings_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: true;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "pulse_settings_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: true
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-      sent_pulses: {
-        Row: {
-          brand_id: string;
-          created_at: string;
-          email_recipient_count: number;
-          email_sent: boolean;
-          frequency: string;
-          id: string;
-          payload: Json;
-          pulse_date: string;
-          warning_keys: string[];
-          webhook_sent: boolean;
-        };
-        Insert: {
-          brand_id: string;
-          created_at?: string;
-          email_recipient_count?: number;
-          email_sent?: boolean;
-          frequency: string;
-          id?: string;
-          payload?: Json;
-          pulse_date: string;
-          warning_keys?: string[];
-          webhook_sent?: boolean;
-        };
-        Update: {
-          brand_id?: string;
-          created_at?: string;
-          email_recipient_count?: number;
-          email_sent?: boolean;
-          frequency?: string;
-          id?: string;
-          payload?: Json;
-          pulse_date?: string;
-          warning_keys?: string[];
-          webhook_sent?: boolean;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'sent_pulses_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
+        ]
+      }
       reports: {
         Row: {
-          brand_id: string;
-          created_at: string;
-          created_by: string | null;
-          date_from: string;
-          date_to: string;
-          id: string;
-          payload: Json;
-          template: string;
-          title: string;
-        };
+          brand_id: string
+          created_at: string
+          created_by: string | null
+          date_from: string
+          date_to: string
+          id: string
+          payload: Json
+          template: string
+          title: string
+        }
         Insert: {
-          brand_id: string;
-          created_at?: string;
-          created_by?: string | null;
-          date_from: string;
-          date_to: string;
-          id?: string;
-          payload?: Json;
-          template?: string;
-          title: string;
-        };
+          brand_id: string
+          created_at?: string
+          created_by?: string | null
+          date_from: string
+          date_to: string
+          id?: string
+          payload?: Json
+          template?: string
+          title: string
+        }
         Update: {
-          brand_id?: string;
-          created_at?: string;
-          created_by?: string | null;
-          date_from?: string;
-          date_to?: string;
-          id?: string;
-          payload?: Json;
-          template?: string;
-          title?: string;
-        };
+          brand_id?: string
+          created_at?: string
+          created_by?: string | null
+          date_from?: string
+          date_to?: string
+          id?: string
+          payload?: Json
+          template?: string
+          title?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'reports_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "reports_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'reports_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'profiles';
-            referencedColumns: ['id'];
+            foreignKeyName: "reports_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
+      sent_pulses: {
+        Row: {
+          brand_id: string
+          created_at: string
+          email_recipient_count: number
+          email_sent: boolean
+          frequency: string
+          id: string
+          payload: Json
+          pulse_date: string
+          warning_keys: string[]
+          webhook_sent: boolean
+        }
+        Insert: {
+          brand_id: string
+          created_at?: string
+          email_recipient_count?: number
+          email_sent?: boolean
+          frequency: string
+          id?: string
+          payload?: Json
+          pulse_date: string
+          warning_keys?: string[]
+          webhook_sent?: boolean
+        }
+        Update: {
+          brand_id?: string
+          created_at?: string
+          email_recipient_count?: number
+          email_sent?: boolean
+          frequency?: string
+          id?: string
+          payload?: Json
+          pulse_date?: string
+          warning_keys?: string[]
+          webhook_sent?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sent_pulses_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      site_audit_usage: {
+        Row: {
+          audit_id: string | null
+          created_at: string | null
+          id: string
+          organization_id: string
+          used_at: string
+        }
+        Insert: {
+          audit_id?: string | null
+          created_at?: string | null
+          id?: string
+          organization_id: string
+          used_at?: string
+        }
+        Update: {
+          audit_id?: string | null
+          created_at?: string | null
+          id?: string
+          organization_id?: string
+          used_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "site_audit_usage_audit_id_fkey"
+            columns: ["audit_id"]
+            isOneToOne: false
+            referencedRelation: "site_audits"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "site_audit_usage_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       site_audits: {
         Row: {
-          brand_id: string;
-          category_scores: Json;
-          completed_at: string | null;
-          created_at: string;
-          error: string | null;
-          final_url: string | null;
-          id: string;
-          rubric_version: string | null;
-          signals_evaluated: number | null;
-          signals_total: number | null;
-          status: string;
-          total_score: number | null;
-          url: string;
-        };
+          brand_id: string
+          category_scores: Json
+          completed_at: string | null
+          created_at: string
+          error: string | null
+          final_url: string | null
+          id: string
+          recommendations: Json
+          rubric_version: string | null
+          signals_evaluated: number | null
+          signals_total: number | null
+          status: string
+          total_score: number | null
+          url: string
+        }
         Insert: {
-          brand_id: string;
-          category_scores?: Json;
-          completed_at?: string | null;
-          created_at?: string;
-          error?: string | null;
-          final_url?: string | null;
-          id?: string;
-          rubric_version?: string | null;
-          signals_evaluated?: number | null;
-          signals_total?: number | null;
-          status?: string;
-          total_score?: number | null;
-          url: string;
-        };
+          brand_id: string
+          category_scores?: Json
+          completed_at?: string | null
+          created_at?: string
+          error?: string | null
+          final_url?: string | null
+          id?: string
+          recommendations?: Json
+          rubric_version?: string | null
+          signals_evaluated?: number | null
+          signals_total?: number | null
+          status?: string
+          total_score?: number | null
+          url: string
+        }
         Update: {
-          brand_id?: string;
-          category_scores?: Json;
-          completed_at?: string | null;
-          created_at?: string;
-          error?: string | null;
-          final_url?: string | null;
-          id?: string;
-          rubric_version?: string | null;
-          signals_evaluated?: number | null;
-          signals_total?: number | null;
-          status?: string;
-          total_score?: number | null;
-          url?: string;
-        };
+          brand_id?: string
+          category_scores?: Json
+          completed_at?: string | null
+          created_at?: string
+          error?: string | null
+          final_url?: string | null
+          id?: string
+          recommendations?: Json
+          rubric_version?: string | null
+          signals_evaluated?: number | null
+          signals_total?: number | null
+          status?: string
+          total_score?: number | null
+          url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'site_audits_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "site_audits_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       topic_suggestions: {
         Row: {
-          added_topic_id: string | null;
-          brand_id: string;
-          created_at: string;
-          generated_at: string;
-          id: string;
-          name: string;
-          reason: string | null;
-          source: string;
-          status: string;
-          updated_at: string;
-        };
+          added_topic_id: string | null
+          brand_id: string
+          created_at: string
+          generated_at: string
+          id: string
+          name: string
+          reason: string | null
+          source: string
+          status: string
+          updated_at: string
+        }
         Insert: {
-          added_topic_id?: string | null;
-          brand_id: string;
-          created_at?: string;
-          generated_at?: string;
-          id?: string;
-          name: string;
-          reason?: string | null;
-          source?: string;
-          status?: string;
-          updated_at?: string;
-        };
+          added_topic_id?: string | null
+          brand_id: string
+          created_at?: string
+          generated_at?: string
+          id?: string
+          name: string
+          reason?: string | null
+          source?: string
+          status?: string
+          updated_at?: string
+        }
         Update: {
-          added_topic_id?: string | null;
-          brand_id?: string;
-          created_at?: string;
-          generated_at?: string;
-          id?: string;
-          name?: string;
-          reason?: string | null;
-          source?: string;
-          status?: string;
-          updated_at?: string;
-        };
+          added_topic_id?: string | null
+          brand_id?: string
+          created_at?: string
+          generated_at?: string
+          id?: string
+          name?: string
+          reason?: string | null
+          source?: string
+          status?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'topic_suggestions_added_topic_id_fkey';
-            columns: ['added_topic_id'];
-            isOneToOne: false;
-            referencedRelation: 'topics';
-            referencedColumns: ['id'];
+            foreignKeyName: "topic_suggestions_added_topic_id_fkey"
+            columns: ["added_topic_id"]
+            isOneToOne: false
+            referencedRelation: "topics"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'topic_suggestions_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "topic_suggestions_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       topics: {
         Row: {
-          brand_id: string;
-          created_at: string;
-          id: string;
-          is_active: boolean;
-          name: string;
-        };
+          brand_id: string
+          created_at: string | null
+          id: string
+          is_active: boolean | null
+          name: string
+        }
         Insert: {
-          brand_id: string;
-          created_at?: string;
-          id?: string;
-          is_active?: boolean;
-          name: string;
-        };
+          brand_id: string
+          created_at?: string | null
+          id?: string
+          is_active?: boolean | null
+          name: string
+        }
         Update: {
-          brand_id?: string;
-          created_at?: string;
-          id?: string;
-          is_active?: boolean;
-          name?: string;
-        };
+          brand_id?: string
+          created_at?: string | null
+          id?: string
+          is_active?: boolean | null
+          name?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'topics_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "topics_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       tracking_runs: {
         Row: {
-          brand_id: string;
-          completed_at: string | null;
-          created_at: string;
-          id: string;
-          result_count: number | null;
-          source: string;
-          started_at: string;
-        };
+          brand_id: string
+          completed_at: string | null
+          created_at: string
+          id: string
+          result_count: number | null
+          source: string
+          started_at: string
+        }
         Insert: {
-          brand_id: string;
-          completed_at?: string | null;
-          created_at?: string;
-          id?: string;
-          result_count?: number | null;
-          source?: string;
-          started_at?: string;
-        };
+          brand_id: string
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          result_count?: number | null
+          source?: string
+          started_at?: string
+        }
         Update: {
-          brand_id?: string;
-          completed_at?: string | null;
-          created_at?: string;
-          id?: string;
-          result_count?: number | null;
-          source?: string;
-          started_at?: string;
-        };
+          brand_id?: string
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          result_count?: number | null
+          source?: string
+          started_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'tracking_runs_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "tracking_runs_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
+      volume_usage: {
+        Row: {
+          action: string
+          created_at: string | null
+          id: string
+          organization_id: string
+          prompt_count: number | null
+          used_at: string
+        }
+        Insert: {
+          action: string
+          created_at?: string | null
+          id?: string
+          organization_id: string
+          prompt_count?: number | null
+          used_at?: string
+        }
+        Update: {
+          action?: string
+          created_at?: string | null
+          id?: string
+          organization_id?: string
+          prompt_count?: number | null
+          used_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "volume_usage_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       webhook_configs: {
         Row: {
-          brand_id: string;
-          created_at: string | null;
-          events: string[] | null;
-          id: string;
-          is_active: boolean | null;
-          name: string;
-          updated_at: string | null;
-          webhook_secret: string | null;
-          webhook_url: string;
-        };
+          brand_id: string
+          created_at: string | null
+          events: string[] | null
+          id: string
+          is_active: boolean | null
+          name: string
+          updated_at: string | null
+          webhook_secret: string | null
+          webhook_url: string
+        }
         Insert: {
-          brand_id: string;
-          created_at?: string | null;
-          events?: string[] | null;
-          id?: string;
-          is_active?: boolean | null;
-          name?: string;
-          updated_at?: string | null;
-          webhook_secret?: string | null;
-          webhook_url: string;
-        };
+          brand_id: string
+          created_at?: string | null
+          events?: string[] | null
+          id?: string
+          is_active?: boolean | null
+          name?: string
+          updated_at?: string | null
+          webhook_secret?: string | null
+          webhook_url: string
+        }
         Update: {
-          brand_id?: string;
-          created_at?: string | null;
-          events?: string[] | null;
-          id?: string;
-          is_active?: boolean | null;
-          name?: string;
-          updated_at?: string | null;
-          webhook_secret?: string | null;
-          webhook_url?: string;
-        };
+          brand_id?: string
+          created_at?: string | null
+          events?: string[] | null
+          id?: string
+          is_active?: boolean | null
+          name?: string
+          updated_at?: string | null
+          webhook_secret?: string | null
+          webhook_url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhook_configs_brand_id_fkey';
-            columns: ['brand_id'];
-            isOneToOne: false;
-            referencedRelation: 'brands';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhook_configs_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
+      ai_visibility_aggregates: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_platform?: string
+          p_prompt_id?: string
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: Json
+      }
+      competitor_aggregates: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_platform?: string
+          p_prompt_id?: string
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: Json
+      }
       get_latest_prompt_results:
         | {
-            Args: { p_brand_id: string; p_platform?: string };
+            Args: { p_brand_id: string; p_platform?: string }
             Returns: {
-              brand_id: string;
-              citation_count: number;
-              citations: Json;
-              competitor_mentions: Json;
-              created_at: string;
-              id: string;
-              mention_count: number;
-              model_used: string | null;
-              platform: string;
-              prompt_id: string;
-              region: string | null;
-              response: string;
-              sentiment: string;
-              visibility_score: number;
-            }[];
+              brand_id: string
+              citation_count: number
+              citations: Json
+              competitor_mentions: Json
+              created_at: string
+              id: string
+              inline_products: Json
+              mention_count: number
+              mention_position: number | null
+              mentioned_entity_count: number | null
+              model_used: string | null
+              platform: string
+              prompt_id: string
+              region: string | null
+              response: string
+              search_queries: Json
+              sentiment: string
+              shopping_cards: Json
+              visibility_score: number
+            }[]
             SetofOptions: {
-              from: '*';
-              to: 'prompt_results';
-              isOneToOne: false;
-              isSetofReturn: true;
-            };
+              from: "*"
+              to: "prompt_results"
+              isOneToOne: false
+              isSetofReturn: true
+            }
           }
         | {
             Args: {
-              p_brand_id: string;
-              p_date_from?: string;
-              p_date_to?: string;
-              p_model?: string;
-              p_platform?: string;
-              p_region?: string;
-            };
+              p_brand_id: string
+              p_date_from?: string
+              p_date_to?: string
+              p_model?: string
+              p_platform?: string
+              p_region?: string
+            }
             Returns: {
-              brand_id: string;
-              citation_count: number;
-              citations: Json;
-              competitor_mentions: Json;
-              created_at: string;
-              id: string;
-              mention_count: number;
-              model_used: string | null;
-              platform: string;
-              prompt_id: string;
-              region: string | null;
-              response: string;
-              sentiment: string;
-              visibility_score: number;
-            }[];
+              brand_id: string
+              citation_count: number
+              citations: Json
+              competitor_mentions: Json
+              created_at: string
+              id: string
+              inline_products: Json
+              mention_count: number
+              mention_position: number | null
+              mentioned_entity_count: number | null
+              model_used: string | null
+              platform: string
+              prompt_id: string
+              region: string | null
+              response: string
+              search_queries: Json
+              sentiment: string
+              shopping_cards: Json
+              visibility_score: number
+            }[]
             SetofOptions: {
-              from: '*';
-              to: 'prompt_results';
-              isOneToOne: false;
-              isSetofReturn: true;
-            };
-          };
+              from: "*"
+              to: "prompt_results"
+              isOneToOne: false
+              isSetofReturn: true
+            }
+          }
+      gsc_candidate_queries: {
+        Args: { p_brand_id: string; p_min_impressions: number; p_since: string }
+        Returns: {
+          avg_position: number
+          clicks: number
+          impressions: number
+          query: string
+        }[]
+      }
       insights_aggregates: {
         Args: {
-          p_brand_id: string;
-          p_platform?: string | null;
-          p_models?: string[] | null;
-          p_region?: string | null;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-          p_prompt_id?: string | null;
-          p_topic_id?: string | null;
-        };
-        Returns: Json;
-      };
-      tracked_prompt_count: {
-        Args: {
-          p_brand_id: string;
-          p_platform?: string | null;
-          p_models?: string[] | null;
-          p_region?: string | null;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-          p_topic_id?: string | null;
-        };
-        Returns: number;
-      };
-      visible_prompt_stats: {
-        Args: {
-          p_brand_id: string;
-          p_platform?: string | null;
-          p_models?: string[] | null;
-          p_region?: string | null;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-          p_topic_id?: string | null;
-        };
-        Returns: Json;
-      };
-      prompt_visibility_summaries: {
-        Args: {
-          p_brand_id: string;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-        };
-        Returns: {
-          prompt_id: string;
-          avg_visibility: number;
-          avg_visibility_visible: number | null;
-          total_mentions: number;
-          total_citations: number;
-          runs: number;
-          visible_runs: number;
-          mention_answers: number;
-          citation_answers: number;
-          position_factor: number | null;
-          last_run_at: string;
-        }[];
-      };
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_platform?: string
+          p_prompt_id?: string
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: Json
+      }
       insights_filter_options: {
-        Args: {
-          p_brand_id: string;
-        };
+        Args: { p_brand_id: string }
         Returns: {
-          regions: string[];
-          models: string[];
-        }[];
-      };
-      competitor_aggregates: {
+          models: string[]
+          regions: string[]
+        }[]
+      }
+      prompt_performance_aggregates: {
         Args: {
-          p_brand_id: string;
-          p_platform?: string | null;
-          p_models?: string[] | null;
-          p_region?: string | null;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-          p_prompt_id?: string | null;
-          p_topic_id?: string | null;
-        };
-        Returns: Json;
-      };
-      ai_visibility_aggregates: {
-        Args: {
-          p_brand_id: string;
-          p_platform?: string | null;
-          p_models?: string[] | null;
-          p_region?: string | null;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-          p_prompt_id?: string | null;
-          p_topic_id?: string | null;
-        };
-        Returns: Json;
-      };
-      visibility_rate_trend: {
-        Args: {
-          p_brand_id: string;
-          p_platform?: string | null;
-          p_models?: string[] | null;
-          p_region?: string | null;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-          p_topic_id?: string | null;
-        };
-        Returns: Json;
-      };
-      visibility_trend_aggregates: {
-        Args: {
-          p_brand_id: string;
-          p_models?: string[] | null;
-          p_region?: string | null;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-          p_topic_id?: string | null;
-          p_granularity?: string | null;
-        };
-        Returns: Json;
-      };
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: Json
+      }
+      prompt_visibility_summaries: {
+        Args: { p_brand_id: string; p_date_from?: string; p_date_to?: string }
+        Returns: {
+          avg_visibility: number
+          avg_visibility_visible: number
+          citation_answers: number
+          last_run_at: string
+          mention_answers: number
+          position_factor: number
+          prompt_id: string
+          runs: number
+          total_citations: number
+          total_mentions: number
+          visible_runs: number
+        }[]
+      }
       share_of_voice_aggregates: {
         Args: {
-          p_brand_id: string;
-          p_platform?: string | null;
-          p_models?: string[] | null;
-          p_region?: string | null;
-          p_date_from?: string | null;
-          p_date_to?: string | null;
-          p_prompt_id?: string | null;
-          p_topic_id?: string | null;
-        };
-        Returns: Json;
-      };
-    };
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_platform?: string
+          p_prompt_id?: string
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: Json
+      }
+      tracked_prompt_count: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_platform?: string
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: number
+      }
+      visibility_rate_trend: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_platform?: string
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: Json
+      }
+      visibility_trend_aggregates: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_granularity?: string
+          p_models?: string[]
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: Json
+      }
+      visible_prompt_stats: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_platform?: string
+          p_region?: string
+          p_topic_id?: string
+        }
+        Returns: Json
+      }
+    }
     Enums: {
-      invitation_status: 'pending' | 'accepted' | 'expired' | 'revoked';
-      user_role: 'admin' | 'manager' | 'analyst' | 'agency_partner';
-    };
+      invitation_status: "pending" | "accepted" | "expired" | "revoked"
+      user_role: "admin" | "manager" | "analyst" | "agency_partner"
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<
-  keyof Database,
-  'public'
->];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
-      Row: infer R;
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
-        DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] &
-        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R;
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
       }
       ? R
       : never
-    : never;
+    : never
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Insert: infer I;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
       }
       ? I
       : never
-    : never;
+    : never
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Update: infer U;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
       }
       ? U
       : never
-    : never;
+    : never
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
-      invitation_status: ['pending', 'accepted', 'expired', 'revoked'],
-      user_role: ['admin', 'manager', 'analyst', 'agency_partner'],
+      invitation_status: ["pending", "accepted", "expired", "revoked"],
+      user_role: ["admin", "manager", "analyst", "agency_partner"],
     },
   },
-} as const;
+} as const


### PR DESCRIPTION
## Summary

The detection engine (#724) has been writing findings since it merged and nobody could see them. This puts them on **AI Traffic Analytics**, below the tables that count the tracking snippet's own visits and clearly attributed to Analytics — the two origins describe different things and are never summed, per the constraint #704 set.

The card reads the nightly run rather than computing anything. The ranking, the signal and the evidence were decided server-side; recomputing them here would let the card disagree with what the engine stored.

**The wording follows the signal the engine actually used.** On a property with revenue the column reads *Revenue* and the rank is "by revenue". On one with none it reads *Engagement*, says so, and points at Analytics key events as the way to rank by what pages earn instead. Calling an engagement rank "your most valuable page" would be a true sentence about the wrong thing, and the copy is where that promise is kept or broken.

Nothing renders without findings, so the twenty-nine brands with no mapped property meet no empty card explaining a feature they have not connected.

## The types commit, and why it is here

The first commit regenerates `web/src/types/supabase.ts`, which was last refreshed around migration 00049 — the three Analytics tables and `page_opportunities` were missing, so nothing could read them from the web app. This PR cannot work without it.

It brought more than the tables. The previous file declared `Functions: { [_ in never]: never }`: **every `supabase.rpc()` call in the app was untyped**, and had been since the file was first generated. With real signatures in place, 35 call sites stop compiling — they pass `null` for optional parameters the generator declares as `?: string`.

All 35 become `undefined`, which is behaviour-preserving: an omitted key lets each function apply its own `DEFAULT NULL`. Verified against the live database rather than assumed —

```sql
ai_visibility_aggregates(brand, NULL, NULL, NULL, from, to, NULL, NULL)
  = ai_visibility_aggregates(p_brand_id => brand, p_date_from => from, p_date_to => to)
→ true   (same for insights_aggregates)
```

Kept as a separate commit so the surface diff stays readable.

## Related issue

Part of #719 — the surface for the detection layer. Clustering, LLM enrichment and the action/validation layers stay open.

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open **AI Traffic Analytics** on a brand with a mapped GA4 property. A card appears below the tables listing the pages that rank high on their own site and received no AI-referred visit in the window.
2. The badge reads `Google Analytics · last 28 days`; the rank column names the signal the engine used.
3. Open it on a brand without a mapped property — the page is exactly as it was, no empty card.
4. Switch brands with the card open: findings from the previous brand must not render under the new brand's name (the loaded rows carry their brand and are compared before rendering).

`yarn typecheck`, `yarn lint` (6 pre-existing warnings, 0 errors), `yarn format:check`, `yarn test` (84 pass) and `yarn build` all pass locally. The production build was run before committing — `tsc` alone does not catch what CI's `web` job does.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR