### PR TITLE
feat(prompts): analyze a prompt the moment it is added

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/prompts/page.tsx
@@ -100,7 +100,7 @@ import { DateRangeFilter } from '@/components/filters/date-range-filter';
 import { DataSourcesPanel } from './_data-sources-panel';
 import { PLANS } from '@/config/plans';
 import { getTopics } from '@/lib/actions/topic';
-import { type PromptVisibilitySummary } from '@/lib/actions/tracking';
+import { analyzeNewPrompt, type PromptVisibilitySummary } from '@/lib/actions/tracking';
 import { aggregatePromptVolumeClusters } from '@/lib/prompt-volume-clusters';
 import type { PromptVolume, Prompt, Topic } from '@/types';
 import { toast } from 'sonner';
@@ -578,8 +578,17 @@ function AddPromptDialog({
         setError(result.error);
         return;
       }
+      // Send the prompt off to be analyzed straight away instead of leaving it
+      // idle until tomorrow's scheduled run. Only this prompt is submitted, and
+      // a refusal (daily cap, cooldown, paused brand) is not an error — the
+      // prompt is saved either way, so the message just says which happened.
+      const { started } = await analyzeNewPrompt(brandId, result.prompt.id);
       onClose();
-      toast.success('Prompt added — it will be picked up by the next tracking run.');
+      toast.success(
+        started
+          ? 'Prompt added — analyzing it now.'
+          : 'Prompt added — it will be picked up by the next tracking run.',
+      );
       onAdded();
     } catch {
       setError('Failed to add prompt. Please try again.');

--- a/web/src/lib/actions/tracking.test.ts
+++ b/web/src/lib/actions/tracking.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const promptResultRow = {
   id: 'result-id',
@@ -64,10 +64,13 @@ const insightsAggregatesRow = {
 
 let rpcMock = vi.fn(async () => ({ data: insightsAggregatesRow, error: null }));
 
+let sessionMock: { access_token: string } | null = { access_token: 'access-token' };
+
 vi.mock('@/lib/supabase/server', () => ({
   createClient: async () => ({
     from: (table: string) => fakeQueryBuilder(table),
     rpc: () => rpcMock(),
+    auth: { getSession: async () => ({ data: { session: sessionMock } }) },
   }),
 }));
 
@@ -107,5 +110,63 @@ describe('getInsightsSummary', () => {
     const summary = await getInsightsSummary('brand-id');
 
     expect(summary.positiveSentimentPct).toBe(0);
+  });
+});
+
+describe('analyzeNewPrompt', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    sessionMock = { access_token: 'access-token' };
+  });
+
+  it('submits the prompt that was just created and nothing else', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ jobId: 'job-1' })));
+    vi.stubGlobal('fetch', fetchMock);
+    const { analyzeNewPrompt } = await import('./tracking');
+
+    await expect(analyzeNewPrompt('brand-id', 'new-prompt')).resolves.toEqual({ started: true });
+
+    // The whole point of naming the id: the brand's other unanalyzed prompts —
+    // including any still waiting on Cloro's webhook — must not be swept in and
+    // paid for twice.
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      brandId: 'brand-id',
+      promptIds: ['new-prompt'],
+    });
+  });
+
+  it('reports not-started rather than throwing when the run is refused', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ message: 'limit' }), { status: 429 })),
+    );
+    const { analyzeNewPrompt } = await import('./tracking');
+
+    // The prompt is already saved by this point, so a refusal must stay quiet
+    // and leave it for the daily scheduled run.
+    await expect(analyzeNewPrompt('brand-id', 'new-prompt')).resolves.toEqual({ started: false });
+  });
+
+  it('reports not-started when the server is unreachable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('ECONNREFUSED');
+      }),
+    );
+    const { analyzeNewPrompt } = await import('./tracking');
+
+    await expect(analyzeNewPrompt('brand-id', 'new-prompt')).resolves.toEqual({ started: false });
+  });
+
+  it('makes no request at all when there is no session', async () => {
+    sessionMock = null;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { analyzeNewPrompt } = await import('./tracking');
+
+    await expect(analyzeNewPrompt('brand-id', 'new-prompt')).resolves.toEqual({ started: false });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -1324,6 +1324,60 @@ export async function triggerTrackingCheck(
   return { jobId: data.jobId };
 }
 
+/**
+ * Submit a single freshly created prompt to the tracking pipeline.
+ *
+ * Deliberately scoped to ONE prompt id rather than the brand's whole
+ * unanalyzed set. Cloro delivers results asynchronously, so a prompt that is
+ * still in flight has no `prompt_results` rows yet and would be picked up —
+ * and paid for — a second time by the very next add. Passing only the id we
+ * just created keeps each prompt to exactly one submission.
+ *
+ * Never throws, and never surfaces a failure as an error: a prompt that can't
+ * be submitted right now (daily cap, cooldown, paused brand, no active
+ * subscription, server unreachable) is still saved, and the daily scheduled
+ * run picks it up. The boolean only decides which "prompt added" message the
+ * user sees.
+ */
+export async function analyzeNewPrompt(
+  brandId: string,
+  promptId: string,
+): Promise<{ started: boolean }> {
+  const supabase = await createClient();
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) return { started: false };
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/tracking/analyze-new`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({ brandId, promptIds: [promptId] }),
+    });
+
+    if (!res.ok) {
+      // 402 (no subscription), 409 (paused brand) and 429 (daily cap or
+      // cooldown) are expected states rather than faults — stay quiet about
+      // them. Anything else is worth a server-side log.
+      if (res.status !== 402 && res.status !== 409 && res.status !== 429) {
+        console.error('Failed to submit new prompt for analysis', res.status);
+      }
+      return { started: false };
+    }
+
+    const body: { jobId?: string } = await res.json().catch(() => ({}));
+    return { started: Boolean(body.jobId) };
+  } catch (err) {
+    console.error('Failed to submit new prompt for analysis', err);
+    return { started: false };
+  }
+}
+
 export interface TrackingJobStatus {
   status: 'waiting' | 'active' | 'completed' | 'failed' | 'delayed' | 'not_found';
   progress: {


### PR DESCRIPTION
## Summary

A prompt added from the sidebar's Prompts page was written to the database and then left idle until the next daily tracking run. The confirmation toast said as much — *"it will be picked up by the next tracking run"* — which made the delay honest but no less useless: add a prompt at noon, see nothing until tomorrow morning's scheduled run.

This submits the prompt for analysis as soon as it is saved.

**The request names one prompt id, not the brand's unanalyzed set.** `POST /api/tracking/analyze-new` builds its candidate list from active prompts that have no rows in `prompt_results`. Results arrive asynchronously, so a prompt that is still in flight has no result rows yet and would be swept back into the candidate list — and paid for a second time — by the very next add:

```
14:00  add A  ->  submit  ->  A in flight, no results yet
14:02  add B  ->  submit  ->  candidates = {A, B}   <- A submitted twice
14:05  add C  ->  submit  ->  candidates = {A, B, C}
```

Passing only the id that was just created keeps each prompt to exactly one submission, with no new state to track. The route already accepts `promptIds` and validates them against the brand, so nothing changes server-side.

**A refusal is not an error.** The daily on-demand cap, the cooldown, a paused brand, an inactive subscription and an unreachable server all leave the prompt saved and the scheduled run to collect it. They change the confirmation message and nothing else — no error toast, no failed-looking state on a write that succeeded. Only unexpected statuses reach the server log.

Scoped to the Prompts page in the sidebar. The brand-level prompts page keeps its existing **Analyze Prompts** button and is untouched.

No server changes, so no redeploy is needed.

## Related issue

None — reported directly.

## Type of change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

1. Sidebar → **Prompts** → **Add Prompt**, add a prompt to any brand.
2. The toast reads **"Prompt added — analyzing it now."** instead of the old "next tracking run" wording.
3. Results land for that prompt within a few minutes, without waiting for the daily run.
4. Add two or three prompts in a row: each is submitted on its own, and the earlier ones are not resubmitted.
5. On a plan whose daily on-demand cap is reachable (Starter: 3/day, 15-minute cooldown), keep adding past the cap. The prompt is still saved, the toast falls back to the "next tracking run" wording, and **no error is shown**.

Four tests cover the action, the important one asserting the exact request body so a future change back to "the brand's unanalyzed prompts" fails loudly.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
