### PR TITLE
fix(content): keep filters reachable on zero results, and allow deleting selections

### DIFF
--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -256,6 +256,46 @@ router.post('/bulk/status', async (req, res) => {
 });
 
 /**
+ * POST /api/content/bulk/delete
+ *
+ * Permanently remove opportunities (#731). Dismissing only hides a row behind
+ * a status filter, which is no help to a brand carrying hundreds of stale
+ * suggestions — this is the way to actually clear them.
+ *
+ * The generated brief lives on the opportunity row, so deleting takes it with
+ * it. `brief_usage.opportunity_id` is ON DELETE SET NULL, so the metered usage
+ * record survives and quota already spent stays spent — deleting must not hand
+ * back a brief allowance.
+ */
+router.post('/bulk/delete', async (req, res) => {
+  try {
+    const { ids } = req.body;
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return res.status(400).json({ error: 'ids must be a non-empty array' });
+    }
+
+    await assertOpportunitiesAccess(ids, req.user.id);
+
+    const { data, error } = await supabaseAdmin
+      .from('content_opportunities')
+      .delete()
+      .in('id', ids)
+      .select('id');
+
+    if (error) throw new Error(error.message);
+
+    return res.json({ deleted: data?.length || 0 });
+  } catch (error) {
+    req.log.error({ err: error }, 'bulk delete error');
+    return res.status(error.status || 500).json({
+      error: 'Failed to delete opportunities',
+      details: error.message,
+    });
+  }
+});
+
+/**
  * POST /api/content/bulk/send-webhook
  * Send multiple opportunities to webhook.
  */

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -252,6 +252,7 @@
     "sendToWorkflow": "Send to Workflow",
     "sending": "Sending...",
     "noResults": "No opportunities match your filters.",
+    "clearFilters": "Clear filters",
     "dismiss": "Dismiss",
     "dismissedToast": "Opportunity dismissed",
     "undo": "Undo",
@@ -299,7 +300,12 @@
       "sendAll": "Send All",
       "dismissAll": "Dismiss All",
       "dismissAllTitle": "Dismiss opportunities?",
-      "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} This can't be undone."
+      "dismissAllConfirm": "{count, plural, one {This will dismiss # opportunity.} other {This will dismiss # opportunities.}} This can't be undone.",
+      "deleteAll": "Delete",
+      "deleteAllTitle": "Delete opportunities?",
+      "deleteAllConfirm": "{count, plural, one {This permanently deletes # opportunity.} other {This permanently deletes # opportunities.}} Dismissing instead keeps them out of your way without removing them.",
+      "deleteAllBriefWarning": "{count, plural, one {# of them has a generated brief, which is deleted too and does not return your monthly brief allowance.} other {# of them have generated briefs, which are deleted too and do not return your monthly brief allowance.}}",
+      "deletedToast": "{count, plural, one {Deleted # opportunity} other {Deleted # opportunities}}"
     },
     "table": {
       "action": "Action",

--- a/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/content/page.tsx
@@ -44,6 +44,7 @@ import {
   ExternalLink,
   X,
   Settings2,
+  Trash2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useBrandStore } from '@/stores/use-brand-store';
@@ -56,6 +57,7 @@ import {
   sendToWebhook,
   bulkSendToWebhook,
   bulkUpdateStatus,
+  bulkDeleteOpportunities,
 } from '@/lib/actions/content';
 import type { ContentOpportunity, ContentOpportunityStatus } from '@/types';
 import { toast } from 'sonner';
@@ -419,11 +421,52 @@ export default function ContentPage() {
     }
   };
 
