### PR TITLE
fix(prompts): drop the progress count when it cannot move

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -1142,7 +1142,7 @@ export default function PromptsPage() {
       if (analysisGenRef.current !== gen) return { finished: false, superseded: true };
 
       if (!status) break;
-      setAnalysisProgress({ done: status.done, total: status.total });
+      setAnalysisProgress(status.done === null ? null : { done: status.done, total: status.total });
       if (!status.running) {
         finished = true;
         break;
@@ -1173,7 +1173,7 @@ export default function PromptsPage() {
       if (analysisGenRef.current !== gen || !status?.running) return;
 
       setAnalyzing(true);
-      setAnalysisProgress({ done: status.done, total: status.total });
+      setAnalysisProgress(status.done === null ? null : { done: status.done, total: status.total });
 
       const { finished, superseded } = await watchVolumeAnalysis(brandId, gen);
       if (superseded || analysisGenRef.current !== gen) return;
@@ -1317,7 +1317,9 @@ export default function PromptsPage() {
   const quotaExhausted = quota !== null && quota.limit !== -1 && quota.remaining <= 0;
 
   // Reads "Analyzing 32/100..." once the first poll lands, so a run measured in
-  // minutes shows movement instead of an indefinite spinner.
+  // minutes shows movement instead of an indefinite spinner. A count is only
+  // shown while it is one: a server that does not report live progress leaves
+  // it out rather than parking on 0/100, which says less than no number at all.
   const analyzingLabel = analysisProgress
     ? `Analyzing ${analysisProgress.done}/${analysisProgress.total}...`
     : 'Analyzing...';

--- a/web/src/lib/actions/volumes.ts
+++ b/web/src/lib/actions/volumes.ts
@@ -69,8 +69,15 @@ export interface VolumeAnalysisStatus {
   total: number;
   /** Rows on disk. During a run these are all written at the very end. */
   analyzed: number;
-  /** Prompts the run has finished with — what a progress readout counts. */
-  done: number;
+  /**
+   * Prompts the run has finished with — what a progress readout counts.
+   *
+   * null when the server does not report live progress, which is any build
+   * that predates it. Rows on disk are not a stand-in: they all appear at the
+   * very end, so substituting them would show a count frozen at zero for the
+   * whole run and then jumping to the total.
+   */
+  done: number | null;
 }
 
 async function toErrorCode(res: Response): Promise<VolumeErrorCode> {
@@ -149,7 +156,7 @@ export async function getVolumeAnalysisStatus(
     running: Boolean(body.running),
     total: body.total ?? 0,
     analyzed: body.analyzed ?? 0,
-    done: body.done ?? body.analyzed ?? 0,
+    done: typeof body.done === 'number' ? body.done : null,
   };
 }
 


### PR DESCRIPTION
## Summary

The button still read **`Analyzing 0/10`** for the whole run after #751.

#751 gave the run a live progress count and served it from `GET /status/:brandId` as `done`. The client, though, treated a missing `done` as `analyzed` — the number of rows in `prompt_volumes`. Since #749 those rows are all written in one go at the very end of the run, so that number is zero for the entire wait and then jumps to the total. Against a server that does not send `done`, the page therefore showed a count frozen at `0/N`, which is exactly the symptom #751 set out to remove.

**Rows on disk are not a stand-in for progress.** When the status response carries no live figure, the count is now left out and the button reads `Analyzing...` — less information, but nothing false. When the figure is there, it is shown and it moves.

`done` is typed `number | null` so the difference between "no live progress reported" and "zero prompts done so far" cannot be collapsed again.

## Why this matters beyond the immediate bug

The web app and the API server deploy separately. This makes the page correct against a server that predates the live count, rather than requiring the two to land together — the mismatch is what produced the stalled `0/10` in the first place.

## Related issue

None — reported directly from testing.

## Type of change

- [x] `fix` — Bug fix

## How to test

**Against a server with the live count (`done` present):** start an analysis on a brand with several unanalyzed prompts. Expected: `Analyzing 1/10`, `4/10`, … climbing, as after #751.

**Against a server without it:** start the same analysis. Expected: `Analyzing...` with the spinner, and no number — previously `Analyzing 0/10` for the whole run.

In both cases the button stays disabled for the duration, survives a page refresh, and returns to normal when the run ends.

## Verification already done

- `yarn typecheck` and `yarn format:check` pass from `web/`.
- Server is untouched: this is two files in `web/`, no API change.

Not re-run locally: `yarn build`. The change is a nullable field and one conditional, both covered by typecheck; CI runs format, lint and typecheck on a clean checkout.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
