### PR TITLE
feat(content): generate three opportunities per run instead of five to fifteen

### DIFF
--- a/server/src/lib/opportunity-generator.js
+++ b/server/src/lib/opportunity-generator.js
@@ -9,6 +9,7 @@ import { resolveModel } from './ai-provider.js';
 import { getLanguageName } from './languages.js';
 import supabaseAdmin from '../config/supabase.js';
 import { logger } from './logger.js';
+import { OPPORTUNITIES_PER_RUN, OPPORTUNITY_COUNT_RULE } from './opportunity-limits.js';
 
 const opportunitySchema = z.object({
   opportunities: z
@@ -30,7 +31,7 @@ const opportunitySchema = z.object({
       }),
     )
     .min(1)
-    .max(20),
+    .max(OPPORTUNITIES_PER_RUN),
 });
 
 const SYSTEM_PROMPT = `You are an AEO content strategist. Given a brand's AI visibility data, generate specific, actionable content recommendations.
@@ -39,7 +40,7 @@ Rules:
 - Reference specific data points: volumes, visibility scores, competitor gaps.
 - Focus on content that will improve the brand's visibility in AI-generated answers.
 - Categorize as "owned" or "earned".
-- Generate between 5 and 15 opportunities.
+${OPPORTUNITY_COUNT_RULE}
 - The bracketed [N] indexes in the prompt data exist ONLY for the relatedPromptIndex field. NEVER mention an index like "[0]" or "Prompt 3" in titles or descriptions — refer to the prompt by quoting or paraphrasing its actual text/topic instead.`;
 
 function computeScore(volume, visibility, competitorGap, intent) {

--- a/server/src/lib/opportunity-limits.js
+++ b/server/src/lib/opportunity-limits.js
@@ -1,0 +1,26 @@
+/**
+ * How many content opportunities one generation run may produce.
+ *
+ * The two generators — the automatic one fired after each tracking cycle and
+ * the queued one behind the Generate button — used to carry this rule as a
+ * hand-written sentence and a schema ceiling apiece, and had already drifted
+ * apart in wording. They share it from here so the button and the nightly run
+ * cannot disagree about how many a brand gets.
+ *
+ * Three, not the five-to-fifteen it was: the model reliably landed near ten,
+ * which is more than anyone works through in a day. Generation appends
+ * nightly, so anything the reader does not act on accumulates — a short list
+ * that gets read beats a long one that gets scrolled past.
+ */
+export const OPPORTUNITIES_PER_RUN = 3;
+
+/**
+ * The count instruction, worded for a model that must now choose.
+ *
+ * At ten the ranking barely mattered; the good ones arrived alongside the
+ * filler. At three there is no room for filler, so the instruction has to say
+ * that the slots go to the highest-impact opportunities in the data rather
+ * than to whichever the model composes first. The prompt data is already
+ * ordered by score, which is what "provided" refers to.
+ */
+export const OPPORTUNITY_COUNT_RULE = `- Generate exactly ${OPPORTUNITIES_PER_RUN} opportunities: the ${OPPORTUNITIES_PER_RUN} highest-impact ones supported by the data provided, not the first ${OPPORTUNITIES_PER_RUN} that come to mind. Weigh volume, the visibility gap and the competitor gap together when choosing which ${OPPORTUNITIES_PER_RUN} to keep, and drop anything you would have ranked below them.`;

--- a/server/src/lib/opportunity-limits.test.js
+++ b/server/src/lib/opportunity-limits.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { OPPORTUNITIES_PER_RUN, OPPORTUNITY_COUNT_RULE } from './opportunity-limits.js';
+
+/**
+ * The count rule is shared because it was duplicated (#730).
+ *
+ * Two generators produce opportunities — the automatic one after each tracking
+ * cycle and the queued one behind the Generate button — and each used to carry
+ * its own copy of the sentence and its own schema ceiling. They had already
+ * drifted in wording. These tests fail if a number is hand-written back into
+ * either file, which is the only way they can disagree again.
+ */
+
+const source = (relative) =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8');
+
+const GENERATORS = [
+  ['automatic (tracking cycle)', './opportunity-generator.js'],
+  ['queued (Generate button)', '../workers/content-worker.js'],
+];
+
+describe('opportunity count', () => {
+  it('asks for three', () => {
+    expect(OPPORTUNITIES_PER_RUN).toBe(3);
+  });
+
+  it('states the count and that the slots go to the highest-impact findings', () => {
+    expect(OPPORTUNITY_COUNT_RULE).toContain(String(OPPORTUNITIES_PER_RUN));
+    expect(OPPORTUNITY_COUNT_RULE).toMatch(/highest-impact/i);
+  });
+
+  for (const [label, path] of GENERATORS) {
+    it(`the ${label} generator takes its ceiling from the shared constant`, () => {
+      const code = source(path);
+      expect(code).toContain('OPPORTUNITIES_PER_RUN');
+      expect(code).toContain('.max(OPPORTUNITIES_PER_RUN)');
+      // A literal ceiling here is how the two drifted apart before.
+      expect(code).not.toMatch(/\.max\(\d+\)/);
+    });
+
+    it(`the ${label} generator takes its count instruction from the shared rule`, () => {
+      const code = source(path);
+      expect(code).toContain('${OPPORTUNITY_COUNT_RULE}');
+      expect(code).not.toMatch(/Generate (between )?\d+/);
+    });
+  }
+});

--- a/server/src/workers/content-worker.js
+++ b/server/src/workers/content-worker.js
@@ -9,6 +9,7 @@ import { resolveModel } from '../lib/ai-provider.js';
 import { getLanguageName } from '../lib/languages.js';
 import supabaseAdmin from '../config/supabase.js';
 import logger from '../lib/logger.js';
+import { OPPORTUNITIES_PER_RUN, OPPORTUNITY_COUNT_RULE } from '../lib/opportunity-limits.js';
 
 const opportunitySchema = z.object({
   opportunities: z
@@ -38,7 +39,7 @@ const opportunitySchema = z.object({
       }),
     )
     .min(1)
-    .max(20),
+    .max(OPPORTUNITIES_PER_RUN),
 });
 
 const OPPORTUNITY_SYSTEM_PROMPT = `You are an AEO (Answer Engine Optimization) content strategist. Given a brand's AI visibility data — including prompt tracking results, search volumes, and competitor mentions — generate specific, actionable content recommendations.
@@ -49,7 +50,7 @@ Rules:
 - Focus on content that will improve the brand's visibility in AI-generated answers.
 - Categorize as "owned" (blog posts, landing pages, FAQ pages the brand controls) or "earned" (guest posts, PR, review sites).
 - Set impact based on: volume × (100 - current visibility) × competitor gap.
-- Generate between 5 and 15 opportunities depending on data richness.
+${OPPORTUNITY_COUNT_RULE}
 - Do NOT repeat the same recommendation in different wording.
 - The bracketed [N] indexes in the prompt data exist ONLY for the relatedPromptIndex field. NEVER mention an index like "[0]" or "Prompt 3" in titles or descriptions — refer to the prompt by quoting or paraphrasing its actual text/topic instead.`;
 


