### PR TITLE
fix(settings): restrict organization updates to admins and lock server-managed columns

### DIFF
--- a/supabase/migrations/00062_organization_client_write_guard.sql
+++ b/supabase/migrations/00062_organization_client_write_guard.sql
@@ -1,0 +1,81 @@
+-- Organizations: restrict client-side updates to admins, and keep
+-- server-managed columns out of the client's reach entirely.
+--
+-- Two permissive UPDATE policies were in force. Postgres ORs permissive
+-- policies together, so the wider of the two decided the outcome and the
+-- admin restriction never applied. The wider policy's name states an intent
+-- its WITH CHECK does not carry out: it names no columns, so it allowed a
+-- row's every column to be rewritten by any member of the org.
+--
+-- Column-level intent cannot be expressed in a policy at all. WITH CHECK sees
+-- only the new row, so "this column may not change" has nowhere to compare
+-- against. A BEFORE UPDATE trigger can see both rows, and that is where the
+-- rule belongs.
+
+DROP POLICY IF EXISTS "Users cannot update plan fields directly" ON "public"."organizations";
+DROP POLICY IF EXISTS "organizations: admin update" ON "public"."organizations";
+
+-- USING picks the rows an admin may reach; WITH CHECK keeps the updated row
+-- inside the same set, so an org cannot be handed to somebody else.
+CREATE POLICY "organizations: admin update" ON "public"."organizations"
+  FOR UPDATE
+  USING (
+    "id" IN (
+      SELECT "profiles"."organization_id"
+      FROM "public"."profiles"
+      WHERE "profiles"."id" = "auth"."uid"()
+        AND "profiles"."role" = 'admin'::"public"."user_role"
+    )
+  )
+  WITH CHECK (
+    "id" IN (
+      SELECT "profiles"."organization_id"
+      FROM "public"."profiles"
+      WHERE "profiles"."id" = "auth"."uid"()
+        AND "profiles"."role" = 'admin'::"public"."user_role"
+    )
+  );
+
+-- Billing state belongs to Stripe and the webhook that mirrors it; the API key
+-- columns hold ciphertext produced server-side. Neither is the client's to
+-- write, admin or not.
+CREATE OR REPLACE FUNCTION "public"."guard_organization_server_columns"()
+RETURNS "trigger"
+LANGUAGE "plpgsql"
+SET "search_path" = ''
+AS $$
+BEGIN
+  -- A role that already bypasses row-level security is server-side by
+  -- definition -- the service role key, migrations, psql -- and this guard is
+  -- not aimed at it. Everything else is a request carrying an end user's JWT.
+  -- Naming the client roles instead would fail open on any role nobody
+  -- thought of; asking about the privilege fails closed.
+  IF (SELECT "rolbypassrls" FROM "pg_catalog"."pg_roles" WHERE "rolname" = current_user) THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW."plan" IS DISTINCT FROM OLD."plan"
+     OR NEW."plan_overrides" IS DISTINCT FROM OLD."plan_overrides"
+     OR NEW."subscription_status" IS DISTINCT FROM OLD."subscription_status"
+     OR NEW."subscription_ends_at" IS DISTINCT FROM OLD."subscription_ends_at"
+     OR NEW."stripe_customer_id" IS DISTINCT FROM OLD."stripe_customer_id"
+     OR NEW."stripe_subscription_id" IS DISTINCT FROM OLD."stripe_subscription_id"
+     OR NEW."anthropic_api_key_encrypted" IS DISTINCT FROM OLD."anthropic_api_key_encrypted"
+     OR NEW."anthropic_api_key_last4" IS DISTINCT FROM OLD."anthropic_api_key_last4"
+     OR NEW."anthropic_api_key_set_at" IS DISTINCT FROM OLD."anthropic_api_key_set_at"
+     OR NEW."anthropic_api_key_set_by" IS DISTINCT FROM OLD."anthropic_api_key_set_by"
+  THEN
+    RAISE EXCEPTION 'organization column is managed server-side and cannot be set from the client'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "organizations_guard_server_columns" ON "public"."organizations";
+
+CREATE TRIGGER "organizations_guard_server_columns"
+  BEFORE UPDATE ON "public"."organizations"
+  FOR EACH ROW
+  EXECUTE FUNCTION "public"."guard_organization_server_columns"();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6254,3 +6254,88 @@ comment on function public.citations_urls(uuid, timestamptz, timestamptz, text[]
 comment on function public.citations_window_stats(uuid, timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
   'Answers scanned and regions observed in a Citations window (#732) — the denominator for every usage percentage, including answers that cite nothing.';
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00062_organization_client_write_guard.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Organizations: restrict client-side updates to admins, and keep
+-- server-managed columns out of the client's reach entirely.
+--
+-- Two permissive UPDATE policies were in force. Postgres ORs permissive
+-- policies together, so the wider of the two decided the outcome and the
+-- admin restriction never applied. The wider policy's name states an intent
+-- its WITH CHECK does not carry out: it names no columns, so it allowed a
+-- row's every column to be rewritten by any member of the org.
+--
+-- Column-level intent cannot be expressed in a policy at all. WITH CHECK sees
+-- only the new row, so "this column may not change" has nowhere to compare
+-- against. A BEFORE UPDATE trigger can see both rows, and that is where the
+-- rule belongs.
+
+DROP POLICY IF EXISTS "Users cannot update plan fields directly" ON "public"."organizations";
+DROP POLICY IF EXISTS "organizations: admin update" ON "public"."organizations";
+
+-- USING picks the rows an admin may reach; WITH CHECK keeps the updated row
+-- inside the same set, so an org cannot be handed to somebody else.
+CREATE POLICY "organizations: admin update" ON "public"."organizations"
+  FOR UPDATE
+  USING (
+    "id" IN (
+      SELECT "profiles"."organization_id"
+      FROM "public"."profiles"
+      WHERE "profiles"."id" = "auth"."uid"()
+        AND "profiles"."role" = 'admin'::"public"."user_role"
+    )
+  )
+  WITH CHECK (
+    "id" IN (
+      SELECT "profiles"."organization_id"
+      FROM "public"."profiles"
+      WHERE "profiles"."id" = "auth"."uid"()
+        AND "profiles"."role" = 'admin'::"public"."user_role"
+    )
+  );
+
+-- Billing state belongs to Stripe and the webhook that mirrors it; the API key
+-- columns hold ciphertext produced server-side. Neither is the client's to
+-- write, admin or not.
+CREATE OR REPLACE FUNCTION "public"."guard_organization_server_columns"()
+RETURNS "trigger"
+LANGUAGE "plpgsql"
+SET "search_path" = ''
+AS $$
+BEGIN
+  -- A role that already bypasses row-level security is server-side by
+  -- definition -- the service role key, migrations, psql -- and this guard is
+  -- not aimed at it. Everything else is a request carrying an end user's JWT.
+  -- Naming the client roles instead would fail open on any role nobody
+  -- thought of; asking about the privilege fails closed.
+  IF (SELECT "rolbypassrls" FROM "pg_catalog"."pg_roles" WHERE "rolname" = current_user) THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW."plan" IS DISTINCT FROM OLD."plan"
+     OR NEW."plan_overrides" IS DISTINCT FROM OLD."plan_overrides"
+     OR NEW."subscription_status" IS DISTINCT FROM OLD."subscription_status"
+     OR NEW."subscription_ends_at" IS DISTINCT FROM OLD."subscription_ends_at"
+     OR NEW."stripe_customer_id" IS DISTINCT FROM OLD."stripe_customer_id"
+     OR NEW."stripe_subscription_id" IS DISTINCT FROM OLD."stripe_subscription_id"
+     OR NEW."anthropic_api_key_encrypted" IS DISTINCT FROM OLD."anthropic_api_key_encrypted"
+     OR NEW."anthropic_api_key_last4" IS DISTINCT FROM OLD."anthropic_api_key_last4"
+     OR NEW."anthropic_api_key_set_at" IS DISTINCT FROM OLD."anthropic_api_key_set_at"
+     OR NEW."anthropic_api_key_set_by" IS DISTINCT FROM OLD."anthropic_api_key_set_by"
+  THEN
+    RAISE EXCEPTION 'organization column is managed server-side and cannot be set from the client'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "organizations_guard_server_columns" ON "public"."organizations";
+
+CREATE TRIGGER "organizations_guard_server_columns"
+  BEFORE UPDATE ON "public"."organizations"
+  FOR EACH ROW
+  EXECUTE FUNCTION "public"."guard_organization_server_columns"();
+

--- a/web/src/app/api/stripe/checkout/route.ts
+++ b/web/src/app/api/stripe/checkout/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { supabaseAdmin } from '@/lib/supabase/admin';
 import { stripe, PRICE_IDS } from '@/lib/stripe';
 
 export async function POST(req: NextRequest) {
@@ -21,6 +22,20 @@ export async function POST(req: NextRequest) {
 
     if (!planId || !organizationId) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    // The org id arrives in the request body, so confirm the caller is
+    // actually in it. Row-level security used to be the only thing standing
+    // between this and another org's row; the customer id below is now
+    // written with the service role, which answers to nothing but this check.
+    const { data: callerProfile } = await supabase
+      .from('profiles')
+      .select('organization_id')
+      .eq('id', user.id)
+      .single();
+
+    if (callerProfile?.organization_id !== organizationId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     const priceId = PRICE_IDS[planId]?.monthly;
@@ -54,7 +69,7 @@ export async function POST(req: NextRequest) {
       });
       customerId = customer.id;
 
-      await supabase
+      await supabaseAdmin
         .from('organizations')
         .update({ stripe_customer_id: customerId })
         .eq('id', organizationId);

--- a/web/src/app/api/stripe/subscription/route.ts
+++ b/web/src/app/api/stripe/subscription/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { supabaseAdmin } from '@/lib/supabase/admin';
 import { stripe, PRICE_IDS } from '@/lib/stripe';
 import { SUBSCRIBABLE_PLANS } from '@/config/plans';
 import { alignPromptsToPlanForOrg } from '@/lib/plan-engines';
@@ -170,9 +171,10 @@ export async function PATCH(req: NextRequest) {
       proration_behavior: 'create_prorations',
     })) as unknown as SubscriptionRaw;
 
-    // Optimistic DB update
-    const supabase = await createClient();
-    await supabase.from('organizations').update({ plan: newPlanId }).eq('id', org.id);
+    // Optimistic DB update. Stripe has already accepted the plan change, so
+    // this is the server mirroring its own decision, not the caller writing
+    // their own plan — hence the service role, same as the webhook.
+    await supabaseAdmin.from('organizations').update({ plan: newPlanId }).eq('id', org.id);
 
     // Align prompts to the new plan's engine set so an upgrade actually
     // expands (Starter → Growth: 2 → 8 engines) or trims (Growth → Starter:


### PR DESCRIPTION
## Summary

The `organizations` table carried **two permissive UPDATE policies**:

| Policy | Reaches |
|---|---|
| `organizations: admin update` | rows whose org has the caller as `admin` |
| `Users cannot update plan fields directly` | rows whose org has the caller as a member — **no column restriction** |

Postgres ORs permissive policies together, so the wider one decided every case and the admin restriction never applied. The second policy's name states an intent its `WITH CHECK` does not carry out: it names no columns, so the row's whole shape — `plan`, `subscription_status`, `plan_overrides`, the Stripe ids, the encrypted API key — was writable through PostgREST by anyone in the org, whatever their role.

This came up while looking at the inert Project settings tab (#753): a rename UI would rely on these policies, and they do not hold.

### Where the rule belongs

Column-level intent cannot be expressed in a policy at all. An UPDATE policy's `WITH CHECK` sees only the new row, so *"this column may not change"* has nothing to compare against — which is why the original attempt names columns in its title and nowhere in its body.

A `BEFORE UPDATE` trigger sees both rows, so that is where it goes. The policy is now purely about **who** may update; the trigger is about **what** may change.

The trigger exempts roles that already bypass RLS. Naming the client roles instead (`authenticated`, `anon`) would fail open on any role nobody thought of; asking about the privilege fails closed.

### Two writes this would have broken

Both went through the user's own client and touch guarded columns:

- `stripe/subscription` — the optimistic `plan` write after Stripe accepts a plan change
- `stripe/checkout` — persisting a newly created `stripe_customer_id`

Neither is the caller writing their own billing state; both are the server mirroring a decision Stripe already made. They now use the service role, as `stripe/webhook` and `stripe/success` always have.

### One thing that turned up on the way

`stripe/checkout` takes `organizationId` **from the request body** and never checked that the caller belongs to it. Row-level security was the only thing stopping a request from naming someone else's org. Moving that write to the service role removes the backstop, so the membership check is now explicit — a `403` rather than an implicit no-op.

## Related issue

Adjacent to #753, which is the UI half. This is the part that has to be right before a rename form exists.

## Type of change

- [x] `fix` — Bug fix

## How to test

**The guard holds.** As a non-admin member, `PATCH` your organization row through the client: expect a permission error rather than a write. As an admin, change `plan` the same way: expect the trigger to refuse it.

**Renaming still works.** As an admin, update `name` on your own org: expect success. This is what #753 will build on.

**Billing is unaffected.**
1. Start a checkout on an org with no `stripe_customer_id`. Expect the customer id to land on the row.
2. Post a checkout with another org's id in the body. Expect `403`.
3. Change plan from the billing page. Expect the plan to update as before — the write is now server-side, so the optimistic update lands rather than silently failing.
4. Let a `subscription.updated` webhook arrive. Expect it to write as it always has; the trigger does not apply to it.

## Migration

`00062_organization_client_write_guard.sql`. **Apply after this merges and Vercel has deployed**, not before — until the new code is live, the two writes above still go through the user's client and the trigger would reject them. Both fail silently today (neither checks the error) and the webhook repairs the state afterwards, so the ordering is about avoiding noise rather than damage, but there is no reason to invite it.

## Verification already done

- Confirmed against the hosted database that both UPDATE policies are live and permissive, and read the column list the wider one leaves open.
- Checked every `from('organizations')` write in `web/` and `server/`: four already use the service role, two used the user's client, and both are changed here. The remaining references are reads and one insert, neither affected.
- Checked role distribution before making updates admin-only: org creators are already `admin`, so no existing owner loses access.
- `yarn typecheck`, `yarn lint` (0 errors) and `yarn format:check` pass from `web/`.

**Not verified by execution: the migration itself.** I could not exercise the trigger against a scratch copy, so it has not run anywhere yet. The `How to test` steps above are the real check, and they should be run right after it is applied.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
