### PR TITLE
refactor(citations): make the source scope a segmented control beside the table it scopes

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/page.tsx
@@ -28,6 +28,7 @@ import { Link } from '@/i18n/navigation';
 import { AddCompetitorButton } from '@/components/citations/add-competitor-button';
 import {
   CitationsFilterBar,
+  SourceScopeFilter,
   DEFAULT_CITATIONS_FILTERS as DEFAULT_FILTERS,
   buildPlatformOptions,
   buildCitationDetailHref,
@@ -1166,6 +1167,17 @@ export default function CitationsPage() {
               <CardTitle className="text-base">{t('sourcesTitle')}</CardTitle>
             </CardHeader>
             <CardContent>
+              {/* Only Domains and URLs are scoped by it — Competitor Gaps and
+                  Source Types read the same data whatever it says — so it
+                  appears with those two rather than standing over all four
+                  claiming to narrow them. */}
+              {(sourceTab === 'domains' || sourceTab === 'urls') && (
+                <SourceScopeFilter
+                  value={filters.sourceScope}
+                  onChange={(sourceScope) => setFilters((f) => ({ ...f, sourceScope }))}
+                  className="mb-4"
+                />
+              )}
               <Tabs
                 value={sourceTab}
                 onValueChange={(v) => setSourceTab(v as 'domains' | 'urls' | 'gaps' | 'types')}

--- a/web/src/app/[locale]/(dashboard)/dashboard/citations/url/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/citations/url/page.tsx
@@ -288,7 +288,6 @@ export default function CitationUrlDetailPage() {
         onChange={(patch) => setFilters((prev) => ({ ...prev, ...patch }))}
         platforms={platformOptions}
         regions={[]}
-        showCategoryToggles={false}
       />
 
       {loading ? (

--- a/web/src/components/citations/filter-bar.tsx
+++ b/web/src/components/citations/filter-bar.tsx
@@ -9,11 +9,11 @@
 
 import { useMemo } from 'react';
 import type { Topic } from '@/types';
+import { cn } from '@/lib/utils';
 import type { CitationsDatePreset } from '@/lib/actions/citations';
 import { MODEL_PROVIDER_LABELS, PLATFORM_LABELS } from '@/config/platform-labels';
 import { getAIProviderDisplayName, resolveAIProvider } from '@/components/ai-provider-avatar';
 import { DateRangeFilter } from '@/components/filters/date-range-filter';
-import { Button } from '@/components/ui/button';
 import {
   Select,
   SelectContent,
@@ -56,6 +56,59 @@ export const DEFAULT_CITATIONS_FILTERS: CitationsUIFilters = {
   prompt: '',
   sourceScope: 'all',
 };
+
+export type SourceScope = CitationsUIFilters['sourceScope'];
+
+const SOURCE_SCOPES: { value: SourceScope; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'own', label: 'Brand' },
+  { value: 'competitors', label: 'Competitors' },
+  { value: 'third_party', label: 'Third-Party' },
+];
+
+/**
+ * Which sources the table below covers.
+ *
+ * It belongs with the table rather than in the filter bar, because it scopes
+ * only that table: the KPIs above count every citation whatever this says, and
+ * Competitor Gaps and Source Types ignore it outright. Sitting among the
+ * page-wide filters it read as another one of them, and as a dropdown whose
+ * value defaulted to "All" the trigger was the only label on screen — the word
+ * "All" with nothing saying all of what.
+ *
+ * Shaped like the date-range control it now sits near, so the two read as the
+ * same kind of choice.
+ */
+export function SourceScopeFilter({
+  value,
+  onChange,
+  className,
+}: {
+  value: SourceScope;
+  onChange: (scope: SourceScope) => void;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex flex-wrap gap-2', className)} role="group" aria-label="Sources">
+      {SOURCE_SCOPES.map((scope) => (
+        <button
+          key={scope.value}
+          type="button"
+          onClick={() => onChange(scope.value)}
+          aria-pressed={value === scope.value}
+          className={cn(
+            'rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
+            value === scope.value
+              ? 'border-primary bg-primary text-primary-foreground'
+              : 'bg-card text-foreground hover:bg-muted',
+          )}
+        >
+          {scope.label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export interface PromptOption {
   id: string;
@@ -171,7 +224,6 @@ export function CitationsFilterBar({
   prompts = [],
   platforms,
   regions,
-  showCategoryToggles = true,
 }: {
   filters: CitationsUIFilters;
   onChange: (patch: Partial<CitationsUIFilters>) => void;
@@ -179,8 +231,6 @@ export function CitationsFilterBar({
   prompts?: PromptOption[];
   platforms: PlatformOption[];
   regions: string[];
-  /** Hide the own/competitor domain toggles (meaningless on a single URL). */
-  showCategoryToggles?: boolean;
 }) {
   // base-ui Combobox needs `{ value, label }` shaped items so it can use the
   // built-in filter and display logic without custom item-to-string helpers.
@@ -319,26 +369,6 @@ export function CitationsFilterBar({
           </SelectContent>
         </Select>
       </div>
-
-      {showCategoryToggles && (
-        <div className="flex items-center gap-2 pb-0.5">
-          <Select
-            value={filters.sourceScope}
-            onValueChange={(value) => onChange({ sourceScope: value ?? 'all' })}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Sources" />
-            </SelectTrigger>
-
-            <SelectContent>
-              <SelectItem value="all">All</SelectItem>
-              <SelectItem value="own">Brand</SelectItem>
-              <SelectItem value="competitors">Competitors</SelectItem>
-              <SelectItem value="third_party">Third-party</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The own/competitor/third-party filter on Citations was a dropdown at the end of the page's filter bar. It is now a segmented control inside the **Top Sources** card, next to the tables it actually scopes.

Two things were wrong with where it sat.

**It was the only control in the bar with no label.** Topic, Prompt, Platform and Region each name themselves above the input. This one leaned on a `Sources` placeholder that its own default value covered up — so the bar ended in a box reading **"All"**, with nothing on screen saying all of *what*. It also carried none of the sizing its neighbours share (`h-8 w-40 text-xs`), so it rendered taller and in a larger type than the rest of the row.

**It does not scope the page.** The KPI cards count every citation whatever it says, and Competitor Gaps and Source Types read the same data regardless — it narrows the Domains and URLs tables and nothing else. Sitting among the page-wide filters it claimed a reach it never had.

It now renders as a segmented control shaped like the date-range control, so the two read as the same kind of choice.

### One deliberate deviation from the mockup

The design shows the control standing above all four tabs. It renders only on **Domains** and **URLs** — the two it applies to — because a control sitting over Competitor Gaps that does nothing when clicked is worse than the alternative. The cost is that the tab row shifts up by about 40px when you switch to Gaps or Source Types. Happy to make it always-visible if the mockup should be followed literally; it is a one-line change.

### Also removed

- `showCategoryToggles`, a prop that existed only to hide this dropdown on the single-URL page — with the control gone from the bar, the URL page needs nothing.
- The unused `Button` import left behind by #742. Lint warnings drop from 8 to 7.

## Related issue

None — follow-up on the source filters merged in #742.

## Type of change

- [x] `refactor` — Code change that neither fixes a bug nor adds a feature

## How to test

1. Open **Citations**. The filter bar now ends at **Region**; there is no unlabelled dropdown after it.
2. In the **Top Sources** card, the scope now reads as four buttons above the tabs, with **All** selected.
3. Click **Brand**, **Competitors**, **Third-Party** on the **Domains** tab — the table narrows as before. Same on **URLs**.
4. Switch to **Competitor Gaps** or **Source Types** — the buttons are not shown, since neither tab is affected by them.
5. Open a domain's detail page (`/dashboard/citations/url`) — its filter bar is unchanged, and never showed this control.

## Known inconsistency, left alone

The tab counts (`Domains (4300)`, `URLs (11169)`) are unfiltered totals, so picking **Competitors** leaves the heading unchanged while the table shrinks. Moving the control next to the tabs makes that more visible, but the fix is not obvious: the URL table is capped at 2,000 rows while the true unique-URL count is far higher, so switching the label to the filtered row count would trade one wrong number for another. Worth deciding separately.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
