### PR TITLE
fix(citations): resolve the ambiguous url reference in citation_url_ids

### DIFF
--- a/supabase/migrations/00060_citation_url_ids_variable_conflict.sql
+++ b/supabase/migrations/00060_citation_url_ids_variable_conflict.sql
@@ -1,0 +1,57 @@
+-- Fix `column reference "url" is ambiguous` in citation_url_ids (#732).
+--
+-- `returns table (id bigint, url text)` declares those names as PL/pgSQL
+-- variables, so `on conflict (url)` inside the body could mean either the
+-- variable or the column, and PL/pgSQL refuses to guess. The function was
+-- therefore broken for every call — 00059 shipped it having been parsed but
+-- never executed, and the unit tests around it mock the database, so neither
+-- could see it.
+--
+-- `#variable_conflict use_column` is the documented resolution: an ambiguous
+-- name resolves to the column, which is what every reference in this body
+-- means. Renaming the output columns would work too and would change the
+-- shape the caller reads, for no benefit here.
+
+create or replace function public.citation_url_ids(p_urls jsonb)
+returns table (id bigint, url text)
+language plpgsql
+volatile
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+begin
+  -- p_urls: [{"url": "...", "domain": "...", "title": "..."}, ...]
+  --
+  -- `distinct on` because one answer can cite the same page twice, and the
+  -- unique index would reject the second copy inside the same statement
+  -- rather than treating it as a conflict.
+  insert into public.citation_urls (url, domain, title)
+  select distinct on (e.value ->> 'url')
+         e.value ->> 'url',
+         e.value ->> 'domain',
+         nullif(e.value ->> 'title', '')
+  from jsonb_array_elements(p_urls) e
+  where e.value ->> 'url' is not null
+    and e.value ->> 'domain' is not null
+  order by e.value ->> 'url'
+  on conflict (url) do nothing;
+
+  -- Returned for every URL asked about, not only the ones just inserted:
+  -- the caller needs an id per citation, and the overwhelming majority were
+  -- already in the dictionary. A concurrent writer that won the insert race
+  -- is picked up here too, which is what makes the call safe to run twice.
+  return query
+  select cu.id, cu.url
+  from public.citation_urls cu
+  join (
+    select distinct e.value ->> 'url' as u
+    from jsonb_array_elements(p_urls) e
+  ) asked on asked.u = cu.url;
+end;
+$$;
+
+revoke all on function public.citation_url_ids(jsonb) from public;
+revoke all on function public.citation_url_ids(jsonb) from anon;
+revoke all on function public.citation_url_ids(jsonb) from authenticated;
+grant execute on function public.citation_url_ids(jsonb) to service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6005,3 +6005,64 @@ grant execute on function public.citation_url_ids(jsonb) to service_role;
 comment on function public.citation_url_ids(jsonb) is
   'Insert any unseen citation URLs and return the dictionary id for every URL asked about. Takes its argument in the request body so a long list cannot overflow the query string, which is what broke the .in() lookup it replaces (#732).';
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00060_citation_url_ids_variable_conflict.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Fix `column reference "url" is ambiguous` in citation_url_ids (#732).
+--
+-- `returns table (id bigint, url text)` declares those names as PL/pgSQL
+-- variables, so `on conflict (url)` inside the body could mean either the
+-- variable or the column, and PL/pgSQL refuses to guess. The function was
+-- therefore broken for every call — 00059 shipped it having been parsed but
+-- never executed, and the unit tests around it mock the database, so neither
+-- could see it.
+--
+-- `#variable_conflict use_column` is the documented resolution: an ambiguous
+-- name resolves to the column, which is what every reference in this body
+-- means. Renaming the output columns would work too and would change the
+-- shape the caller reads, for no benefit here.
+
+create or replace function public.citation_url_ids(p_urls jsonb)
+returns table (id bigint, url text)
+language plpgsql
+volatile
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+begin
+  -- p_urls: [{"url": "...", "domain": "...", "title": "..."}, ...]
+  --
+  -- `distinct on` because one answer can cite the same page twice, and the
+  -- unique index would reject the second copy inside the same statement
+  -- rather than treating it as a conflict.
+  insert into public.citation_urls (url, domain, title)
+  select distinct on (e.value ->> 'url')
+         e.value ->> 'url',
+         e.value ->> 'domain',
+         nullif(e.value ->> 'title', '')
+  from jsonb_array_elements(p_urls) e
+  where e.value ->> 'url' is not null
+    and e.value ->> 'domain' is not null
+  order by e.value ->> 'url'
+  on conflict (url) do nothing;
+
+  -- Returned for every URL asked about, not only the ones just inserted:
+  -- the caller needs an id per citation, and the overwhelming majority were
+  -- already in the dictionary. A concurrent writer that won the insert race
+  -- is picked up here too, which is what makes the call safe to run twice.
+  return query
+  select cu.id, cu.url
+  from public.citation_urls cu
+  join (
+    select distinct e.value ->> 'url' as u
+    from jsonb_array_elements(p_urls) e
+  ) asked on asked.u = cu.url;
+end;
+$$;
+
+revoke all on function public.citation_url_ids(jsonb) from public;
+revoke all on function public.citation_url_ids(jsonb) from anon;
+revoke all on function public.citation_url_ids(jsonb) from authenticated;
+grant execute on function public.citation_url_ids(jsonb) to service_role;
+


### PR DESCRIPTION
## Summary

`citation_url_ids` from #741 raised on every call:

```
column reference "url" is ambiguous
DETAIL: It could refer to either a PL/pgSQL variable or a table column.
```

`returns table (id bigint, url text)` declares those names as PL/pgSQL variables, so `on conflict (url)` inside the body could mean the variable or the column, and PL/pgSQL refuses to guess.

That is worse than the bug it replaced. The old one lost the answers carrying the most citations; this one lost all of them.

`#variable_conflict use_column` resolves an ambiguous name to the column, which is what every reference in this body means. Renaming the output columns would also work and would change the shape the caller reads, for no benefit.

## Why it got through

#741 was checked two ways, and neither could see this:

- **Parsed** with Postgres's own grammar (`pglast`). Parsing proves a function compiles, not that it runs — the ambiguity is raised at execution.
- **Unit tested** with the Supabase client mocked, which is the right shape for testing the caller and no test at all of the SQL.

The gap is that nothing executed the function against a database before it shipped. That is now the thing to change, not the specific mistake.

## Applied ahead of merge

The hosted database has this already. The deployed write path was calling a function that raised for every answer, so leaving it until a merge would have cost another night of the nightly run writing no citation rows at all.

The repo was briefly behind the database, which is the drift #728 exists to prevent — this PR closes it, and the migration is `create or replace`, so applying it again is a no-op.

## Verified against real data

Not mocked this time. Run against one of the answers that had been failing since the start:

| | |
|---|---|
| Citations in the answer | 37 |
| URL text | 21,892 bytes |
| Ids returned | 26 (26 distinct URLs) |

That payload is precisely what overflowed the query string in the `.in()` versions. It passes in the body.

Also confirmed: a URL already in the dictionary comes back with its existing id rather than a new row, and a URL cited twice in one answer collapses to one entry.

## What this means for the backfill

No new deploy is needed. The server already runs the code that calls this function, and the function now works — the backfill can be re-run as it stands.

## Related issue

Refs #732 — phase 1 correction; the page still reads jsonb until phase 2.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Re-run the backfill and confirm it finishes reporting **0 failed** and exits zero.
2. Confirm this returns zero, which it never yet has:
   ```sql
   select count(*) from prompt_results pr
   where exists (select 1 from jsonb_array_elements(coalesce(pr.citations,'[]'::jsonb)) c
                 where c.value->>'url' ~ '^https?://')
     and not exists (select 1 from prompt_result_citations x where x.prompt_result_id = pr.id);
   ```
3. Confirm the row count reaches roughly 2,170,000, matching the jsonb total less the citations whose URL yields no host.
4. Run a tracking cycle and confirm an answer with 30+ citations stores all of them.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Changes are focused — one concern per PR

Migration only; no application code changes, so `server/` and `web/` are untouched. `supabase/schema.sql` regenerated.
