### PR TITLE
fix(tracking): stop submitting Grok tasks while Cloro returns 500 for all of them

### DIFF
--- a/server/src/workers/tracking-worker.js
+++ b/server/src/workers/tracking-worker.js
@@ -20,6 +20,41 @@ function resolveModelPlatform(model) {
 }
 
 /**
+ * Platforms Cloro cannot currently deliver, dropped before anything is
+ * submitted.
+ *
+ * Grok started answering every task with a 500 on 2026-08-18. Leaving it in
+ * the run would submit a paid task per prompt per region, hold the drain open
+ * waiting for results that never arrive, and record nothing — so the platform
+ * is removed up front rather than failing task by task.
+ *
+ * Deliberately a run-time filter and nothing else. Dropping Grok from the
+ * engine picker would also drop it from `ALL_SCRAPERS`, which
+ * `filterByPlan` and `alignPromptsToPlanForOrg` use as the allow-set when
+ * writing prompts — so every prompt edit and every plan change would quietly
+ * strip the stored id, and restoring Grok would need a data repair rather
+ * than a revert. Empty this list when Cloro reports Grok healthy again and
+ * every prompt that still lists it resumes on the next run.
+ */
+export const UNAVAILABLE_PLATFORMS = ['grok-web'];
+
+/**
+ * The platforms a prompt should actually be run against.
+ *
+ * Prompts keep whatever platform ids they were saved with, so the stored array
+ * cannot be trusted at run time: a brand may have turned Shopping off since,
+ * and a platform may be down. Both are filtered here rather than at the picker,
+ * because every id that survives becomes a paid Cloro submission.
+ */
+export function runnablePlatforms(platforms, { shoppingEnabled } = {}) {
+  return (platforms ?? []).filter(
+    (platform) =>
+      !UNAVAILABLE_PLATFORMS.includes(platform) &&
+      (shoppingEnabled || platform !== 'chatgpt-shopping'),
+  );
+}
+
+/**
  * PostgREST silently caps an un-paginated select at 1000 rows, so reading a
  * brand's pending tasks in one request under-reports any run that submitted
  * more than that (#714). Page through instead.
@@ -210,17 +245,8 @@ export async function processTrackingJob({ brandId, promptId, promptIds, source,
     return allowedModels ? models.filter((m) => allowedModels.includes(m)) : models;
   };
 
-  // Shopping tracking is opt-in per brand: prompts can still carry the
-  // chatgpt-shopping platform from before the brand turned Shopping off (or
-  // from a picker that offered it regardless of the pref), so filter at run
-  // time instead of trusting the stored arrays — each skipped task is a paid
-  // Cloro scrape for data the brand can't even see.
-  const allowedPlatformsFor = (prompt) => {
-    const platforms = prompt.platforms && prompt.platforms.length > 0 ? prompt.platforms : [];
-    return brand.shopping_mode_enabled
-      ? platforms
-      : platforms.filter((p) => p !== 'chatgpt-shopping');
-  };
+  const allowedPlatformsFor = (prompt) =>
+    runnablePlatforms(prompt.platforms, { shoppingEnabled: brand.shopping_mode_enabled });
 
   // 4. Count total tasks: prompt × (models + scrapers) × regions
   let totalTasks = 0;

--- a/server/src/workers/tracking-worker.test.js
+++ b/server/src/workers/tracking-worker.test.js
@@ -4,7 +4,13 @@ import { describe, expect, it, vi } from 'vitest';
 // SUPABASE_* env is absent (as in CI) — stub it before the import chain.
 vi.mock('../config/supabase.js', () => ({ default: {} }));
 
-import { allTasksAreStale, drainBudgetExceeded, fetchAllPendingRows } from './tracking-worker.js';
+import {
+  allTasksAreStale,
+  drainBudgetExceeded,
+  fetchAllPendingRows,
+  runnablePlatforms,
+  UNAVAILABLE_PLATFORMS,
+} from './tracking-worker.js';
 
 /**
  * Ghost detection for the Cloro drain loop (#687).
@@ -202,5 +208,47 @@ describe('fetchAllPendingRows', () => {
 
     expect(rows).toEqual([]);
     expect(error).toBeNull();
+  });
+});
+
+/**
+ * What a run is allowed to submit (#731 follow-up).
+ *
+ * Every id that survives this filter becomes a paid Cloro task, so the two
+ * reasons to drop one — the brand turned Shopping off, the platform is down —
+ * both have to hold at run time, not at the moment the prompt was saved.
+ */
+describe('runnablePlatforms', () => {
+  it('drops a platform that is currently unavailable', () => {
+    expect(
+      runnablePlatforms(['chatgpt-web', 'grok-web', 'perplexity-web'], { shoppingEnabled: true }),
+    ).toEqual(['chatgpt-web', 'perplexity-web']);
+  });
+
+  it('drops shopping unless the brand has it enabled', () => {
+    expect(
+      runnablePlatforms(['chatgpt-web', 'chatgpt-shopping'], { shoppingEnabled: false }),
+    ).toEqual(['chatgpt-web']);
+    expect(
+      runnablePlatforms(['chatgpt-web', 'chatgpt-shopping'], { shoppingEnabled: true }),
+    ).toEqual(['chatgpt-web', 'chatgpt-shopping']);
+  });
+
+  it('applies both reasons at once', () => {
+    expect(
+      runnablePlatforms(['grok-web', 'chatgpt-shopping', 'gemini-web'], { shoppingEnabled: false }),
+    ).toEqual(['gemini-web']);
+  });
+
+  it('returns an empty list for a prompt with no platforms', () => {
+    expect(runnablePlatforms([], { shoppingEnabled: true })).toEqual([]);
+    expect(runnablePlatforms(null, { shoppingEnabled: true })).toEqual([]);
+    expect(runnablePlatforms(undefined, { shoppingEnabled: true })).toEqual([]);
+  });
+
+  // A prompt that lists only the unavailable platform must submit nothing at
+  // all, rather than falling back to "no filter means run everything".
+  it('leaves nothing to run when every platform is unavailable', () => {
+    expect(runnablePlatforms([...UNAVAILABLE_PLATFORMS], { shoppingEnabled: true })).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Cloro is returning 500 for every Grok task. Until that clears, a nightly run that still lists the platform submits one paid task per prompt per region, holds the drain loop open waiting for callbacks that never arrive, and stores nothing for the trouble. This drops Grok before submission instead of letting each task fail on its own.

The filter is a single list:

```js
export const UNAVAILABLE_PLATFORMS = ['grok-web'];
```

Emptying it restores Grok on the very next run. Nothing else has to change, and no prompt has to be touched — which is the point of doing it this way.

## Why the engine picker is deliberately untouched

The obvious companion change — removing Grok from `SCRAPER_GROUPS` so nobody can select it — is the one thing that must not happen here.

`ALL_SCRAPERS` is derived from that list, and two write paths use it as the allow-set:

- `filterByPlan` in `web/src/lib/actions/prompt.ts` filters `platforms` on every prompt write
- `alignPromptsToPlanForOrg` in `web/src/lib/plan-engines.ts` rewrites `prompts.platforms` on plan changes

Drop Grok from the list and both start silently stripping the stored id. Every prompt edit and every upgrade, downgrade or cancellation would erase the selection, and restoring Grok would then need a data repair across every affected org rather than deleting one array entry.

So prompts keep their Grok selection; only the submission is skipped. The trade-off is that the picker still offers an engine that produces nothing for now — the same outcome the customer gets today from the 500s, minus the spend.

## Also here

The existing `chatgpt-shopping` filter moves into the same helper. Both answer one question — which of a prompt's stored platform ids should this run actually pay for — and both exist because the saved array cannot be trusted at run time: a brand may have turned Shopping off since, a platform may be down. Keeping them in one place means a future outage is a one-line list edit, not a new branch in the middle of the run loop.

`runnablePlatforms` is exported and unit-tested, matching how the other run-loop predicates in this file are already covered.

## Related issue

None — operational response to a live provider outage.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Run a tracking cycle for a brand whose prompts include `grok-web` and confirm no Grok task is submitted to Cloro, while every other platform still is.
2. Confirm the run's task total reflects the reduced count rather than reporting tasks it never submitted.
3. Confirm the prompt rows are unchanged — `platforms` still contains `grok-web` after the run.
4. Confirm a brand with Shopping disabled still skips `chatgpt-shopping`, and one with it enabled still runs it.
5. Empty `UNAVAILABLE_PLATFORMS` locally and confirm Grok tasks are submitted again with no other change.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `server/`)
- [x] `yarn format:check` passes (run from `server/`)
- [x] Changes are focused — one concern per PR

Server test suite passes: 281 tests, including 5 new ones for `runnablePlatforms`. No `web/` files are touched.
