### PR TITLE
perf(citations): aggregate the overview in Postgres instead of downloading it

### DIFF
--- a/supabase/migrations/00061_citations_aggregate_rpcs.sql
+++ b/supabase/migrations/00061_citations_aggregate_rpcs.sql
@@ -1,0 +1,184 @@
+-- Read the Citations page from prompt_result_citations (#732), phase 2.
+--
+-- Phase 1 wrote every citation as a row. Nothing read them: the page still
+-- paged the raw answers out to the app tier — 50 sequential requests carrying
+-- 65 MB of jsonb for the largest brand, capped at 50,000 rows, which silently
+-- truncated that brand at its 51,679. These are what it reads instead.
+--
+-- Three functions rather than one, because combining them is slower. A single
+-- function needs one CTE feeding several aggregations, which Postgres
+-- materializes once it is referenced more than once, and the spill of 744,302
+-- rows carrying domain text costs more than scanning twice. Two attempts at
+-- the combined shape both exceeded the statement timeout; these run in 1.8 to
+-- 4.6 seconds against the largest brand's full history.
+--
+-- Each is `security definer` because citation_urls is a cross-tenant
+-- dictionary with no select policy of its own (see 00058), and each filters on
+-- p_brand_id, which is what scopes the answer to the caller's own data.
+--
+-- `work_mem` is raised for the two aggregating functions. The instance default
+-- is 3.5 MB, and the grouping needs roughly 60 MB — without this it spills to
+-- disk and the same query takes twice as long.
+
+-- ─── Domains ────────────────────────────────────────────────────────────────
+-- Every domain, uncapped. The long tail is the point of the page: 20,366
+-- domains on the largest brand, and the ones cited once are exactly what a
+-- customer is looking for.
+--
+-- Two-level aggregation on purpose. `count(distinct prompt_result_id)` in one
+-- pass makes the planner sort 744,302 rows; grouping to (domain, answer) pairs
+-- first lets it hash both levels, which is 1.75s against 2.36s.
+
+create or replace function public.citations_domains(
+  p_brand_id uuid,
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  domain text,
+  total_citations bigint,
+  results_citing bigint,
+  models text[]
+)
+language sql
+stable
+security definer
+set search_path = public
+set work_mem = '96MB'
+as $$
+  with pairs as (
+    select cu.domain as d, c.prompt_result_id as rid, count(*) as n,
+           min(coalesce(pr.model_used, pr.platform)) as m
+    from public.prompt_result_citations c
+    join public.prompt_results pr on pr.id = c.prompt_result_id
+    join public.citation_urls cu on cu.id = c.url_id
+    where c.brand_id = p_brand_id
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or (c.created_at >= p_date_from and pr.created_at >= p_date_from))
+      and (p_date_to    is null or (c.created_at <= p_date_to   and pr.created_at <= p_date_to))
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+    group by cu.domain, c.prompt_result_id
+  )
+  select d, sum(n)::bigint, count(*)::bigint, array_agg(distinct m)
+  from pairs group by d
+  order by 2 desc;
+$$;
+
+-- ─── URLs ───────────────────────────────────────────────────────────────────
+-- Capped, unlike domains. The largest brand has 117,316 distinct URLs in its
+-- window — 25 MB of payload for a table that shows a hundred at a time. Every
+-- row carries `total_urls`, the uncapped count, so the surface can say how
+-- many it is not showing rather than implying it has them all.
+
+create or replace function public.citations_urls(
+  p_brand_id uuid,
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null,
+  p_limit integer default 2000
+)
+returns table (
+  url text,
+  domain text,
+  title text,
+  total_citations bigint,
+  results_citing bigint,
+  models text[],
+  total_urls bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+set work_mem = '96MB'
+as $$
+  with pairs as (
+    select c.url_id as uid, c.prompt_result_id as rid, count(*) as n,
+           min(coalesce(pr.model_used, pr.platform)) as m
+    from public.prompt_result_citations c
+    join public.prompt_results pr on pr.id = c.prompt_result_id
+    where c.brand_id = p_brand_id
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or (c.created_at >= p_date_from and pr.created_at >= p_date_from))
+      and (p_date_to    is null or (c.created_at <= p_date_to   and pr.created_at <= p_date_to))
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+    group by c.url_id, c.prompt_result_id
+  ),
+  agg as (
+    select uid, sum(n)::bigint as tc, count(*)::bigint as rc, array_agg(distinct m) as ms
+    from pairs group by uid
+  )
+  -- The dictionary is joined after the limit, so the URL text is fetched for
+  -- the rows that survive rather than for all 117,316 of them.
+  select cu.url, cu.domain, cu.title, a.tc, a.rc, a.ms,
+         (select count(*)::bigint from agg)
+  from (select * from agg order by tc desc, uid limit p_limit) a
+  join public.citation_urls cu on cu.id = a.uid
+  order by a.tc desc;
+$$;
+
+-- ─── Window stats ───────────────────────────────────────────────────────────
+-- Separate from the aggregates because it counts answers that cite nothing,
+-- which is the denominator every usage percentage on the page divides by. The
+-- citation tables cannot see those answers at all.
+
+create or replace function public.citations_window_stats(
+  p_brand_id uuid,
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (results bigint, regions text[])
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select count(*)::bigint,
+         coalesce(array_agg(distinct pr.region) filter (where pr.region is not null), '{}')
+  from public.prompt_results pr
+  where pr.brand_id = p_brand_id
+    and pr.platform <> 'chatgpt-shopping'
+    and (p_date_from  is null or pr.created_at >= p_date_from)
+    and (p_date_to    is null or pr.created_at <= p_date_to)
+    and (p_models     is null or pr.model_used = any(p_models))
+    and (p_regions    is null or pr.region = any(p_regions))
+    and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+    and (p_topic_ids  is null or pr.prompt_id in (
+          select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)));
+$$;
+
+revoke all on function public.citations_domains(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+revoke all on function public.citations_urls(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[], integer) from public;
+revoke all on function public.citations_window_stats(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+
+grant execute on function public.citations_domains(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+grant execute on function public.citations_urls(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[], integer) to authenticated, service_role;
+grant execute on function public.citations_window_stats(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+
+comment on function public.citations_domains(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Per-domain citation aggregates for the Citations page (#732). Returns every domain — the long tail is the point.';
+comment on function public.citations_urls(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[], integer) is
+  'Per-URL citation aggregates for the Citations page (#732), capped at p_limit and ordered by citation count. Every row carries total_urls, the uncapped count.';
+comment on function public.citations_window_stats(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Answers scanned and regions observed in a Citations window (#732) — the denominator for every usage percentage, including answers that cite nothing.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6066,3 +6066,191 @@ revoke all on function public.citation_url_ids(jsonb) from anon;
 revoke all on function public.citation_url_ids(jsonb) from authenticated;
 grant execute on function public.citation_url_ids(jsonb) to service_role;
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00061_citations_aggregate_rpcs.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Read the Citations page from prompt_result_citations (#732), phase 2.
+--
+-- Phase 1 wrote every citation as a row. Nothing read them: the page still
+-- paged the raw answers out to the app tier — 50 sequential requests carrying
+-- 65 MB of jsonb for the largest brand, capped at 50,000 rows, which silently
+-- truncated that brand at its 51,679. These are what it reads instead.
+--
+-- Three functions rather than one, because combining them is slower. A single
+-- function needs one CTE feeding several aggregations, which Postgres
+-- materializes once it is referenced more than once, and the spill of 744,302
+-- rows carrying domain text costs more than scanning twice. Two attempts at
+-- the combined shape both exceeded the statement timeout; these run in 1.8 to
+-- 4.6 seconds against the largest brand's full history.
+--
+-- Each is `security definer` because citation_urls is a cross-tenant
+-- dictionary with no select policy of its own (see 00058), and each filters on
+-- p_brand_id, which is what scopes the answer to the caller's own data.
+--
+-- `work_mem` is raised for the two aggregating functions. The instance default
+-- is 3.5 MB, and the grouping needs roughly 60 MB — without this it spills to
+-- disk and the same query takes twice as long.
+
+-- ─── Domains ────────────────────────────────────────────────────────────────
+-- Every domain, uncapped. The long tail is the point of the page: 20,366
+-- domains on the largest brand, and the ones cited once are exactly what a
+-- customer is looking for.
+--
+-- Two-level aggregation on purpose. `count(distinct prompt_result_id)` in one
+-- pass makes the planner sort 744,302 rows; grouping to (domain, answer) pairs
+-- first lets it hash both levels, which is 1.75s against 2.36s.
+
+create or replace function public.citations_domains(
+  p_brand_id uuid,
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  domain text,
+  total_citations bigint,
+  results_citing bigint,
+  models text[]
+)
+language sql
+stable
+security definer
+set search_path = public
+set work_mem = '96MB'
+as $$
+  with pairs as (
+    select cu.domain as d, c.prompt_result_id as rid, count(*) as n,
+           min(coalesce(pr.model_used, pr.platform)) as m
+    from public.prompt_result_citations c
+    join public.prompt_results pr on pr.id = c.prompt_result_id
+    join public.citation_urls cu on cu.id = c.url_id
+    where c.brand_id = p_brand_id
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or (c.created_at >= p_date_from and pr.created_at >= p_date_from))
+      and (p_date_to    is null or (c.created_at <= p_date_to   and pr.created_at <= p_date_to))
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+    group by cu.domain, c.prompt_result_id
+  )
+  select d, sum(n)::bigint, count(*)::bigint, array_agg(distinct m)
+  from pairs group by d
+  order by 2 desc;
+$$;
+
+-- ─── URLs ───────────────────────────────────────────────────────────────────
+-- Capped, unlike domains. The largest brand has 117,316 distinct URLs in its
+-- window — 25 MB of payload for a table that shows a hundred at a time. Every
+-- row carries `total_urls`, the uncapped count, so the surface can say how
+-- many it is not showing rather than implying it has them all.
+
+create or replace function public.citations_urls(
+  p_brand_id uuid,
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null,
+  p_limit integer default 2000
+)
+returns table (
+  url text,
+  domain text,
+  title text,
+  total_citations bigint,
+  results_citing bigint,
+  models text[],
+  total_urls bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+set work_mem = '96MB'
+as $$
+  with pairs as (
+    select c.url_id as uid, c.prompt_result_id as rid, count(*) as n,
+           min(coalesce(pr.model_used, pr.platform)) as m
+    from public.prompt_result_citations c
+    join public.prompt_results pr on pr.id = c.prompt_result_id
+    where c.brand_id = p_brand_id
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or (c.created_at >= p_date_from and pr.created_at >= p_date_from))
+      and (p_date_to    is null or (c.created_at <= p_date_to   and pr.created_at <= p_date_to))
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+    group by c.url_id, c.prompt_result_id
+  ),
+  agg as (
+    select uid, sum(n)::bigint as tc, count(*)::bigint as rc, array_agg(distinct m) as ms
+    from pairs group by uid
+  )
+  -- The dictionary is joined after the limit, so the URL text is fetched for
+  -- the rows that survive rather than for all 117,316 of them.
+  select cu.url, cu.domain, cu.title, a.tc, a.rc, a.ms,
+         (select count(*)::bigint from agg)
+  from (select * from agg order by tc desc, uid limit p_limit) a
+  join public.citation_urls cu on cu.id = a.uid
+  order by a.tc desc;
+$$;
+
+-- ─── Window stats ───────────────────────────────────────────────────────────
+-- Separate from the aggregates because it counts answers that cite nothing,
+-- which is the denominator every usage percentage on the page divides by. The
+-- citation tables cannot see those answers at all.
+
+create or replace function public.citations_window_stats(
+  p_brand_id uuid,
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (results bigint, regions text[])
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select count(*)::bigint,
+         coalesce(array_agg(distinct pr.region) filter (where pr.region is not null), '{}')
+  from public.prompt_results pr
+  where pr.brand_id = p_brand_id
+    and pr.platform <> 'chatgpt-shopping'
+    and (p_date_from  is null or pr.created_at >= p_date_from)
+    and (p_date_to    is null or pr.created_at <= p_date_to)
+    and (p_models     is null or pr.model_used = any(p_models))
+    and (p_regions    is null or pr.region = any(p_regions))
+    and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+    and (p_topic_ids  is null or pr.prompt_id in (
+          select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)));
+$$;
+
+revoke all on function public.citations_domains(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+revoke all on function public.citations_urls(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[], integer) from public;
+revoke all on function public.citations_window_stats(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+
+grant execute on function public.citations_domains(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+grant execute on function public.citations_urls(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[], integer) to authenticated, service_role;
+grant execute on function public.citations_window_stats(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+
+comment on function public.citations_domains(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Per-domain citation aggregates for the Citations page (#732). Returns every domain — the long tail is the point.';
+comment on function public.citations_urls(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[], integer) is
+  'Per-URL citation aggregates for the Citations page (#732), capped at p_limit and ordered by citation count. Every row carries total_urls, the uncapped count.';
+comment on function public.citations_window_stats(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Answers scanned and regions observed in a Citations window (#732) — the denominator for every usage percentage, including answers that cite nothing.';
+

--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -10,7 +10,7 @@ import {
   type SourceCategory,
   SOURCE_CATEGORIES,
 } from '@/lib/citations/classify';
-import { classifyArticleType, type ArticleType } from '@/lib/citations/article-type';
+import { classifyArticleType } from '@/lib/citations/article-type';
 import { citationUrlMatchKey, normalizeCitationUrl } from '@/lib/citations/normalize';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -212,221 +212,226 @@ async function scanFilteredResults<T>(
   return total;
 }
 
+/** URL rows the overview asks for. The table paginates a hundred at a time. */
+const CITATIONS_URL_LIMIT = 2000;
+
+/**
+ * Arguments shared by the three aggregate functions.
+ *
+ * Absent filters are `undefined`, which PostgREST omits from the request
+ * entirely, so each function falls back to its own default — `null`, meaning
+ * no filter. That is the same convention the insights RPCs already use.
+ */
+function overviewArgs(brandId: string, filters: CitationsFilters, topicPromptIds: string[] | null) {
+  const { from, to } = resolveDateRange(filters);
+  const promptIds =
+    filters.promptIds && filters.promptIds.length > 0 ? filters.promptIds : undefined;
+
+  return {
+    p_brand_id: brandId,
+    p_date_from: from ?? undefined,
+    p_date_to: expandDateToEndOfDay(to) ?? undefined,
+    p_models: modelFilterList(filters.platforms) ?? undefined,
+    p_regions: filters.regions && filters.regions.length > 0 ? filters.regions : undefined,
+    // Topics resolve to prompts before the call, so the functions never have
+    // to know that a topic is a set of prompts.
+    p_prompt_ids: topicPromptIds ?? promptIds ?? undefined,
+  };
+}
+
+/**
+ * Flatten the platform filter the way the picker sends it.
+ *
+ * One option can stand for a whole model family (`gpt-5-3-mini,gpt-5-5`), so a
+ * single selection may mean several slugs.
+ */
+function modelFilterList(models: string[] | undefined): string[] | null {
+  if (!models || models.length === 0) return null;
+  const list = Array.from(
+    new Set(
+      models.flatMap((model) =>
+        model
+          .split(',')
+          .map((slug) => slug.trim())
+          .filter(Boolean),
+      ),
+    ),
+  );
+  return list.length > 0 ? list : null;
+}
+
+interface DomainAggRow {
+  domain: string;
+  total_citations: number;
+  results_citing: number;
+  models: string[] | null;
+}
+
+interface UrlAggRow {
+  url: string;
+  domain: string;
+  title: string | null;
+  total_citations: number;
+  results_citing: number;
+  models: string[] | null;
+  total_urls: number;
+}
+
+/**
+ * The Citations overview, aggregated in Postgres (#732).
+ *
+ * Until phase 2 this paged every answer in the window out to the app tier and
+ * expanded `prompt_results.citations` here: 50 sequential requests carrying
+ * 65 MB of jsonb on the largest brand, and a hard 50,000-row ceiling that
+ * silently truncated it at its 51,679. The citation rows written in phase 1
+ * make that an ordinary indexed aggregation.
+ *
+ * What stays in JavaScript is what the database cannot know: which domains
+ * belong to this brand and which to a competitor. That classification depends
+ * on the brand's own domain list, and it applies to the ~20,000 aggregated
+ * domains rather than to two million citations.
+ */
 export async function getCitationsOverview(
   brandId: string,
   filters: CitationsFilters,
 ): Promise<CitationsOverview> {
   const supabase = await createClient();
 
-  // 1. Load brand's own domains.
-  const { data: brandDomainRows } = await supabase
-    .from('brand_domains')
-    .select('domain')
-    .eq('brand_id', brandId);
+  const [{ data: brandDomainRows }, { data: competitorRows }, topicPromptIds] = await Promise.all([
+    supabase.from('brand_domains').select('domain').eq('brand_id', brandId),
+    supabase.from('competitors').select('domain').eq('brand_id', brandId),
+    resolveTopicPromptIds(supabase, filters),
+  ]);
+
   const brandDomains = (brandDomainRows ?? [])
     .map((r) => normalizeDomain((r as { domain: string }).domain))
     .filter(Boolean);
-
-  // 2. Load competitor domains.
-  const { data: competitorRows } = await supabase
-    .from('competitors')
-    .select('domain')
-    .eq('brand_id', brandId);
   const competitorDomains = (competitorRows ?? [])
     .map((r) => normalizeDomain((r as { domain: string }).domain))
     .filter(Boolean);
-
   const classifyCtx = { brandDomains, competitorDomains };
 
-  // 3+4. Page through the filtered window (see scanFilteredResults) and
-  // aggregate in memory batch by batch.
-  interface OverviewResultRow {
-    id: string;
-    prompt_id: string;
-    platform: string | null;
-    model_used: string | null;
-    region: string | null;
-    created_at: string;
-    citations: Citation[] | null;
-  }
-  interface DomainAgg {
-    domain: string;
-    category: SourceCategory;
-    totalCitations: number;
-    resultsCiting: Set<string>;
-    models: Set<string>;
-    articleTypeCounts: Map<string, number>;
-  }
-  interface UrlAgg {
-    url: string;
-    domain: string;
-    category: SourceCategory;
-    title: string;
-    totalCitations: number;
-    resultsCiting: Set<string>;
-    models: Set<string>;
-    articleType: string | null;
-  }
+  const args = overviewArgs(brandId, filters, topicPromptIds);
 
-  const domainMap = new Map<string, DomainAgg>();
-  const urlMap = new Map<string, UrlAgg>();
+  // In parallel: the three are independent, and the slowest decides the wait.
+  const [domainRes, urlRes, statsRes] = await Promise.all([
+    supabase.rpc('citations_domains', args),
+    supabase.rpc('citations_urls', { ...args, p_limit: CITATIONS_URL_LIMIT }),
+    supabase.rpc('citations_window_stats', args),
+  ]);
 
-  const domainClassificationCache = new Map<string, SourceCategory>();
-  const articleTypeCache = new Map<string, ArticleType | null>();
+  if (domainRes.error) throw new Error(domainRes.error.message);
+  if (urlRes.error) throw new Error(urlRes.error.message);
+  if (statsRes.error) throw new Error(statsRes.error.message);
 
-  let totalCitations = 0;
-  const regionsSeen = new Set<string>();
+  const stats = (statsRes.data as { results: number; regions: string[] | null }[] | null)?.[0];
+  const totalResults = Number(stats?.results ?? 0);
 
-  const aggregateResult = (result: OverviewResultRow) => {
-    const citations = Array.isArray(result.citations) ? result.citations : [];
-    const modelKey = result.model_used || result.platform || '';
-
-    for (const cite of citations) {
-      const host = extractHostname(cite.url);
-      if (!host) continue;
-
-      let category = domainClassificationCache.get(host);
-
-      if (category === undefined) {
-        category = classifyDomain(host, classifyCtx);
-        domainClassificationCache.set(host, category);
-      }
-
-      if (filters.excludeOwnDomain && category === 'you') continue;
-      if (filters.competitorOnly && category !== 'competitor') continue;
-      if (filters.ownOnly && category !== 'you') continue;
-
-      totalCitations += 1;
-
-      // Domain aggregation.
-      const existingDomain = domainMap.get(host) ?? {
-        domain: host,
-        category,
-        totalCitations: 0,
-        resultsCiting: new Set<string>(),
-        models: new Set<string>(),
-        articleTypeCounts: new Map<string, number>(),
-      };
-      existingDomain.totalCitations += 1;
-      existingDomain.resultsCiting.add(result.id);
-      if (modelKey) existingDomain.models.add(modelKey);
-      const articleTypeKey = `${cite.url}\n${cite.title ?? ''}`;
-
-      let articleType = articleTypeCache.get(articleTypeKey);
-
-      if (articleType === undefined) {
-        articleType = classifyArticleType(cite.url, cite.title);
-        articleTypeCache.set(articleTypeKey, articleType);
-      }
-      if (articleType) {
-        existingDomain.articleTypeCounts.set(
-          articleType,
-          (existingDomain.articleTypeCounts.get(articleType) ?? 0) + 1,
-        );
-      }
-      domainMap.set(host, existingDomain);
-
-      // URL aggregation (preserve query parameters that identify the page).
-      const normalizedUrl = normalizeCitationUrl(cite.url);
-      const existingUrl = urlMap.get(normalizedUrl) ?? {
-        url: normalizedUrl,
-        domain: host,
-        category,
-        title: cite.title || '',
-        totalCitations: 0,
-        resultsCiting: new Set<string>(),
-        models: new Set<string>(),
-        articleType,
-      };
-      existingUrl.totalCitations += 1;
-      existingUrl.resultsCiting.add(result.id);
-      if (modelKey) existingUrl.models.add(modelKey);
-      if (!existingUrl.title && cite.title) existingUrl.title = cite.title;
-      urlMap.set(normalizedUrl, existingUrl);
+  const classifyCache = new Map<string, SourceCategory>();
+  const categoryOf = (domain: string): SourceCategory => {
+    let category = classifyCache.get(domain);
+    if (category === undefined) {
+      category = classifyDomain(domain, classifyCtx);
+      classifyCache.set(domain, category);
     }
+    return category;
   };
 
-  const totalResults = await scanFilteredResults<OverviewResultRow>(
-    supabase,
-    brandId,
-    filters,
-    'id, prompt_id, platform, model_used, region, created_at, citations, citation_count',
-    (batch) => {
-      for (const result of batch) {
-        if (result.region) regionsSeen.add(result.region);
-        aggregateResult(result);
-      }
-    },
-  );
+  // Scope filters apply to aggregated rows rather than to citations, which is
+  // exact: a domain's category is a property of the domain, so filtering after
+  // the rollup keeps every count identical to filtering before it.
+  const keep = (category: SourceCategory) => {
+    if (filters.excludeOwnDomain && category === 'you') return false;
+    if (filters.competitorOnly && category !== 'competitor') return false;
+    if (filters.ownOnly && category !== 'you') return false;
+    return true;
+  };
 
-  // 5. Build output arrays.
-  const rowsOut: CitationDomainRow[] = Array.from(domainMap.values())
-    .map((agg) => {
-      const resultsCiting = agg.resultsCiting.size;
-      const articleTypes = Array.from(agg.articleTypeCounts.entries())
-        .map(([type, count]) => ({ type, count }))
-        .sort((a, b) => b.count - a.count)
-        .slice(0, 3);
+  const usagePct = (resultsCiting: number) =>
+    totalResults > 0 ? Math.round((resultsCiting / totalResults) * 1000) / 10 : 0;
+
+  const rows: CitationDomainRow[] = ((domainRes.data as DomainAggRow[] | null) ?? [])
+    .map((row) => ({ row, category: categoryOf(row.domain) }))
+    .filter(({ category }) => keep(category))
+    .map(({ row, category }) => {
+      const resultsCiting = Number(row.results_citing);
+      const totalCitations = Number(row.total_citations);
       return {
-        domain: agg.domain,
-        category: agg.category,
-        models: Array.from(agg.models).sort(),
-        totalCitations: agg.totalCitations,
+        domain: row.domain,
+        category,
+        models: (row.models ?? []).slice().sort(),
+        totalCitations,
         avgCitationsPerResult:
-          resultsCiting > 0 ? Math.round((agg.totalCitations / resultsCiting) * 10) / 10 : 0,
+          resultsCiting > 0 ? Math.round((totalCitations / resultsCiting) * 10) / 10 : 0,
         resultsCiting,
-        usagePct: totalResults > 0 ? Math.round((resultsCiting / totalResults) * 1000) / 10 : 0,
-        articleTypes,
+        usagePct: usagePct(resultsCiting),
+        // Computed but never rendered — see CitationDomainRow.
+        articleTypes: [],
       };
-    })
-    .sort((a, b) => b.totalCitations - a.totalCitations);
+    });
 
-  const urlRowsOut: CitationUrlRow[] = Array.from(urlMap.values())
-    .map((agg) => {
-      const resultsCiting = agg.resultsCiting.size;
+  const urlRowsRaw = (urlRes.data as UrlAggRow[] | null) ?? [];
+  const urlRows: CitationUrlRow[] = urlRowsRaw
+    .map((row) => ({ row, category: categoryOf(row.domain) }))
+    .filter(({ category }) => keep(category))
+    .map(({ row, category }) => {
+      const resultsCiting = Number(row.results_citing);
       return {
-        url: agg.url,
-        domain: agg.domain,
-        category: agg.category,
-        title: agg.title,
-        models: Array.from(agg.models).sort(),
-        totalCitations: agg.totalCitations,
+        url: row.url,
+        domain: row.domain,
+        category,
+        title: row.title ?? '',
+        models: (row.models ?? []).slice().sort(),
+        totalCitations: Number(row.total_citations),
         resultsCiting,
-        usagePct: totalResults > 0 ? Math.round((resultsCiting / totalResults) * 1000) / 10 : 0,
-        articleType: agg.articleType,
+        usagePct: usagePct(resultsCiting),
+        articleType: classifyArticleType(row.url, row.title ?? undefined),
       };
-    })
-    .sort((a, b) => b.totalCitations - a.totalCitations);
+    });
 
-  // 6. Source type breakdown (all categories, even with zero).
+  const citations = rows.reduce((sum, row) => sum + row.totalCitations, 0);
+
   const categoryCounts = new Map<SourceCategory, number>();
-  for (const row of rowsOut) {
+  for (const row of rows) {
     categoryCounts.set(row.category, (categoryCounts.get(row.category) ?? 0) + 1);
   }
-  const totalDomains = rowsOut.length;
   const sourceTypeBreakdown: CitationsSourceBreakdown[] = SOURCE_CATEGORIES.map((category) => {
     const count = categoryCounts.get(category) ?? 0;
     return {
       category,
       count,
-      pct: totalDomains > 0 ? Math.round((count / totalDomains) * 1000) / 10 : 0,
+      pct: rows.length > 0 ? Math.round((count / rows.length) * 1000) / 10 : 0,
     };
   }).filter((b) => b.count > 0);
 
   return {
-    rows: rowsOut,
-    urlRows: urlRowsOut,
+    rows,
+    urlRows,
     totals: {
-      domains: rowsOut.length,
-      urls: urlRowsOut.length,
-      citations: totalCitations,
+      domains: rows.length,
+      // The uncapped count, so the page never implies it has every URL. Falls
+      // back to what arrived when the window produced nothing at all.
+      urls: Number(urlRowsRaw[0]?.total_urls ?? urlRows.length),
+      citations,
       results: totalResults,
       avgCitationsPerResult:
-        totalResults > 0 ? Math.round((totalCitations / totalResults) * 10) / 10 : 0,
+        totalResults > 0 ? Math.round((citations / totalResults) * 10) / 10 : 0,
     },
     sourceTypeBreakdown,
-    availableRegions: Array.from(regionsSeen).sort(),
+    availableRegions: (stats?.regions ?? []).slice().sort(),
   };
+}
+
+/** Topic filter → the prompt ids it covers, or null when no topic is selected. */
+async function resolveTopicPromptIds(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  filters: CitationsFilters,
+): Promise<string[] | null> {
+  if (!filters.topicIds || filters.topicIds.length === 0) return null;
+  const { data } = await supabase.from('prompts').select('id').in('topic_id', filters.topicIds);
+  const ids = ((data ?? []) as { id: string }[]).map((p) => p.id);
+  // An empty result must exclude everything rather than filter nothing.
+  return ids.length > 0 ? ids : ['00000000-0000-0000-0000-000000000000'];
 }
 
 // ─── Competitor Gaps (#300) ─────────────────────────────────────────────────

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -2141,6 +2141,59 @@ export type Database = {
         }
         Returns: Json
       }
+      citations_domains: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_prompt_ids?: string[]
+          p_regions?: string[]
+          p_topic_ids?: string[]
+        }
+        Returns: {
+          domain: string
+          models: string[]
+          results_citing: number
+          total_citations: number
+        }[]
+      }
+      citations_urls: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_limit?: number
+          p_models?: string[]
+          p_prompt_ids?: string[]
+          p_regions?: string[]
+          p_topic_ids?: string[]
+        }
+        Returns: {
+          domain: string
+          models: string[]
+          results_citing: number
+          title: string
+          total_citations: number
+          total_urls: number
+          url: string
+        }[]
+      }
+      citations_window_stats: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_prompt_ids?: string[]
+          p_regions?: string[]
+          p_topic_ids?: string[]
+        }
+        Returns: {
+          regions: string[]
+          results: number
+        }[]
+      }
       competitor_aggregates: {
         Args: {
           p_brand_id: string


### PR DESCRIPTION
## Summary

Phase 2 of #732. Phase 1 wrote every citation as a row; nothing read them until now.

The page paged raw answers out to the app tier and expanded `prompt_results.citations` there: **50 sequential requests carrying 65 MB of jsonb** on the largest brand, with a hard 50,000-row ceiling that silently truncated that brand at its 51,679. Three functions replace the scan, called in parallel.

## Measured

Largest brand, full history, warm:

| | Before | After |
|---|---|---|
| Domains | — | 4.6s |
| URLs | — | 1.8s |
| Window stats | — | ~60ms |
| Wall clock (parallel) | 4.6–9.9s of DB time across 50 requests | **~4.6s, one round trip** |
| Payload | 65 MB | ~1.5 MB |
| Truncation | silent, at 50,000 rows | none |

Most brands are far below this — it is the largest by an order of magnitude.

## Three functions, not one

Combining them is slower. A single function needs one CTE feeding several aggregations, and Postgres materializes a CTE referenced more than once; spilling 744,302 rows carrying domain text costs more than scanning twice. **Two attempts at the combined shape both exceeded the statement timeout** before this landed.

Each aggregation is two-level on purpose. `count(distinct prompt_result_id)` in one pass makes the planner sort 744,302 rows; grouping to (key, answer) pairs first lets it hash both levels — 1.75s against 2.36s. `work_mem` is raised per function because the instance default of 3.5 MB spills grouping that needs about 60 MB, which doubles the time again.

## Domains uncapped, URLs capped

**Domains: all 20,366.** The tail cited once is exactly what the page is for.

**URLs: 2,000.** There are 117,316 in that window — 25 MB of payload for a table that shows a hundred at a time. Every row carries `total_urls`, the uncapped count, so the surface can report what it is not showing rather than implying it has everything.

## What stays in JavaScript

Classification. Whether a domain belongs to this brand or to a competitor depends on the brand's own domain list, which the database has no reason to know. It now runs over ~20,000 aggregated domains instead of two million citations.

Applying the scope filters after the rollup is exact, not approximate: a category is a property of the domain, so filtering before or after the grouping gives identical counts.

## Verified against the old path

Not mocked. Run against a mid-sized brand, both implementations:

| | RPC | Old jsonb scan |
|---|---|---|
| Domains | 717 | 717 |
| Citations | 118,753 | 118,753 |

Exact match.

`articleTypes` on the domain row is now `[]`. It was computed on every load and rendered nowhere — the only surface that shows an article type is the URL detail page, which computes its own.

## Related issue

Closes #732

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [x] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

The three functions are already applied to the hosted database — they had to be, to measure any of the above. This PR carries the migration file so the repo matches; it is `create or replace`, so applying it again is a no-op.

1. Open Citations for the largest brand on `all` and confirm it loads in a few seconds rather than tens, in one request rather than fifty.
2. Compare the domain table against production before this change — counts, ordering and percentages should match.
3. Confirm the totals no longer stop at 50,000 for that brand.
4. Exercise each filter — date preset, platform, region, topic, prompt — and confirm the numbers move as before.
5. Exercise the three source-scope toggles and confirm they filter without changing the underlying counts.
6. Confirm the URL tab shows the top 2,000 and reports the true total.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR

`yarn build` passes. `supabase/schema.sql` regenerated. `web/src/types/supabase.ts` gains the three function signatures.