+  const handleBulkDelete = async () => {
+    setBulkSending(true);
+    try {
+      const ids = Array.from(selectedIds);
+      const result = await bulkDeleteOpportunities(ids);
+      toast.success(t('bulk.deletedToast', { count: result.deleted }));
+      setSelectedIds(new Set());
+      // No page reset needed: `usePagination` clamps to the last page that
+      // still exists, and the narrowed `start` refetches on its own. Resetting
+      // here as well would fire a second, competing load.
+      await loadData(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Bulk delete failed');
+    } finally {
+      setBulkSending(false);
+    }
+  };
+
   const filtered = opportunities.filter(
     (o) =>
       o.title.toLowerCase().includes(search.toLowerCase()) ||
       (o.description || '').toLowerCase().includes(search.toLowerCase()),
   );
+
+  /** How many of the selected rows would lose a generated brief (#731). */
+  const selectedWithBrief = opportunities.filter(
+    (o) => selectedIds.has(o.id) && Boolean(o.brief),
+  ).length;
+
+  // "The brand has nothing" and "this filter matched nothing" are different
+  // states with different remedies, and the page used to answer both with the
+  // Generate card — which hid the very controls needed to undo the filter
+  // (#660). The unfiltered view is the only one whose emptiness means the
+  // brand truly has no opportunities.
+  const hasActiveFilters =
+    statusFilter !== 'all' ||
+    impactFilter !== 'all' ||
+    typeFilter !== 'all' ||
+    search.trim() !== '';
+
+  const clearFilters = () => {
+    setStatusFilter('all');
+    setImpactFilter('all');
+    setTypeFilter('all');
+    setSearch('');
+  };
 
   if (!activeBrandId) {
     return (
@@ -478,7 +521,7 @@ export default function ContentPage() {
         <div className="flex items-center justify-center min-h-[300px]">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
-      ) : opportunities.length === 0 ? (
+      ) : opportunities.length === 0 && !hasActiveFilters ? (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-16 gap-4">
             <Lightbulb className="h-12 w-12 text-muted-foreground/40" />
@@ -660,6 +703,47 @@ export default function ContentPage() {
                       </DialogFooter>
                     </DialogContent>
                   </Dialog>
+
+                  {/* Last in the row, and the only destructive-styled trigger:
+                      this one does not move a row, it removes it. */}
+                  <Dialog>
+                    <DialogTrigger
+                      render={
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs gap-1.5 text-destructive hover:text-destructive"
+                          disabled={bulkSending}
+                        />
+                      }
+                    >
+                      <Trash2 className="h-3 w-3" />
+                      {t('bulk.deleteAll')}
+                    </DialogTrigger>
+                    <DialogContent className="sm:max-w-sm">
+                      <DialogHeader>
+                        <DialogTitle>{t('bulk.deleteAllTitle')}</DialogTitle>
+                        <DialogDescription>
+                          {t('bulk.deleteAllConfirm', { count: selectedIds.size })}
+                          {selectedWithBrief > 0 && (
+                            <span className="mt-2 block font-medium text-foreground">
+                              {t('bulk.deleteAllBriefWarning', { count: selectedWithBrief })}
+                            </span>
+                          )}
+                        </DialogDescription>
+                      </DialogHeader>
+                      <DialogFooter>
+                        <DialogClose render={<Button variant="outline" />}>
+                          {t('cancel')}
+                        </DialogClose>
+                        <DialogClose
+                          render={<Button variant="destructive" onClick={handleBulkDelete} />}
+                        >
+                          {t('bulk.deleteAll')}
+                        </DialogClose>
+                      </DialogFooter>
+                    </DialogContent>
+                  </Dialog>
                 </div>
               </div>
             )}
@@ -791,8 +875,14 @@ export default function ContentPage() {
                 </TableBody>
               </Table>
               {filtered.length === 0 && (
-                <div className="py-10 text-center text-sm text-muted-foreground">
-                  {t('noResults')}
+                <div className="flex flex-col items-center gap-3 py-10 text-center">
+                  <p className="text-sm text-muted-foreground">{t('noResults')}</p>
+                  {hasActiveFilters && (
+                    <Button variant="outline" size="sm" className="gap-1.5" onClick={clearFilters}>
+                      <X className="h-3.5 w-3.5" />
+                      {t('clearFilters')}
+                    </Button>
+                  )}
                 </div>
               )}
               <TablePager

--- a/web/src/lib/actions/content.ts
+++ b/web/src/lib/actions/content.ts
@@ -285,6 +285,33 @@ export async function bulkUpdateStatus(
   return res.json();
 }
 
+/**
+ * Permanently delete opportunities (#731).
+ *
+ * Distinct from `bulkUpdateStatus(ids, 'dismissed')`, which only moves a row
+ * behind a status filter. Anything deleted here is gone, including any brief
+ * generated for it.
+ */
+export async function bulkDeleteOpportunities(ids: string[]): Promise<{ deleted: number }> {
+  const session = await getSession();
+
+  const res = await fetch(`${AEO_SERVER_URL}/api/content/bulk/delete`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify({ ids }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Server error: ${res.status}`);
+  }
+
+  return res.json();
+}
+
 export type BulkSendResult =
   | {
       success: true;


### PR DESCRIPTION
## Summary

Two problems on the Content page, both about a list the reader cannot get out of. They share the same file and the same bulk bar, so they land together.

**Zero-result filters hid the filters themselves (#660).** Selecting a filter combination that matched nothing unmounted the whole content branch — filter bar included — and replaced it with the "No content opportunities yet" + Generate card. The filter values live in React state, so the reader was left with no control on screen to undo their own choice, and the empty state was wrong: data existed, the filter just matched nothing.

Only the unfiltered view can say a brand truly has no opportunities, so the Generate card is now gated on `!hasActiveFilters`. When filters are active the header, KPIs, filter bar and table stay rendered, and the existing no-matches message — previously unreachable in this state — now carries a **Clear filters** button.

**Nothing could be removed (#731).** The bulk bar offered send, done and dismiss. Dismissing only moves a row behind a status filter and leaves it in the table, which is no help to a brand carrying hundreds of stale suggestions: across production the open list averages 147 rows per brand, against 114 dismissed in total across every brand.

Delete now sits last in the bar and is the only destructive-styled trigger there. It opens a confirmation stating the count, following the same `Dialog` shape as Dismiss all.

Two details worth calling out in review:

- **Briefs go with the row.** The generated brief is a column on the opportunity, not a separate record, and briefs are metered against a monthly quota. When the selection includes one the dialog says so in its own line rather than describing every deletion identically. `brief_usage.opportunity_id` is `ON DELETE SET NULL`, so the usage record survives and quota already spent stays spent — deleting must not hand back an allowance.
- **Authorization is unchanged.** The new endpoint guards with `assertOpportunitiesAccess(ids, req.user.id)`, exactly like `POST /bulk/status` next to it, so deletion is available to any org member. #731 raised whether permanent deletion should instead be admin/manager only. That is a product decision and is deliberately not made here; say the word and it is a one-line change.

Single-row deletion is intentionally out of scope — on a list this long a per-row delete invites accidents.

## Related issue

Closes #660
Closes #731

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

**Filters (#660)**

1. On a brand with opportunities, set Status to a value with no rows (e.g. `dismissed` on a brand that has none).
2. The filter bar stays visible, the message reads "No opportunities match your filters", and a **Clear filters** button is offered.
3. Click it — all four controls (status, impact, type, search) reset and the list returns.
4. On a brand with no opportunities at all and no filters active, the "No content opportunities yet" + Generate card still appears, unchanged.

**Delete (#731)**

5. Select several rows; **Delete** appears only while a selection exists.
6. Open the dialog and cancel — nothing is removed.
7. Confirm — the rows are gone after a reload, not merely hidden behind a status filter.
8. Select a row that has a generated brief and confirm the dialog adds the brief warning.
9. Delete enough rows from the last page to empty it and confirm the pager lands on a page that still exists rather than a blank one.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

`yarn build` and the server test suite (276 tests) also pass locally.
