### PR TITLE
fix(citations): chunk URL lookups so answers with many citations are not dropped

### DIFF
--- a/server/src/lib/citation-rows.js
+++ b/server/src/lib/citation-rows.js
@@ -74,6 +74,43 @@ export function normalizeCitations(rawCitations) {
 }
 
 /**
+ * URLs looked up per request.
+ *
+ * A PostgREST `.in()` filter is spelled out in the query string, so the whole
+ * list travels in the request line — which has a length limit that a plain
+ * insert does not. The first version sent every URL of an answer at once and
+ * silently lost the answers that most needed storing: 228 of 174,466 in the
+ * first production backfill, averaging 45 citations and 16 KB of URL text
+ * each, against 12 citations and 1.2 KB for the ones that succeeded. The
+ * failure surfaced as a logged error and a skipped answer, not as a crash.
+ *
+ * Sized so that even pathological URLs stay well inside the limit: 100 URLs
+ * at the observed 2,048-character ceiling is roughly 200 KB, and the longest
+ * single answer seen carries 191 citations.
+ */
+const URL_LOOKUP_CHUNK = 100;
+
+function chunk(items, size) {
+  const out = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/** `select id, url where url in (...)`, split across as many requests as it takes. */
+async function selectUrlIds(urls, label) {
+  const ids = new Map();
+  for (const batch of chunk(urls, URL_LOOKUP_CHUNK)) {
+    const { data, error } = await supabaseAdmin
+      .from('citation_urls')
+      .select('id, url')
+      .in('url', batch);
+    if (error) throw new Error(`citation url ${label}: ${error.message}`);
+    for (const row of data ?? []) ids.set(row.url, row.id);
+  }
+  return ids;
+}
+
+/**
  * Resolve URLs to dictionary ids, inserting the ones not seen before.
  *
  * Two steps rather than one upsert-returning: `ignoreDuplicates` does not
@@ -93,16 +130,12 @@ async function resolveUrlIds(entries) {
   const urls = [...byUrl.keys()];
   if (urls.length === 0) return new Map();
 
-  const { data: known, error: knownErr } = await supabaseAdmin
-    .from('citation_urls')
-    .select('id, url')
-    .in('url', urls);
-  if (knownErr) throw new Error(`citation url lookup: ${knownErr.message}`);
-
-  const ids = new Map((known ?? []).map((row) => [row.url, row.id]));
+  const ids = await selectUrlIds(urls, 'lookup');
   const missing = urls.filter((url) => !ids.has(url));
 
   if (missing.length > 0) {
+    // The insert itself carries its payload in the body, not the query string,
+    // so it needs no chunking — only the `.in()` reads around it do.
     const { error: insertErr } = await supabaseAdmin.from('citation_urls').upsert(
       missing.map((url) => {
         const entry = byUrl.get(url);
@@ -112,12 +145,7 @@ async function resolveUrlIds(entries) {
     );
     if (insertErr) throw new Error(`citation url insert: ${insertErr.message}`);
 
-    const { data: added, error: addedErr } = await supabaseAdmin
-      .from('citation_urls')
-      .select('id, url')
-      .in('url', missing);
-    if (addedErr) throw new Error(`citation url re-read: ${addedErr.message}`);
-    for (const row of added ?? []) ids.set(row.url, row.id);
+    for (const [url, id] of await selectUrlIds(missing, 're-read')) ids.set(url, id);
   }
 
   return ids;

--- a/server/src/lib/citation-rows.test.js
+++ b/server/src/lib/citation-rows.test.js
@@ -108,3 +108,87 @@ describe('normalizeCitations', () => {
     expect(rows.map((r) => r.position)).toEqual([0, 1]);
   });
 });
+
+/**
+ * URL lookups are chunked because a PostgREST `.in()` filter travels in the
+ * query string (#732).
+ *
+ * The first production backfill lost 228 of 174,466 answers to this — the ones
+ * carrying the most citations, averaging 16 KB of URL text against 1.2 KB for
+ * the answers that succeeded. The failure was logged and the answer skipped,
+ * so the totals looked healthy. These tests pin the batching rather than the
+ * limit, since the limit is the server's to enforce.
+ */
+describe('persistCitationRows url lookups', () => {
+  /** Records every `.in()` batch so the test can assert on their sizes. */
+  function makeClient({ existing = new Map() } = {}) {
+    const batches = [];
+    let nextId = existing.size + 1;
+
+    const client = {
+      from(table) {
+        if (table === 'citation_urls') {
+          return {
+            select: () => ({
+              in: (_col, urls) => {
+                batches.push(urls.length);
+                return Promise.resolve({
+                  data: urls
+                    .filter((u) => existing.has(u))
+                    .map((u) => ({ id: existing.get(u), url: u })),
+                  error: null,
+                });
+              },
+            }),
+            upsert: (rows) => {
+              for (const row of rows) if (!existing.has(row.url)) existing.set(row.url, nextId++);
+              return Promise.resolve({ error: null });
+            },
+          };
+        }
+        return { upsert: () => Promise.resolve({ error: null }) };
+      },
+    };
+    return { client, batches };
+  }
+
+  async function run(citations, opts) {
+    const { client, batches } = makeClient(opts);
+    vi.resetModules();
+    vi.doMock('../config/supabase.js', () => ({ default: client }));
+    const { persistCitationRows } = await import('./citation-rows.js');
+    const written = await persistCitationRows({
+      promptResultId: 'r1',
+      brandId: 'b1',
+      createdAt: '2026-08-19T00:00:00Z',
+      citations,
+    });
+    return { written, batches };
+  }
+
+  it('splits a large URL set into bounded batches', async () => {
+    const citations = Array.from({ length: 250 }, (_, i) => ({ url: `https://a.com/${i}` }));
+    const { written, batches } = await run(citations);
+
+    expect(written).toBe(250);
+    // 250 unknown URLs: three batches to look them up, three to read them back.
+    expect(batches).toEqual([100, 100, 50, 100, 100, 50]);
+    expect(Math.max(...batches)).toBeLessThanOrEqual(100);
+  });
+
+  it('stores every citation of an answer far larger than one batch', async () => {
+    // The largest answer in production carries 191 citations.
+    const citations = Array.from({ length: 191 }, (_, i) => ({ url: `https://b.com/${i}` }));
+    const { written } = await run(citations);
+    expect(written).toBe(191);
+  });
+
+  it('makes no second round trip when every URL is already known', async () => {
+    const existing = new Map(Array.from({ length: 120 }, (_, i) => [`https://c.com/${i}`, i + 1]));
+    const citations = Array.from({ length: 120 }, (_, i) => ({ url: `https://c.com/${i}` }));
+    const { written, batches } = await run(citations, { existing });
+
+    expect(written).toBe(120);
+    expect(batches).toEqual([100, 20]); // lookup only — nothing to insert
+  });
+});

--- a/server/src/scripts/backfill-citations.js
+++ b/server/src/scripts/backfill-citations.js
@@ -72,6 +72,7 @@ async function main() {
   let answers = 0;
   let citations = 0;
   let empty = 0;
+  const failed = [];
 
   console.log(
     `Backfilling citations — batch ${BATCH}, pause ${PAUSE_MS}ms` +
@@ -83,6 +84,7 @@ async function main() {
     if (batch.length === 0) break;
 
     for (const row of batch) {
+      const expected = Array.isArray(row.citations) ? row.citations.length : 0;
       const written = await persistCitationRows({
         promptResultId: row.id,
         brandId: row.brand_id,
@@ -91,7 +93,13 @@ async function main() {
       });
       answers += 1;
       citations += written;
-      if (written === 0) empty += 1;
+      if (expected === 0) empty += 1;
+      // An answer that had citations and stored none wrote nothing at all:
+      // persistCitationRows is best-effort and reports failure by returning 0.
+      // Counting those separately is what makes a systematic fault visible —
+      // the first production run lost 228 answers this way and the totals
+      // alone looked healthy.
+      else if (written === 0) failed.push(row.id);
     }
 
     const last = batch[batch.length - 1];
@@ -99,7 +107,8 @@ async function main() {
 
     const elapsed = Math.round((Date.now() - startedAt) / 1000);
     console.log(
-      `  ${answers} answers · ${citations} citations · ${empty} with none · ${elapsed}s · at ${last.created_at}`,
+      `  ${answers} answers · ${citations} citations · ${empty} with none · ` +
+        `${failed.length} failed · ${elapsed}s · at ${last.created_at}`,
     );
 
     if (batch.length < BATCH) break;
@@ -111,6 +120,17 @@ async function main() {
     `\nDone. ${answers} answers scanned, ${citations} citation rows written, ` +
       `${empty} answers had none, ${elapsed}s.`,
   );
+
+  if (failed.length > 0) {
+    // Loud on purpose. These answers have citations and stored none, so the
+    // table is short by however many they carried — and re-running the script
+    // is the fix, since everything else is skipped as already present.
+    console.error(
+      `\n${failed.length} answer(s) had citations but stored none. Re-run to retry them.`,
+    );
+    console.error(`First few: ${failed.slice(0, 10).join(', ')}`);
+    process.exitCode = 1;
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

A bug in the phase 1 write path (#737), found by comparing the backfilled rows against the jsonb they came from.

A PostgREST `.in()` filter is spelled out in the query string, so the whole list travels in the request line — which has a length limit that an insert body does not. `resolveUrlIds` sent every URL of an answer in a single call. That holds for a typical answer and fails for exactly the ones that matter most.

## What it cost

The first production backfill stored 2,159,802 of 2,170,187 citations. The shortfall was not spread thin — it was **228 whole answers out of 174,466**, each losing every citation it had:

| | Answers that failed | Answers that succeeded |
|---|---|---|
| Count | 228 | 174,238 |
| Average citations | **45.5** | 12.4 |
| Average URL text per answer | **16,568 bytes** | 1,182 bytes |
| Largest | 191 citations | 156 citations |

The URLs were not malformed — 10,133 of the 10,380 lost citations are ordinary `https://` links. The only thing the failures had in common was size.

`persistCitationRows` is best-effort by design, so each failure was logged and the answer skipped. 99.5% written reads as success right up until the missing half-percent turns out to be a shape rather than chance.

## The fix

Lookups now go 100 URLs at a time. At the 2,048-character ceiling this module already enforces, that is roughly 200 KB per request in the worst case, well inside the limit, and the largest answer observed carries 191 citations — two batches.

The insert between the two lookups carries its payload in the body, so it needs no chunking. Only the `.in()` reads around it do.

## Making the next one loud

The backfill reported one number for "answers that stored nothing", which conflated *had no storable citations* with *had citations and stored none*. Those are a normal outcome and a fault, and merging them is why this had to be found afterwards by counting rows against jsonb.

They are now separate. Failures are counted per batch, listed at the end, and the script exits non-zero if any occurred.

## Recovering the lost 228

Re-run the backfill. Everything already stored is skipped by the existing upsert on `(prompt_result_id, position)`, so it walks the history and writes only the answers that failed.

```bash
docker exec -d ansvisor-server-1 sh -c 'node src/scripts/backfill-citations.js > /tmp/backfill.log 2>&1'
```

Afterwards, this should return zero:

```sql
select count(*) from prompt_results pr
where jsonb_array_length(coalesce(pr.citations,'[]'::jsonb)) > 0
  and not exists (select 1 from prompt_result_citations c where c.prompt_result_id = pr.id);
```

## Related issue

Refs #732 — phase 1 correction; the page still reads jsonb until phase 2.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Deploy, then re-run the backfill and confirm it finishes reporting `0 failed`.
2. Confirm the query above returns zero.
3. Confirm the row count now matches the jsonb total, allowing only for citations whose URL yields no host at all.
4. Run a tracking cycle and confirm an answer with an unusually long citation list stores every one of them.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `server/`)
- [x] `yarn format:check` passes (run from `server/`)
- [x] Changes are focused — one concern per PR

Server suite passes: 302 tests, 3 of them new — one asserting the batch sizes directly, one storing a 191-citation answer end to end, one confirming no second round trip when every URL is already known. No migration, no `web/` changes.
