### PR TITLE
feat(nav): put Reports in the sidebar

### DIFF
--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -105,6 +105,11 @@ export function Sidebar() {
                 {group.title}
               </p>
             )}
+            {/* A group with no title has no header to set it apart, so it
+                carries a rule instead — without one its items read as the tail
+                of the group above. The first group needs neither: nothing
+                precedes it. */}
+            {!group.title && i > 0 && <Separator className="mb-2" />}
             {group.title && isCollapsed && i > 0 && <Separator className="my-2" />}
             <nav className="space-y-0.5">
               {group.items.map((item) => {

--- a/web/src/config/dashboard.ts
+++ b/web/src/config/dashboard.ts
@@ -1,6 +1,7 @@
 import {
   BarChart3,
   Building2,
+  FileBarChart,
   FileText,
   Gauge,
   Globe,
@@ -106,6 +107,24 @@ export const dashboardNav: NavGroup[] = [
         href: '/dashboard/audit',
         icon: Gauge,
         requiredFeature: 'content_optimization',
+      },
+    ],
+  },
+  /**
+   * Reports sits in its own group rather than under Analytics or Optimization,
+   * because it draws on both: of its thirteen sections, `auditScore` comes from
+   * Site Audit and the rest from the analytics surfaces. Filing it under either
+   * heading would understate what it covers.
+   *
+   * It is also the only way into /dashboard/reports besides the button on
+   * Visibility — from Citations or Site Audit there was no route to it at all.
+   */
+  {
+    items: [
+      {
+        title: 'Reports',
+        href: '/dashboard/reports',
+        icon: FileBarChart,
       },
     ],
   },


### PR DESCRIPTION
## Summary

Reports had **exactly one entry point in the app** — a button on the Visibility page. From Citations, Site Audit, or anywhere else there was no route to `/dashboard/reports` at all: you had to navigate back to Visibility first, or type the URL.

The sidebar was already half-wired for this. Both `sidebar.tsx` and `mobile-nav.tsx` carry a `Reports: t('reports')` label mapping, and `nav.reports` exists in `messages/en.json`. All three were dead code, because no nav item ever referenced them. This adds the missing item; both navs read the same config, so the mobile menu needed no separate change.

### Why its own group

Reports draws on **both** existing groups. Of its thirteen sections, `auditScore` comes from Site Audit (Optimization) and the remaining twelve from the analytics surfaces:

`kpis, trend, shareOfVoice, competitors, topicPerformance, promptPerformance, mentionEvidence, queryFanout, aiTraffic, shoppingVisibility, auditScore, citations, citationEvidence`

Filing it under either heading would understate what it covers. It is also an *output* rather than a surface you analyze on, which puts it after the two — matching the order of the work: look, optimize, report.

The group has no title on purpose: a one-item group headed "REPORTS" above an item labelled "Reports" is a header repeating its own contents.

### One supporting fix

An untitled group had no divider of its own — the uppercase header is what separates the titled ones — so a trailing untitled group's items read as the tail of the group above it. Untitled groups after the first now carry a rule, in both the expanded and collapsed sidebar. The first group needs none (nothing precedes it), and the existing titled groups render exactly as before.

### No plan gate

`custom_reports` is included in all four plans, and nothing enforces it server-side — `lib/actions/reports.ts` performs no feature check. Declaring a `requiredFeature` on the nav item would imply a lock that does not exist, so it is left off. Whether report generation *should* be gated is a separate product question.

The button on Visibility stays, now as a contextual shortcut rather than the only way in.

## Related issue

None — came out of a question about where Reports belongs in the navigation.

## Type of change

- [x] `feat` — New feature

## How to test

1. Open any dashboard page. **Reports** appears at the bottom of the sidebar, below Site Audit, with a rule above it.
2. Click it — `/dashboard/reports` opens and the nav item takes the active highlight.
3. Collapse the sidebar (`«`). The rule is still there, the icon is centred, and hovering shows the "Reports" tooltip.
4. Narrow the window to the mobile breakpoint and open the menu — Reports appears at the end of the list.
5. Check the other groups are unchanged, expanded and collapsed.
6. The **Reports** button top-right on Visibility still works.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
