### PR TITLE
perf(topics): aggregate the overview in Postgres instead of downloading it

### DIFF
--- a/supabase/migrations/00057_topics_overview_aggregates.sql
+++ b/supabase/migrations/00057_topics_overview_aggregates.sql
@@ -1,0 +1,192 @@
+-- Topics overview, aggregated in Postgres (#721).
+--
+-- The page downloaded the brand's entire 30-day result set to compute twenty
+-- table rows: 33 sequential requests, 73 MB of JSON, ~19 s on the largest
+-- brand. Two thirds of that was one column — competitor_mentions, averaging
+-- eleven entries per row — fetched to derive a single top competitor per
+-- topic. The rest was pagination: .range() becomes LIMIT/OFFSET, so page k
+-- re-walked k×1000 rows, ~563k buffer touches to read 32k rows once.
+--
+-- Everything below is what the client was doing in JavaScript, moved to where
+-- the data already is. The AI Visibility Score itself stays in JS
+-- (lib/visibility-score) over ~20 rows, so the Topics page and the Insights
+-- headline keep computing it from one implementation.
+--
+-- Windows are resolved from now() inside the function rather than passed in:
+-- the caller's clock and the database's would otherwise disagree about which
+-- answers fall in "the last 7 days", and the page has no reason to care.
+
+CREATE FUNCTION public.topics_overview_aggregates(p_brand_id uuid)
+RETURNS TABLE (
+  topic_id             uuid,
+  answers              bigint,
+  mention_answers      bigint,
+  citation_answers     bigint,
+  pos_sum              double precision,
+  pos_n                bigint,
+  cur_answers          bigint,
+  cur_mention_answers  bigint,
+  cur_citation_answers bigint,
+  cur_pos_sum          double precision,
+  cur_pos_n            bigint,
+  prev_answers         bigint,
+  prev_mention_answers bigint,
+  prev_citation_answers bigint,
+  prev_pos_sum         double precision,
+  prev_pos_n           bigint,
+  total_mentions       bigint,
+  total_citations      bigint,
+  comp_mentions        bigint,
+  active_prompts       bigint,
+  visible_prompts      bigint,
+  last_run_at          timestamptz,
+  competitors          jsonb,
+  daily                jsonb
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+WITH bounds AS (
+  SELECT now() - interval '30 days' AS since_30d,
+         now() - interval '7 days'  AS cur_from,
+         now() - interval '14 days' AS prev_from,
+         -- Start of the 14th day back in UTC, so the earliest bucket the page
+         -- draws is complete rather than clipped at the current time of day.
+         date_trunc('day', (now() AT TIME ZONE 'UTC') - interval '13 days')
+           AT TIME ZONE 'UTC' AS spark_from
+),
+-- Answers in the window, carrying the topic their prompt belongs to. The
+-- prompt_sets join is what scopes prompts to this brand; prompt_results is
+-- filtered on brand_id as well, matching what the page did client-side.
+rows AS (
+  SELECT p.topic_id,
+         pr.prompt_id,
+         pr.created_at,
+         COALESCE(pr.mention_count, 0)  AS mentions,
+         COALESCE(pr.citation_count, 0) AS citations,
+         pr.mention_position,
+         (COALESCE(pr.mention_count, 0) > 0 OR COALESCE(pr.citation_count, 0) > 0) AS visible
+  FROM public.prompt_results pr
+  JOIN public.prompts p        ON p.id = pr.prompt_id
+  JOIN public.prompt_sets ps   ON ps.id = p.prompt_set_id
+  CROSS JOIN bounds b
+  WHERE pr.brand_id = p_brand_id
+    AND ps.brand_id = p_brand_id
+    AND p.topic_id IS NOT NULL
+    AND pr.platform <> 'chatgpt-shopping'  -- #155 - isolate from analytics
+    AND pr.created_at >= b.since_30d
+),
+-- Competitor share per topic. Summed straight from the array: the client
+-- folded duplicates within a row before adding them up, which reaches the
+-- same total.
+--
+-- Scans prompt_results again rather than reusing `rows`. `rows` is referenced
+-- several times so Postgres materialises it, and carrying competitor_mentions
+-- through that materialisation spills 32k detoasted jsonb values to temp
+-- files — 4.5 s and 7,500 temp blocks, measured. Reading the column only
+-- where it is needed keeps the shared CTE lean.
+comps AS (
+  SELECT p.topic_id,
+         cm.value ->> 'competitor_id' AS competitor_id,
+         MIN(cm.value ->> 'name')     AS name,
+         SUM(COALESCE((cm.value ->> 'mention_count')::bigint, 0)) AS mentions
+  FROM public.prompt_results pr
+  JOIN public.prompts p      ON p.id = pr.prompt_id
+  JOIN public.prompt_sets ps ON ps.id = p.prompt_set_id
+  CROSS JOIN bounds b
+  CROSS JOIN LATERAL jsonb_array_elements(COALESCE(pr.competitor_mentions, '[]'::jsonb)) cm
+  WHERE pr.brand_id = p_brand_id
+    AND ps.brand_id = p_brand_id
+    AND p.topic_id IS NOT NULL
+    AND pr.platform <> 'chatgpt-shopping'
+    AND pr.created_at >= b.since_30d
+  GROUP BY p.topic_id, cm.value ->> 'competitor_id'
+),
+comp_totals AS (
+  SELECT topic_id,
+         SUM(mentions) AS comp_mentions,
+         jsonb_object_agg(competitor_id, jsonb_build_object('name', name, 'sov', mentions)) AS competitors
+  FROM comps
+  GROUP BY topic_id
+),
+-- Fourteen daily buckets for the sparkline. Only the days the page draws.
+--
+-- Keyed in UTC, because the client builds the same keys from
+-- `Date.toISOString()` — reading them in the database's session timezone
+-- would shift every bucket by the offset and silently redraw the trend.
+daily AS (
+  SELECT d.topic_id,
+         jsonb_object_agg(d.day, jsonb_build_object('visible', d.visible, 'count', d.count)) AS daily
+  FROM (
+    SELECT r2.topic_id,
+           to_char(r2.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
+           COUNT(*) FILTER (WHERE r2.visible) AS visible,
+           COUNT(*) AS count
+    FROM rows r2
+    CROSS JOIN bounds b
+    WHERE r2.created_at >= b.spark_from
+    GROUP BY r2.topic_id, to_char(r2.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD')
+  ) d
+  GROUP BY d.topic_id
+),
+main AS (
+  SELECT r.topic_id,
+         COUNT(*)::bigint                                          AS answers,
+         COUNT(*) FILTER (WHERE r.mentions > 0)::bigint            AS mention_answers,
+         COUNT(*) FILTER (WHERE r.citations > 0)::bigint           AS citation_answers,
+         COALESCE(SUM(1.0 / r.mention_position)
+           FILTER (WHERE r.mention_position > 0), 0)::double precision AS pos_sum,
+         COUNT(*) FILTER (WHERE r.mention_position > 0)::bigint    AS pos_n,
+
+         COUNT(*) FILTER (WHERE r.created_at >= b.cur_from)::bigint AS cur_answers,
+         COUNT(*) FILTER (WHERE r.created_at >= b.cur_from AND r.mentions > 0)::bigint
+                                                                    AS cur_mention_answers,
+         COUNT(*) FILTER (WHERE r.created_at >= b.cur_from AND r.citations > 0)::bigint
+                                                                    AS cur_citation_answers,
+         COALESCE(SUM(1.0 / r.mention_position)
+           FILTER (WHERE r.created_at >= b.cur_from AND r.mention_position > 0), 0)::double precision
+                                                                    AS cur_pos_sum,
+         COUNT(*) FILTER (WHERE r.created_at >= b.cur_from AND r.mention_position > 0)::bigint
+                                                                    AS cur_pos_n,
+
+         COUNT(*) FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from)::bigint
+                                                                    AS prev_answers,
+         COUNT(*) FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from
+           AND r.mentions > 0)::bigint                              AS prev_mention_answers,
+         COUNT(*) FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from
+           AND r.citations > 0)::bigint                             AS prev_citation_answers,
+         COALESCE(SUM(1.0 / r.mention_position)
+           FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from
+             AND r.mention_position > 0), 0)::double precision      AS prev_pos_sum,
+         COUNT(*) FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from
+           AND r.mention_position > 0)::bigint                      AS prev_pos_n,
+
+         COALESCE(SUM(r.mentions), 0)::bigint                       AS total_mentions,
+         COALESCE(SUM(r.citations), 0)::bigint                      AS total_citations,
+         COUNT(DISTINCT r.prompt_id)::bigint                        AS active_prompts,
+         COUNT(DISTINCT r.prompt_id) FILTER (WHERE r.visible)::bigint AS visible_prompts,
+         MAX(r.created_at)                                          AS last_run_at
+  FROM rows r
+  CROSS JOIN bounds b
+  GROUP BY r.topic_id
+)
+-- The two jsonb rollups join on at the end rather than riding through the
+-- GROUP BY: Postgres has no max(jsonb), and carrying them through an
+-- aggregate would need a wrapper that buys nothing here.
+SELECT m.topic_id,
+       m.answers, m.mention_answers, m.citation_answers, m.pos_sum, m.pos_n,
+       m.cur_answers, m.cur_mention_answers, m.cur_citation_answers, m.cur_pos_sum, m.cur_pos_n,
+       m.prev_answers, m.prev_mention_answers, m.prev_citation_answers, m.prev_pos_sum, m.prev_pos_n,
+       m.total_mentions, m.total_citations,
+       COALESCE(ct.comp_mentions, 0)::bigint,
+       m.active_prompts, m.visible_prompts, m.last_run_at,
+       COALESCE(ct.competitors, '{}'::jsonb),
+       COALESCE(dl.daily, '{}'::jsonb)
+FROM main m
+LEFT JOIN comp_totals ct ON ct.topic_id = m.topic_id
+LEFT JOIN daily dl       ON dl.topic_id = m.topic_id
+$$;
+
+GRANT EXECUTE ON FUNCTION public.topics_overview_aggregates(uuid) TO authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5606,3 +5606,199 @@ CREATE POLICY "page_opportunities: member select" ON public.page_opportunities
 
 GRANT SELECT ON public.page_opportunities TO authenticated;
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00057_topics_overview_aggregates.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Topics overview, aggregated in Postgres (#721).
+--
+-- The page downloaded the brand's entire 30-day result set to compute twenty
+-- table rows: 33 sequential requests, 73 MB of JSON, ~19 s on the largest
+-- brand. Two thirds of that was one column — competitor_mentions, averaging
+-- eleven entries per row — fetched to derive a single top competitor per
+-- topic. The rest was pagination: .range() becomes LIMIT/OFFSET, so page k
+-- re-walked k×1000 rows, ~563k buffer touches to read 32k rows once.
+--
+-- Everything below is what the client was doing in JavaScript, moved to where
+-- the data already is. The AI Visibility Score itself stays in JS
+-- (lib/visibility-score) over ~20 rows, so the Topics page and the Insights
+-- headline keep computing it from one implementation.
+--
+-- Windows are resolved from now() inside the function rather than passed in:
+-- the caller's clock and the database's would otherwise disagree about which
+-- answers fall in "the last 7 days", and the page has no reason to care.
+
+CREATE FUNCTION public.topics_overview_aggregates(p_brand_id uuid)
+RETURNS TABLE (
+  topic_id             uuid,
+  answers              bigint,
+  mention_answers      bigint,
+  citation_answers     bigint,
+  pos_sum              double precision,
+  pos_n                bigint,
+  cur_answers          bigint,
+  cur_mention_answers  bigint,
+  cur_citation_answers bigint,
+  cur_pos_sum          double precision,
+  cur_pos_n            bigint,
+  prev_answers         bigint,
+  prev_mention_answers bigint,
+  prev_citation_answers bigint,
+  prev_pos_sum         double precision,
+  prev_pos_n           bigint,
+  total_mentions       bigint,
+  total_citations      bigint,
+  comp_mentions        bigint,
+  active_prompts       bigint,
+  visible_prompts      bigint,
+  last_run_at          timestamptz,
+  competitors          jsonb,
+  daily                jsonb
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+WITH bounds AS (
+  SELECT now() - interval '30 days' AS since_30d,
+         now() - interval '7 days'  AS cur_from,
+         now() - interval '14 days' AS prev_from,
+         -- Start of the 14th day back in UTC, so the earliest bucket the page
+         -- draws is complete rather than clipped at the current time of day.
+         date_trunc('day', (now() AT TIME ZONE 'UTC') - interval '13 days')
+           AT TIME ZONE 'UTC' AS spark_from
+),
+-- Answers in the window, carrying the topic their prompt belongs to. The
+-- prompt_sets join is what scopes prompts to this brand; prompt_results is
+-- filtered on brand_id as well, matching what the page did client-side.
+rows AS (
+  SELECT p.topic_id,
+         pr.prompt_id,
+         pr.created_at,
+         COALESCE(pr.mention_count, 0)  AS mentions,
+         COALESCE(pr.citation_count, 0) AS citations,
+         pr.mention_position,
+         (COALESCE(pr.mention_count, 0) > 0 OR COALESCE(pr.citation_count, 0) > 0) AS visible
+  FROM public.prompt_results pr
+  JOIN public.prompts p        ON p.id = pr.prompt_id
+  JOIN public.prompt_sets ps   ON ps.id = p.prompt_set_id
+  CROSS JOIN bounds b
+  WHERE pr.brand_id = p_brand_id
+    AND ps.brand_id = p_brand_id
+    AND p.topic_id IS NOT NULL
+    AND pr.platform <> 'chatgpt-shopping'  -- #155 - isolate from analytics
+    AND pr.created_at >= b.since_30d
+),
+-- Competitor share per topic. Summed straight from the array: the client
+-- folded duplicates within a row before adding them up, which reaches the
+-- same total.
+--
+-- Scans prompt_results again rather than reusing `rows`. `rows` is referenced
+-- several times so Postgres materialises it, and carrying competitor_mentions
+-- through that materialisation spills 32k detoasted jsonb values to temp
+-- files — 4.5 s and 7,500 temp blocks, measured. Reading the column only
+-- where it is needed keeps the shared CTE lean.
+comps AS (
+  SELECT p.topic_id,
+         cm.value ->> 'competitor_id' AS competitor_id,
+         MIN(cm.value ->> 'name')     AS name,
+         SUM(COALESCE((cm.value ->> 'mention_count')::bigint, 0)) AS mentions
+  FROM public.prompt_results pr
+  JOIN public.prompts p      ON p.id = pr.prompt_id
+  JOIN public.prompt_sets ps ON ps.id = p.prompt_set_id
+  CROSS JOIN bounds b
+  CROSS JOIN LATERAL jsonb_array_elements(COALESCE(pr.competitor_mentions, '[]'::jsonb)) cm
+  WHERE pr.brand_id = p_brand_id
+    AND ps.brand_id = p_brand_id
+    AND p.topic_id IS NOT NULL
+    AND pr.platform <> 'chatgpt-shopping'
+    AND pr.created_at >= b.since_30d
+  GROUP BY p.topic_id, cm.value ->> 'competitor_id'
+),
+comp_totals AS (
+  SELECT topic_id,
+         SUM(mentions) AS comp_mentions,
+         jsonb_object_agg(competitor_id, jsonb_build_object('name', name, 'sov', mentions)) AS competitors
+  FROM comps
+  GROUP BY topic_id
+),
+-- Fourteen daily buckets for the sparkline. Only the days the page draws.
+--
+-- Keyed in UTC, because the client builds the same keys from
+-- `Date.toISOString()` — reading them in the database's session timezone
+-- would shift every bucket by the offset and silently redraw the trend.
+daily AS (
+  SELECT d.topic_id,
+         jsonb_object_agg(d.day, jsonb_build_object('visible', d.visible, 'count', d.count)) AS daily
+  FROM (
+    SELECT r2.topic_id,
+           to_char(r2.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
+           COUNT(*) FILTER (WHERE r2.visible) AS visible,
+           COUNT(*) AS count
+    FROM rows r2
+    CROSS JOIN bounds b
+    WHERE r2.created_at >= b.spark_from
+    GROUP BY r2.topic_id, to_char(r2.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD')
+  ) d
+  GROUP BY d.topic_id
+),
+main AS (
+  SELECT r.topic_id,
+         COUNT(*)::bigint                                          AS answers,
+         COUNT(*) FILTER (WHERE r.mentions > 0)::bigint            AS mention_answers,
+         COUNT(*) FILTER (WHERE r.citations > 0)::bigint           AS citation_answers,
+         COALESCE(SUM(1.0 / r.mention_position)
+           FILTER (WHERE r.mention_position > 0), 0)::double precision AS pos_sum,
+         COUNT(*) FILTER (WHERE r.mention_position > 0)::bigint    AS pos_n,
+
+         COUNT(*) FILTER (WHERE r.created_at >= b.cur_from)::bigint AS cur_answers,
+         COUNT(*) FILTER (WHERE r.created_at >= b.cur_from AND r.mentions > 0)::bigint
+                                                                    AS cur_mention_answers,
+         COUNT(*) FILTER (WHERE r.created_at >= b.cur_from AND r.citations > 0)::bigint
+                                                                    AS cur_citation_answers,
+         COALESCE(SUM(1.0 / r.mention_position)
+           FILTER (WHERE r.created_at >= b.cur_from AND r.mention_position > 0), 0)::double precision
+                                                                    AS cur_pos_sum,
+         COUNT(*) FILTER (WHERE r.created_at >= b.cur_from AND r.mention_position > 0)::bigint
+                                                                    AS cur_pos_n,
+
+         COUNT(*) FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from)::bigint
+                                                                    AS prev_answers,
+         COUNT(*) FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from
+           AND r.mentions > 0)::bigint                              AS prev_mention_answers,
+         COUNT(*) FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from
+           AND r.citations > 0)::bigint                             AS prev_citation_answers,
+         COALESCE(SUM(1.0 / r.mention_position)
+           FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from
+             AND r.mention_position > 0), 0)::double precision      AS prev_pos_sum,
+         COUNT(*) FILTER (WHERE r.created_at < b.cur_from AND r.created_at >= b.prev_from
+           AND r.mention_position > 0)::bigint                      AS prev_pos_n,
+
+         COALESCE(SUM(r.mentions), 0)::bigint                       AS total_mentions,
+         COALESCE(SUM(r.citations), 0)::bigint                      AS total_citations,
+         COUNT(DISTINCT r.prompt_id)::bigint                        AS active_prompts,
+         COUNT(DISTINCT r.prompt_id) FILTER (WHERE r.visible)::bigint AS visible_prompts,
+         MAX(r.created_at)                                          AS last_run_at
+  FROM rows r
+  CROSS JOIN bounds b
+  GROUP BY r.topic_id
+)
+-- The two jsonb rollups join on at the end rather than riding through the
+-- GROUP BY: Postgres has no max(jsonb), and carrying them through an
+-- aggregate would need a wrapper that buys nothing here.
+SELECT m.topic_id,
+       m.answers, m.mention_answers, m.citation_answers, m.pos_sum, m.pos_n,
+       m.cur_answers, m.cur_mention_answers, m.cur_citation_answers, m.cur_pos_sum, m.cur_pos_n,
+       m.prev_answers, m.prev_mention_answers, m.prev_citation_answers, m.prev_pos_sum, m.prev_pos_n,
+       m.total_mentions, m.total_citations,
+       COALESCE(ct.comp_mentions, 0)::bigint,
+       m.active_prompts, m.visible_prompts, m.last_run_at,
+       COALESCE(ct.competitors, '{}'::jsonb),
+       COALESCE(dl.daily, '{}'::jsonb)
+FROM main m
+LEFT JOIN comp_totals ct ON ct.topic_id = m.topic_id
+LEFT JOIN daily dl       ON dl.topic_id = m.topic_id
+$$;
+
+GRANT EXECUTE ON FUNCTION public.topics_overview_aggregates(uuid) TO authenticated;
+

--- a/web/src/lib/actions/topic.ts
+++ b/web/src/lib/actions/topic.ts
@@ -2,7 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { computeAiVisibilityScore } from '@/lib/visibility-score';
-import type { CompetitorMention, Topic } from '@/types';
+import type { Topic } from '@/types';
 
 function mapTopicRow(row: Record<string, unknown>): Topic {
   return {
@@ -152,22 +152,23 @@ export interface TopicOverviewSummary {
  * agree with the Insights KPIs on the same 30d window (#464).
  */
 /**
- * PostgREST silently caps un-paginated selects at 1000 rows, which sampled the
- * topic aggregation on exactly the brands with the most data (#464) — page
- * through the window instead, with a hard ceiling so a pathological brand
- * can't pin the server action. Mirrors the citations scans (#430).
+ * The roster read still pages: PostgREST silently caps an un-paginated select
+ * at 1000 rows, and a brand can hold more prompts than that (#464).
+ *
+ * The result window no longer has a ceiling. It used to stop at 50,000 rows —
+ * the largest brand was already at 32,607, and crossing it would have
+ * truncated the scan silently, understating every figure on the page (#721).
+ * Aggregating in Postgres removes the cliff rather than raising it.
  */
 const TOPIC_RESULTS_PAGE_SIZE = 1000;
-const TOPIC_RESULTS_MAX_ROWS = 50_000;
 const TOPIC_PROMPTS_MAX_ROWS = 10_000;
 
 export async function getTopicsOverview(brandId: string): Promise<TopicOverviewSummary> {
   const supabase = await createClient();
 
+  // Only the sparkline's day keys are built here now; every window boundary
+  // is resolved inside the aggregate, from the database's clock.
   const now = Date.now();
-  const since30d = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
-  const curFrom = new Date(now - 7 * 24 * 60 * 60 * 1000).getTime();
-  const prevFrom = new Date(now - 14 * 24 * 60 * 60 * 1000).getTime();
 
   const [topicsRes, setsRes] = await Promise.all([
     supabase
@@ -209,243 +210,134 @@ export async function getTopicsOverview(brandId: string): Promise<TopicOverviewS
     }
   }
 
-  const promptTopicMap = new Map<string, string | null>();
-  for (const p of prompts) promptTopicMap.set(p.id, p.topic_id);
-
-  interface Agg {
-    // Prompt-level visibility (#490): distinct prompts with results vs
-    // distinct prompts where the brand appeared, per window.
-    allPrompts: Set<string>;
-    visiblePrompts: Set<string>;
-    curPrompts: Set<string>;
-    curVisiblePrompts: Set<string>;
-    prevPrompts: Set<string>;
-    prevVisiblePrompts: Set<string>;
-    totalMentions: number;
-    totalCitations: number;
-    answers: number;
-    mentionAnswers: number;
-    citationAnswers: number;
-    posSum: number;
-    posN: number;
-    curAnswers: number;
-    curMentionAnswers: number;
-    curCitationAnswers: number;
-    curPosSum: number;
-    curPosN: number;
-    prevAnswers: number;
-    prevMentionAnswers: number;
-    prevCitationAnswers: number;
-    prevPosSum: number;
-    prevPosN: number;
-    brandMentions: number;
-    compMentions: number;
-    lastRunAt: number;
-    competitors: Map<string, { name: string; sov: number }>;
-    daily: Map<string, { visible: number; count: number }>;
-  }
-  const emptyAgg = (): Agg => ({
-    allPrompts: new Set(),
-    visiblePrompts: new Set(),
-    curPrompts: new Set(),
-    curVisiblePrompts: new Set(),
-    prevPrompts: new Set(),
-    prevVisiblePrompts: new Set(),
-    totalMentions: 0,
-    totalCitations: 0,
-    answers: 0,
-    mentionAnswers: 0,
-    citationAnswers: 0,
-    posSum: 0,
-    posN: 0,
-    curAnswers: 0,
-    curMentionAnswers: 0,
-    curCitationAnswers: 0,
-    curPosSum: 0,
-    curPosN: 0,
-    prevAnswers: 0,
-    prevMentionAnswers: 0,
-    prevCitationAnswers: 0,
-    prevPosSum: 0,
-    prevPosN: 0,
-    brandMentions: 0,
-    compMentions: 0,
-    lastRunAt: 0,
-    competitors: new Map(),
-    daily: new Map(),
-  });
-
-  const aggByTopic = new Map<string, Agg>();
   let unassignedPromptCount = 0;
+  const promptCountByTopic = new Map<string, number>();
   for (const p of prompts) {
     if (!p.topic_id) {
       unassignedPromptCount += 1;
       continue;
     }
-    if (!aggByTopic.has(p.topic_id)) aggByTopic.set(p.topic_id, emptyAgg());
-  }
-
-  const promptCountByTopic = new Map<string, number>();
-  for (const p of prompts) {
-    if (!p.topic_id) continue;
     promptCountByTopic.set(p.topic_id, (promptCountByTopic.get(p.topic_id) ?? 0) + 1);
   }
 
-  const processRow = (row: Record<string, unknown>) => {
-    const promptId = row.prompt_id as string;
-    const topicId = promptTopicMap.get(promptId);
-    if (!topicId) return;
+  // One aggregate per brand instead of downloading the window (#721). The page
+  // used to page through every result row — 33 requests and 73 MB on the
+  // largest brand — to compute twenty table rows in JavaScript. The arithmetic
+  // now runs where the data is; only the AI Visibility Score stays here, over
+  // ~20 rows, so this page and the Insights headline keep one implementation.
+  const { data: aggRows, error: aggError } = await supabase.rpc('topics_overview_aggregates', {
+    p_brand_id: brandId,
+  });
+  if (aggError) throw new Error(aggError.message);
 
-    const agg = aggByTopic.get(topicId);
-    if (!agg) return;
-
-    const createdAt = row.created_at as string;
-    const ts = new Date(createdAt).getTime();
-    const mentions = (row.mention_count as number) ?? 0;
-    const citations = (row.citation_count as number) ?? 0;
-    // Same "appeared" rule as the Insights rate (#490).
-    const visible = mentions > 0 || citations > 0;
-
-    agg.allPrompts.add(promptId);
-    if (visible) agg.visiblePrompts.add(promptId);
-    agg.totalMentions += mentions;
-    agg.totalCitations += citations;
-    agg.brandMentions += mentions;
-    if (ts > agg.lastRunAt) agg.lastRunAt = ts;
-
-    // AI Visibility Score components (answer-level).
-    const pos = row.mention_position as number | null;
-    agg.answers += 1;
-    if (mentions > 0) agg.mentionAnswers += 1;
-    if (citations > 0) agg.citationAnswers += 1;
-    if (pos !== null && pos !== undefined && pos > 0) {
-      agg.posSum += 1 / pos;
-      agg.posN += 1;
-    }
-
-    if (ts >= curFrom) {
-      agg.curPrompts.add(promptId);
-      if (visible) agg.curVisiblePrompts.add(promptId);
-      agg.curAnswers += 1;
-      if (mentions > 0) agg.curMentionAnswers += 1;
-      if (citations > 0) agg.curCitationAnswers += 1;
-      if (pos !== null && pos !== undefined && pos > 0) {
-        agg.curPosSum += 1 / pos;
-        agg.curPosN += 1;
-      }
-    } else if (ts >= prevFrom) {
-      agg.prevPrompts.add(promptId);
-      if (visible) agg.prevVisiblePrompts.add(promptId);
-      agg.prevAnswers += 1;
-      if (mentions > 0) agg.prevMentionAnswers += 1;
-      if (citations > 0) agg.prevCitationAnswers += 1;
-      if (pos !== null && pos !== undefined && pos > 0) {
-        agg.prevPosSum += 1 / pos;
-        agg.prevPosN += 1;
-      }
-    }
-
-    const day = createdAt.slice(0, 10);
-    const d = agg.daily.get(day) ?? { visible: 0, count: 0 };
-    if (visible) d.visible += 1;
-    d.count += 1;
-    agg.daily.set(day, d);
-
-    const compMentions = (row.competitor_mentions as CompetitorMention[] | null) ?? [];
-    const compTotalsForRow = new Map<string, { name: string; mentions: number }>();
-    for (const cm of compMentions) {
-      agg.compMentions += cm.mention_count;
-      const existing = compTotalsForRow.get(cm.competitor_id) ?? {
-        name: cm.name,
-        mentions: 0,
-      };
-      existing.mentions += cm.mention_count;
-      compTotalsForRow.set(cm.competitor_id, existing);
-    }
-    for (const [compId, info] of compTotalsForRow) {
-      const ec = agg.competitors.get(compId) ?? { name: info.name, sov: 0 };
-      ec.sov += info.mentions;
-      agg.competitors.set(compId, ec);
-    }
-  };
-
-  // Paged scan over the 30-day window, aggregated per batch. Excludes
-  // chatgpt-shopping so the totals match the Insights aggregates (#155/#464).
-  for (let from = 0; from < TOPIC_RESULTS_MAX_ROWS; from += TOPIC_RESULTS_PAGE_SIZE) {
-    const { data, error } = await supabase
-      .from('prompt_results')
-      .select(
-        'prompt_id, created_at, visibility_score, mention_count, citation_count, mention_position, competitor_mentions',
-      )
-      .eq('brand_id', brandId)
-      .neq('platform', 'chatgpt-shopping')
-      .gte('created_at', since30d)
-      // Deterministic order so .range() pages don't shuffle between requests.
-      .order('created_at', { ascending: true })
-      .order('id', { ascending: true })
-      .range(from, from + TOPIC_RESULTS_PAGE_SIZE - 1);
-    if (error) throw new Error(error.message);
-
-    const batch = (data ?? []) as Record<string, unknown>[];
-    for (const row of batch) processRow(row);
-    if (batch.length < TOPIC_RESULTS_PAGE_SIZE) break;
+  interface TopicAggRow {
+    topic_id: string;
+    answers: number;
+    mention_answers: number;
+    citation_answers: number;
+    pos_sum: number;
+    pos_n: number;
+    cur_answers: number;
+    cur_mention_answers: number;
+    cur_citation_answers: number;
+    cur_pos_sum: number;
+    cur_pos_n: number;
+    prev_answers: number;
+    prev_mention_answers: number;
+    prev_citation_answers: number;
+    prev_pos_sum: number;
+    prev_pos_n: number;
+    total_mentions: number;
+    total_citations: number;
+    comp_mentions: number;
+    active_prompts: number;
+    visible_prompts: number;
+    last_run_at: string | null;
+    competitors: Record<string, { name: string; sov: number }>;
+    daily: Record<string, { visible: number; count: number }>;
   }
 
+  const aggByTopic = new Map<string, TopicAggRow>(
+    ((aggRows ?? []) as unknown as TopicAggRow[]).map((row) => [row.topic_id, row]),
+  );
+
+  const scoreOf = (
+    answers: number,
+    mention: number,
+    citation: number,
+    posSum: number,
+    posN: number,
+  ) =>
+    computeAiVisibilityScore({
+      answers,
+      mentionAnswers: mention,
+      citationAnswers: citation,
+      positionFactor: posN > 0 ? posSum / posN : null,
+    }) ?? 0;
+
   const rows: TopicOverviewRow[] = topics.map((t) => {
-    const agg = aggByTopic.get(t.id) ?? emptyAgg();
+    const agg = aggByTopic.get(t.id);
     const promptCount = promptCountByTopic.get(t.id) ?? 0;
 
-    // Visibility Rate now IS the AI Visibility Score over the topic's
-    // answers — same blend as the Insights headline (see lib/visibility-score).
-    const scoreOf = (
-      answers: number,
-      mention: number,
-      citation: number,
-      posSum: number,
-      posN: number,
-    ) =>
-      computeAiVisibilityScore({
-        answers,
-        mentionAnswers: mention,
-        citationAnswers: citation,
-        positionFactor: posN > 0 ? posSum / posN : null,
-      }) ?? 0;
+    if (!agg) {
+      // A topic with prompts but no answers in the window still belongs in the
+      // table — dropping it would make the roster disagree with itself.
+      return {
+        id: t.id,
+        name: t.name,
+        promptCount,
+        visibilityRate: 0,
+        visiblePrompts: 0,
+        activePrompts: 0,
+        visibilityChange: null,
+        totalMentions: 0,
+        totalCitations: 0,
+        shareOfVoice: 0,
+        topCompetitor: null,
+        lastRunAt: null,
+        trendSparkline: Array.from({ length: 14 }, () => 0),
+      };
+    }
+
+    // Visibility Rate IS the AI Visibility Score over the topic's answers —
+    // same blend as the Insights headline (see lib/visibility-score).
     const visibilityRate = scoreOf(
       agg.answers,
-      agg.mentionAnswers,
-      agg.citationAnswers,
-      agg.posSum,
-      agg.posN,
+      agg.mention_answers,
+      agg.citation_answers,
+      agg.pos_sum,
+      agg.pos_n,
     );
     const change =
-      agg.curAnswers > 0 && agg.prevAnswers > 0
+      agg.cur_answers > 0 && agg.prev_answers > 0
         ? Math.round(
             (scoreOf(
-              agg.curAnswers,
-              agg.curMentionAnswers,
-              agg.curCitationAnswers,
-              agg.curPosSum,
-              agg.curPosN,
+              agg.cur_answers,
+              agg.cur_mention_answers,
+              agg.cur_citation_answers,
+              agg.cur_pos_sum,
+              agg.cur_pos_n,
             ) -
               scoreOf(
-                agg.prevAnswers,
-                agg.prevMentionAnswers,
-                agg.prevCitationAnswers,
-                agg.prevPosSum,
-                agg.prevPosN,
+                agg.prev_answers,
+                agg.prev_mention_answers,
+                agg.prev_citation_answers,
+                agg.prev_pos_sum,
+                agg.prev_pos_n,
               )) *
               10,
           ) / 10
         : null;
 
-    const totalForSov = agg.brandMentions + agg.compMentions;
+    // The brand's own mentions are the same total the table shows.
+    const totalForSov = agg.total_mentions + agg.comp_mentions;
     const shareOfVoice =
-      totalForSov > 0 ? Math.round((agg.brandMentions / totalForSov) * 1000) / 10 : 0;
+      totalForSov > 0 ? Math.round((agg.total_mentions / totalForSov) * 1000) / 10 : 0;
 
     let topCompetitor: TopicOverviewRow['topCompetitor'] = null;
-    if (totalForSov > 0 && agg.competitors.size > 0) {
+    if (totalForSov > 0) {
       let best: { name: string; sov: number } | null = null;
-      for (const c of agg.competitors.values()) {
+      for (const c of Object.values(agg.competitors ?? {})) {
         const pct = Math.round((c.sov / totalForSov) * 1000) / 10;
         if (!best || pct > best.sov) best = { name: c.name, sov: pct };
       }
@@ -453,13 +345,11 @@ export async function getTopicsOverview(brandId: string): Promise<TopicOverviewS
     }
 
     // Daily visible-answer share (result-level) — a trend proxy for the
-    // prompt-level headline rate; sparklines have no axis, only shape matters.
+    // headline rate; sparklines have no axis, only shape matters.
     const sparklineDays: number[] = [];
-    const todayMs = now;
     for (let i = 13; i >= 0; i--) {
-      const d = new Date(todayMs - i * 24 * 60 * 60 * 1000);
-      const key = d.toISOString().slice(0, 10);
-      const bucket = agg.daily.get(key);
+      const key = new Date(now - i * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+      const bucket = agg.daily?.[key];
       sparklineDays.push(
         bucket && bucket.count > 0 ? Math.round((bucket.visible / bucket.count) * 100) : 0,
       );
@@ -470,14 +360,14 @@ export async function getTopicsOverview(brandId: string): Promise<TopicOverviewS
       name: t.name,
       promptCount,
       visibilityRate,
-      visiblePrompts: agg.visiblePrompts.size,
-      activePrompts: agg.allPrompts.size,
+      visiblePrompts: agg.visible_prompts,
+      activePrompts: agg.active_prompts,
       visibilityChange: change,
-      totalMentions: agg.totalMentions,
-      totalCitations: agg.totalCitations,
+      totalMentions: agg.total_mentions,
+      totalCitations: agg.total_citations,
       shareOfVoice,
       topCompetitor,
-      lastRunAt: agg.lastRunAt > 0 ? new Date(agg.lastRunAt).toISOString() : null,
+      lastRunAt: agg.last_run_at,
       trendSparkline: sparklineDays,
     };
   });

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -2291,6 +2291,35 @@ export type Database = {
         }
         Returns: Json
       }
+      topics_overview_aggregates: {
+        Args: { p_brand_id: string }
+        Returns: {
+          active_prompts: number
+          answers: number
+          citation_answers: number
+          comp_mentions: number
+          competitors: Json
+          cur_answers: number
+          cur_citation_answers: number
+          cur_mention_answers: number
+          cur_pos_n: number
+          cur_pos_sum: number
+          daily: Json
+          last_run_at: string
+          mention_answers: number
+          pos_n: number
+          pos_sum: number
+          prev_answers: number
+          prev_citation_answers: number
+          prev_mention_answers: number
+          prev_pos_n: number
+          prev_pos_sum: number
+          topic_id: string
+          total_citations: number
+          total_mentions: number
+          visible_prompts: number
+        }[]
+      }
       tracked_prompt_count: {
         Args: {
           p_brand_id: string


### PR DESCRIPTION
## Summary

The Topics page fetched the brand's entire 30-day result set to render twenty table rows — **33 sequential requests, 73 MB of JSON, 19.3 s end to end** on the largest brand.

`topics_overview_aggregates` does in Postgres what the client was doing in JavaScript. Only the AI Visibility Score stays on the client, over ~20 rows, so this page and the Insights headline keep computing it from one implementation.

| | before | after |
| --- | --- | --- |
| requests | 33 | 1 |
| payload | 73.1 MB | **33 kB** |
| time | 19,334 ms | **736 ms** (function), ~1.0 s over HTTP |

## Correctness first

The old client-side aggregation and the new function were run **side by side against the live database** before the page was switched over. They agree exactly on all seventeen topics, across every field: answers, mention answers, citation answers, position sum and n, total mentions, total citations, competitor mentions, active prompts, visible prompts and last run.

Two details that would have broken it silently and are handled explicitly:

- **Sparkline buckets are keyed in UTC** (`AT TIME ZONE 'UTC'`), because the client builds the same keys from `Date.toISOString()`. Reading them in the session timezone would shift every bucket by the offset and quietly redraw the trend.
- **Window boundaries resolve inside the function**, from the database's clock, rather than being passed in from the caller's.

## The 4.5 s detour, and why the competitor rollup re-scans

The first working version was still 4.5 s with 7,500 temp blocks. `rows` is referenced several times, so Postgres materialises it — and carrying `competitor_mentions` through that materialisation spills 32k detoasted jsonb values to disk. It was the same over-fetch as before, just moved inside the database.

Reading that column only where it is needed, in its own scan, brought the function to 736 ms. The CTE comment says so, since the shape looks redundant otherwise.

## The 50,000-row cliff is gone

`TOPIC_RESULTS_MAX_ROWS` stopped the scan at 50,000 rows with no error. The largest brand was at **32,607** — 65% of the way there — and crossing it would have understated every figure on the page. Same class of defect as #464, which the constant was added to fix. Aggregating server-side removes the cliff rather than raising it.

`visibility_score` was also being selected and never read; it is gone with the scan.

## Related issue

Closes #721

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [x] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Open **Topics** on a brand with a lot of history — it should render in about a second rather than stalling.
2. Compare the table against what it showed before: visibility rate, change, mentions, citations, share of voice, top competitor, active/visible prompts, last run and the sparkline shape must all be unchanged.
3. A topic with prompts but no answers in the window still appears, with zeros — dropping it would make the roster disagree with itself.
4. Brands with little data are unaffected.

`yarn typecheck`, `yarn lint` (6 pre-existing warnings, 0 errors), `yarn format:check` and `yarn build` pass locally.

The types file is regenerated to include the new function — without it `supabase.rpc('topics_overview_aggregates', …)` does not type-check.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] `supabase/schema.sql` regenerated via `bash supabase/build-schema.sh`
- [x] Changes are focused — one concern per PR