### PR DESCRIPTION
## Summary

The prompt asked for five to fifteen opportunities and the model reliably landed near ten — 9.9 to 10.6 per brand per night across ten days of production. That is more than anyone works through in a day, and because generation appends nightly, whatever goes unread accumulates: the open list already averages 147 rows per brand and reaches 773 on the largest.

Three per run. A short list that gets read beats a long one that gets scrolled past.

## The instruction changed, not just the number

At ten the ranking barely mattered — the good findings arrived alongside the filler. At three there is no room for filler, so the rule now names what the slots are for:

> Generate exactly 3 opportunities: the 3 highest-impact ones supported by the data provided, not the first 3 that come to mind. Weigh volume, the visibility gap and the competitor gap together when choosing which 3 to keep, and drop anything you would have ranked below them.

The prompt data reaching the model is already ordered by score, which is what "provided" refers to.

## Why a shared constant rather than two edited numbers

The rule lived in two places:

- `server/src/lib/opportunity-generator.js` — fired automatically after each tracking cycle
- `server/src/workers/content-worker.js` — the queued run behind the Generate button

Each carried its own hand-written sentence and its own `.max(20)`, and the two had already drifted in wording ("depending on data richness" in one, not the other). Editing two literals is how they drifted in the first place, so both now import one constant. The button and the nightly run cannot disagree about how many a brand gets.

`opportunity-limits.test.js` fails if a literal ceiling or a hand-written count sentence is written back into either generator. That is the regression worth pinning — the numbers agreeing today says nothing about them agreeing after the next edit.

## What this does not fix

Accumulation. Three a night is still ninety a month, and the two paths write differently: the automatic one appends, skipping only rows whose `prompt_id` and title match an existing `new` row exactly, while the manual one deletes every `new` row before inserting. So a manual Generate replaces the list and the nightly run grows it.

Reducing the count slows that down; it does not settle it. Whether the nightly run should replace, expire, or genuinely deduplicate is a separate decision and deliberately not made here. #731, now merged, at least makes the backlog clearable.

## Related issue

Closes #730

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Trigger a manual generation from the Content page for a brand with a rich tracking history and confirm exactly three opportunities come back.
2. Confirm the three are distinct recommendations rather than one idea in three wordings.
3. Run a tracking cycle for a brand on a plan with content optimization and confirm the automatic path produces the same count as the button.
4. Confirm a brand with very little data still produces a sensible result rather than failing schema validation — the floor is still one.
5. Spot-check that the three chosen relate to high-volume or high-gap prompts rather than arbitrary ones.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `server/`)
- [x] `yarn format:check` passes (run from `server/`)
- [x] Changes are focused — one concern per PR

Server suite passes: 287 tests, including 6 new ones. No `web/` files are touched.
