### PR TITLE
fix(csv): quote fields containing lone carriage returns

### DIFF
--- a/web/src/lib/csv.test.ts
+++ b/web/src/lib/csv.test.ts
@@ -21,6 +21,16 @@ test('newline in a value triggers quoting', () => {
   expect(result).toBe('text\n\"line1\nline2\"');
 });
 
+test('lone carriage return in a value triggers quoting', () => {
+  const result = toCsv([{ text: 'line1\rline2' }], ['text']);
+  expect(result).toBe('text\n\"line1\rline2\"');
+});
+
+test('CRLF in a value remains quoted', () => {
+  const result = toCsv([{ text: 'line1\r\nline2' }], ['text']);
+  expect(result).toBe('text\n\"line1\r\nline2\"');
+});
+
 test('null and undefined become empty strings', () => {
   const result = toCsv([{ a: null, b: undefined, c: 'value' }], ['a', 'b', 'c']);
   expect(result).toBe('a,b,c\n,,value');

--- a/web/src/lib/csv.ts
+++ b/web/src/lib/csv.ts
@@ -2,7 +2,7 @@ function escape(value: unknown): string {
   if (value === null || value === undefined) return '';
 
   const s = String(value);
-  if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  if (/[",\r\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
   return s;
 }
 


### PR DESCRIPTION
## Summary

- Quote CSV fields containing a lone carriage return so parsers do not split one row into multiple records.
- Preserve the existing quoting behavior for CRLF values.
- Add regression coverage for both lone CR and CRLF inputs.

## Related issue

Closes #757

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [x] `test` — Adding or updating tests

## Testing

- `yarn test` — 16 files, 90 tests passed
- `yarn typecheck`
- `yarn lint` — 0 errors (8 pre-existing warnings)
- `yarn format:check` — passed in a clean LF checkout matching CI
- `yarn build`
- `git diff --check`

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR