### PR TITLE
fix(reports): aggregate report sections in Postgres, and let a report survive a failed one

### DIFF
--- a/supabase/migrations/00063_report_aggregate_rpcs.sql
+++ b/supabase/migrations/00063_report_aggregate_rpcs.sql
@@ -1,0 +1,234 @@
+-- Report generation: aggregate in Postgres instead of downloading the window.
+--
+-- Three report sections computed their figures by paging every matching
+-- prompt_results row into the Node process and folding them there. On a brand
+-- with ~12k results a week that is dozens of sequential round trips per
+-- section, all running while the report's other sections issue their own
+-- queries. The heavy aggregate RPCs (ai_visibility_aggregates and friends)
+-- then exceed the 8s statement_timeout of the `authenticated` role and the
+-- whole report fails.
+--
+-- The scans also had a ceiling: 50,000 rows. A 30-day report spans 60 days of
+-- data for the topic section, which is already past that on a busy brand, so
+-- the figures were quietly computed from a truncated window.
+--
+-- These functions return the raw accumulator components rather than finished
+-- scores. The blend lives in one place in TypeScript (computeAiVisibilityScore)
+-- and is shared with the Prompts and Topics pages; reimplementing it here
+-- would be a second copy to keep in step.
+
+-- Per-prompt totals for the report window. Rows returned: one per prompt,
+-- not one per answer.
+CREATE OR REPLACE FUNCTION "public"."report_prompt_performance"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz
+)
+RETURNS TABLE(
+  "prompt_id" uuid,
+  "prompt_text" text,
+  "runs" bigint,
+  "visible_runs" bigint,
+  "mention_answers" bigint,
+  "citation_answers" bigint,
+  "total_mentions" bigint,
+  "sum_visibility" double precision,
+  "pos_sum" double precision,
+  "pos_n" bigint
+)
+LANGUAGE "sql"
+STABLE
+SET "search_path" TO 'public'
+AS $$
+  SELECT
+    pr.prompt_id,
+    p.text,
+    count(*)::bigint,
+    count(*) FILTER (
+      WHERE coalesce(pr.mention_count, 0) > 0 OR coalesce(pr.citation_count, 0) > 0
+    )::bigint,
+    count(*) FILTER (WHERE coalesce(pr.mention_count, 0) > 0)::bigint,
+    count(*) FILTER (WHERE coalesce(pr.citation_count, 0) > 0)::bigint,
+    coalesce(sum(coalesce(pr.mention_count, 0)), 0)::bigint,
+    coalesce(sum(coalesce(pr.visibility_score, 0)), 0)::double precision,
+    -- Reciprocal rank, summed only over answers that actually placed the
+    -- brand somewhere; pos_n is that count so the caller can take the mean.
+    coalesce(sum(1.0 / pr.mention_position) FILTER (WHERE pr.mention_position > 0), 0)::double precision,
+    count(*) FILTER (WHERE pr.mention_position > 0)::bigint
+  FROM prompt_results pr
+  JOIN prompts p ON p.id = pr.prompt_id
+  WHERE pr.brand_id = p_brand_id
+    AND pr.platform <> 'chatgpt-shopping'
+    AND pr.created_at >= p_date_from
+    AND pr.created_at <= p_date_to
+    AND p.text IS NOT NULL
+    AND p.text <> ''
+  GROUP BY pr.prompt_id, p.text;
+$$;
+
+-- Per-topic totals for the report window AND the window before it, so the
+-- section can show a change without a second scan. `p_date_from` is the
+-- boundary: at or after it is the current window, before it is the previous.
+CREATE OR REPLACE FUNCTION "public"."report_topic_performance"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz,
+  "p_prev_from" timestamptz
+)
+RETURNS TABLE(
+  "topic_id" uuid,
+  "topic_name" text,
+  "runs" bigint,
+  "visible_runs" bigint,
+  "mention_answers" bigint,
+  "citation_answers" bigint,
+  "sum_visibility" double precision,
+  "pos_sum" double precision,
+  "pos_n" bigint,
+  "prev_runs" bigint,
+  "prev_visible_runs" bigint,
+  "prev_mention_answers" bigint,
+  "prev_citation_answers" bigint,
+  "prev_pos_sum" double precision,
+  "prev_pos_n" bigint
+)
+LANGUAGE "sql"
+STABLE
+SET "search_path" TO 'public'
+AS $$
+  SELECT
+    t.id,
+    t.name,
+    count(*) FILTER (WHERE pr.created_at >= p_date_from)::bigint,
+    count(*) FILTER (
+      WHERE pr.created_at >= p_date_from
+        AND (coalesce(pr.mention_count, 0) > 0 OR coalesce(pr.citation_count, 0) > 0)
+    )::bigint,
+    count(*) FILTER (WHERE pr.created_at >= p_date_from AND coalesce(pr.mention_count, 0) > 0)::bigint,
+    count(*) FILTER (WHERE pr.created_at >= p_date_from AND coalesce(pr.citation_count, 0) > 0)::bigint,
+    coalesce(sum(coalesce(pr.visibility_score, 0)) FILTER (WHERE pr.created_at >= p_date_from), 0)::double precision,
+    coalesce(sum(1.0 / pr.mention_position) FILTER (
+      WHERE pr.created_at >= p_date_from AND pr.mention_position > 0
+    ), 0)::double precision,
+    count(*) FILTER (WHERE pr.created_at >= p_date_from AND pr.mention_position > 0)::bigint,
+    count(*) FILTER (WHERE pr.created_at < p_date_from)::bigint,
+    count(*) FILTER (
+      WHERE pr.created_at < p_date_from
+        AND (coalesce(pr.mention_count, 0) > 0 OR coalesce(pr.citation_count, 0) > 0)
+    )::bigint,
+    count(*) FILTER (WHERE pr.created_at < p_date_from AND coalesce(pr.mention_count, 0) > 0)::bigint,
+    count(*) FILTER (WHERE pr.created_at < p_date_from AND coalesce(pr.citation_count, 0) > 0)::bigint,
+    coalesce(sum(1.0 / pr.mention_position) FILTER (
+      WHERE pr.created_at < p_date_from AND pr.mention_position > 0
+    ), 0)::double precision,
+    count(*) FILTER (WHERE pr.created_at < p_date_from AND pr.mention_position > 0)::bigint
+  FROM prompt_results pr
+  JOIN prompts p ON p.id = pr.prompt_id
+  JOIN topics t ON t.id = p.topic_id
+  WHERE pr.brand_id = p_brand_id
+    AND pr.platform <> 'chatgpt-shopping'
+    AND pr.created_at >= p_prev_from
+    AND pr.created_at <= p_date_to
+  GROUP BY t.id, t.name;
+$$;
+
+-- Top cited URLs with the prompts whose answers cited them.
+--
+-- SECURITY DEFINER because citation_urls carries row-level security with no
+-- select policy — the same reason citations_urls (00061) is defined that way.
+-- Unlike those, this one checks that the caller is in the brand's org rather
+-- than trusting the brand id it was handed.
+CREATE OR REPLACE FUNCTION "public"."report_citation_evidence"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz,
+  "p_limit" integer DEFAULT 10,
+  "p_prompts_per_url" integer DEFAULT 3
+)
+RETURNS TABLE(
+  "url" text,
+  "domain" text,
+  "title" text,
+  "total_citations" bigint,
+  "sourced_prompts" text[]
+)
+LANGUAGE "sql"
+STABLE
+SECURITY DEFINER
+SET "search_path" TO 'public'
+SET "work_mem" TO '96MB'
+AS $$
+  WITH allowed AS (
+    SELECT 1
+    FROM brands b
+    JOIN profiles pf ON pf.organization_id = b.organization_id
+    WHERE b.id = p_brand_id
+      AND pf.id = auth.uid()
+  ),
+  -- citation_urls keeps the query string, so one page can sit under several
+  -- ids (?utm_source=..., ?authuser=...). Evidence is about the page, not the
+  -- link that reached it, so strip query and fragment and group on what is
+  -- left — the same normalization the section applied before this moved into
+  -- SQL. Without it the list shows the same article three times.
+  pairs AS (
+    SELECT
+      regexp_replace(split_part(split_part(cu.url, '#', 1), '?', 1), '/$', '') AS norm_url,
+      cu.domain AS domain,
+      nullif(cu.title, '') AS title,
+      pr.prompt_id AS prompt_id,
+      count(*) AS n
+    FROM prompt_result_citations c
+    JOIN prompt_results pr ON pr.id = c.prompt_result_id
+    JOIN citation_urls cu ON cu.id = c.url_id
+    WHERE EXISTS (SELECT 1 FROM allowed)
+      AND c.brand_id = p_brand_id
+      AND pr.brand_id = p_brand_id
+      AND pr.platform <> 'chatgpt-shopping'
+      AND c.created_at >= p_date_from
+      AND c.created_at <= p_date_to
+      AND pr.created_at >= p_date_from
+      AND pr.created_at <= p_date_to
+    GROUP BY 1, 2, 3, 4, c.prompt_result_id
+  ),
+  agg AS (
+    SELECT
+      norm_url,
+      sum(n)::bigint AS tc,
+      min(domain) AS domain,
+      min(title) AS title
+    FROM pairs
+    GROUP BY norm_url
+  ),
+  top AS (
+    SELECT norm_url, tc, domain, title FROM agg ORDER BY tc DESC, norm_url LIMIT p_limit
+  ),
+  -- One row per (url, prompt text), then keep the first few per url. Ordering
+  -- by text keeps the choice stable across runs of the same report.
+  ranked AS (
+    SELECT norm_url, text, row_number() OVER (PARTITION BY norm_url ORDER BY text) AS rn
+    FROM (
+      SELECT DISTINCT t.norm_url, p.text
+      FROM top t
+      JOIN pairs pa ON pa.norm_url = t.norm_url
+      JOIN prompts p ON p.id = pa.prompt_id
+      WHERE p.text IS NOT NULL AND p.text <> ''
+    ) d
+  )
+  SELECT
+    t.norm_url,
+    coalesce(t.domain, ''),
+    coalesce(t.title, ''),
+    t.tc,
+    coalesce(
+      (SELECT array_agg(r.text ORDER BY r.rn)
+       FROM ranked r
+       WHERE r.norm_url = t.norm_url AND r.rn <= p_prompts_per_url),
+      ARRAY[]::text[]
+    )
+  FROM top t
+  ORDER BY t.tc DESC;
+$$;
+
+GRANT EXECUTE ON FUNCTION "public"."report_prompt_performance"(uuid, timestamptz, timestamptz) TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."report_topic_performance"(uuid, timestamptz, timestamptz, timestamptz) TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."report_citation_evidence"(uuid, timestamptz, timestamptz, integer, integer) TO "authenticated";

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6339,3 +6339,241 @@ CREATE TRIGGER "organizations_guard_server_columns"
   FOR EACH ROW
   EXECUTE FUNCTION "public"."guard_organization_server_columns"();
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00063_report_aggregate_rpcs.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Report generation: aggregate in Postgres instead of downloading the window.
+--
+-- Three report sections computed their figures by paging every matching
+-- prompt_results row into the Node process and folding them there. On a brand
+-- with ~12k results a week that is dozens of sequential round trips per
+-- section, all running while the report's other sections issue their own
+-- queries. The heavy aggregate RPCs (ai_visibility_aggregates and friends)
+-- then exceed the 8s statement_timeout of the `authenticated` role and the
+-- whole report fails.
+--
+-- The scans also had a ceiling: 50,000 rows. A 30-day report spans 60 days of
+-- data for the topic section, which is already past that on a busy brand, so
+-- the figures were quietly computed from a truncated window.
+--
+-- These functions return the raw accumulator components rather than finished
+-- scores. The blend lives in one place in TypeScript (computeAiVisibilityScore)
+-- and is shared with the Prompts and Topics pages; reimplementing it here
+-- would be a second copy to keep in step.
+
+-- Per-prompt totals for the report window. Rows returned: one per prompt,
+-- not one per answer.
+CREATE OR REPLACE FUNCTION "public"."report_prompt_performance"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz
+)
+RETURNS TABLE(
+  "prompt_id" uuid,
+  "prompt_text" text,
+  "runs" bigint,
+  "visible_runs" bigint,
+  "mention_answers" bigint,
+  "citation_answers" bigint,
+  "total_mentions" bigint,
+  "sum_visibility" double precision,
+  "pos_sum" double precision,
+  "pos_n" bigint
+)
+LANGUAGE "sql"
+STABLE
+SET "search_path" TO 'public'
+AS $$
+  SELECT
+    pr.prompt_id,
+    p.text,
+    count(*)::bigint,
+    count(*) FILTER (
+      WHERE coalesce(pr.mention_count, 0) > 0 OR coalesce(pr.citation_count, 0) > 0
+    )::bigint,
+    count(*) FILTER (WHERE coalesce(pr.mention_count, 0) > 0)::bigint,
+    count(*) FILTER (WHERE coalesce(pr.citation_count, 0) > 0)::bigint,
+    coalesce(sum(coalesce(pr.mention_count, 0)), 0)::bigint,
+    coalesce(sum(coalesce(pr.visibility_score, 0)), 0)::double precision,
+    -- Reciprocal rank, summed only over answers that actually placed the
+    -- brand somewhere; pos_n is that count so the caller can take the mean.
+    coalesce(sum(1.0 / pr.mention_position) FILTER (WHERE pr.mention_position > 0), 0)::double precision,
+    count(*) FILTER (WHERE pr.mention_position > 0)::bigint
+  FROM prompt_results pr
+  JOIN prompts p ON p.id = pr.prompt_id
+  WHERE pr.brand_id = p_brand_id
+    AND pr.platform <> 'chatgpt-shopping'
+    AND pr.created_at >= p_date_from
+    AND pr.created_at <= p_date_to
+    AND p.text IS NOT NULL
+    AND p.text <> ''
+  GROUP BY pr.prompt_id, p.text;
+$$;
+
+-- Per-topic totals for the report window AND the window before it, so the
+-- section can show a change without a second scan. `p_date_from` is the
+-- boundary: at or after it is the current window, before it is the previous.
+CREATE OR REPLACE FUNCTION "public"."report_topic_performance"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz,
+  "p_prev_from" timestamptz
+)
+RETURNS TABLE(
+  "topic_id" uuid,
+  "topic_name" text,
+  "runs" bigint,
+  "visible_runs" bigint,
+  "mention_answers" bigint,
+  "citation_answers" bigint,
+  "sum_visibility" double precision,
+  "pos_sum" double precision,
+  "pos_n" bigint,
+  "prev_runs" bigint,
+  "prev_visible_runs" bigint,
+  "prev_mention_answers" bigint,
+  "prev_citation_answers" bigint,
+  "prev_pos_sum" double precision,
+  "prev_pos_n" bigint
+)
+LANGUAGE "sql"
+STABLE
+SET "search_path" TO 'public'
+AS $$
+  SELECT
+    t.id,
+    t.name,
+    count(*) FILTER (WHERE pr.created_at >= p_date_from)::bigint,
+    count(*) FILTER (
+      WHERE pr.created_at >= p_date_from
+        AND (coalesce(pr.mention_count, 0) > 0 OR coalesce(pr.citation_count, 0) > 0)
+    )::bigint,
+    count(*) FILTER (WHERE pr.created_at >= p_date_from AND coalesce(pr.mention_count, 0) > 0)::bigint,
+    count(*) FILTER (WHERE pr.created_at >= p_date_from AND coalesce(pr.citation_count, 0) > 0)::bigint,
+    coalesce(sum(coalesce(pr.visibility_score, 0)) FILTER (WHERE pr.created_at >= p_date_from), 0)::double precision,
+    coalesce(sum(1.0 / pr.mention_position) FILTER (
+      WHERE pr.created_at >= p_date_from AND pr.mention_position > 0
+    ), 0)::double precision,
+    count(*) FILTER (WHERE pr.created_at >= p_date_from AND pr.mention_position > 0)::bigint,
+    count(*) FILTER (WHERE pr.created_at < p_date_from)::bigint,
+    count(*) FILTER (
+      WHERE pr.created_at < p_date_from
+        AND (coalesce(pr.mention_count, 0) > 0 OR coalesce(pr.citation_count, 0) > 0)
+    )::bigint,
+    count(*) FILTER (WHERE pr.created_at < p_date_from AND coalesce(pr.mention_count, 0) > 0)::bigint,
+    count(*) FILTER (WHERE pr.created_at < p_date_from AND coalesce(pr.citation_count, 0) > 0)::bigint,
+    coalesce(sum(1.0 / pr.mention_position) FILTER (
+      WHERE pr.created_at < p_date_from AND pr.mention_position > 0
+    ), 0)::double precision,
+    count(*) FILTER (WHERE pr.created_at < p_date_from AND pr.mention_position > 0)::bigint
+  FROM prompt_results pr
+  JOIN prompts p ON p.id = pr.prompt_id
+  JOIN topics t ON t.id = p.topic_id
+  WHERE pr.brand_id = p_brand_id
+    AND pr.platform <> 'chatgpt-shopping'
+    AND pr.created_at >= p_prev_from
+    AND pr.created_at <= p_date_to
+  GROUP BY t.id, t.name;
+$$;
+
+-- Top cited URLs with the prompts whose answers cited them.
+--
+-- SECURITY DEFINER because citation_urls carries row-level security with no
+-- select policy — the same reason citations_urls (00061) is defined that way.
+-- Unlike those, this one checks that the caller is in the brand's org rather
+-- than trusting the brand id it was handed.
+CREATE OR REPLACE FUNCTION "public"."report_citation_evidence"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz,
+  "p_limit" integer DEFAULT 10,
+  "p_prompts_per_url" integer DEFAULT 3
+)
+RETURNS TABLE(
+  "url" text,
+  "domain" text,
+  "title" text,
+  "total_citations" bigint,
+  "sourced_prompts" text[]
+)
+LANGUAGE "sql"
+STABLE
+SECURITY DEFINER
+SET "search_path" TO 'public'
+SET "work_mem" TO '96MB'
+AS $$
+  WITH allowed AS (
+    SELECT 1
+    FROM brands b
+    JOIN profiles pf ON pf.organization_id = b.organization_id
+    WHERE b.id = p_brand_id
+      AND pf.id = auth.uid()
+  ),
+  -- citation_urls keeps the query string, so one page can sit under several
+  -- ids (?utm_source=..., ?authuser=...). Evidence is about the page, not the
+  -- link that reached it, so strip query and fragment and group on what is
+  -- left — the same normalization the section applied before this moved into
+  -- SQL. Without it the list shows the same article three times.
+  pairs AS (
+    SELECT
+      regexp_replace(split_part(split_part(cu.url, '#', 1), '?', 1), '/$', '') AS norm_url,
+      cu.domain AS domain,
+      nullif(cu.title, '') AS title,
+      pr.prompt_id AS prompt_id,
+      count(*) AS n
+    FROM prompt_result_citations c
+    JOIN prompt_results pr ON pr.id = c.prompt_result_id
+    JOIN citation_urls cu ON cu.id = c.url_id
+    WHERE EXISTS (SELECT 1 FROM allowed)
+      AND c.brand_id = p_brand_id
+      AND pr.brand_id = p_brand_id
+      AND pr.platform <> 'chatgpt-shopping'
+      AND c.created_at >= p_date_from
+      AND c.created_at <= p_date_to
+      AND pr.created_at >= p_date_from
+      AND pr.created_at <= p_date_to
+    GROUP BY 1, 2, 3, 4, c.prompt_result_id
+  ),
+  agg AS (
+    SELECT
+      norm_url,
+      sum(n)::bigint AS tc,
+      min(domain) AS domain,
+      min(title) AS title
+    FROM pairs
+    GROUP BY norm_url
+  ),
+  top AS (
+    SELECT norm_url, tc, domain, title FROM agg ORDER BY tc DESC, norm_url LIMIT p_limit
+  ),
+  -- One row per (url, prompt text), then keep the first few per url. Ordering
+  -- by text keeps the choice stable across runs of the same report.
+  ranked AS (
+    SELECT norm_url, text, row_number() OVER (PARTITION BY norm_url ORDER BY text) AS rn
+    FROM (
+      SELECT DISTINCT t.norm_url, p.text
+      FROM top t
+      JOIN pairs pa ON pa.norm_url = t.norm_url
+      JOIN prompts p ON p.id = pa.prompt_id
+      WHERE p.text IS NOT NULL AND p.text <> ''
+    ) d
+  )
+  SELECT
+    t.norm_url,
+    coalesce(t.domain, ''),
+    coalesce(t.title, ''),
+    t.tc,
+    coalesce(
+      (SELECT array_agg(r.text ORDER BY r.rn)
+       FROM ranked r
+       WHERE r.norm_url = t.norm_url AND r.rn <= p_prompts_per_url),
+      ARRAY[]::text[]
+    )
+  FROM top t
+  ORDER BY t.tc DESC;
+$$;
+
+GRANT EXECUTE ON FUNCTION "public"."report_prompt_performance"(uuid, timestamptz, timestamptz) TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."report_topic_performance"(uuid, timestamptz, timestamptz, timestamptz) TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."report_citation_evidence"(uuid, timestamptz, timestamptz, integer, integer) TO "authenticated";
+

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -558,6 +558,7 @@
       "mentionEvidence": "Mention Evidence",
       "citationEvidence": "Citation Evidence"
     },
+    "missingSections": "Some sections could not be gathered and are not in this report:",
     "brandLabel": "Brand",
     "sectionsLabel": "Sections",
     "selectSections": "Pick at least one section",

--- a/web/src/app/[locale]/(dashboard)/dashboard/reports/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/reports/[id]/page.tsx
@@ -220,6 +220,20 @@ export default function ReportDetailPage() {
       {/* Everything below renders from the immutable saved payload; the
           container id is the future PDF capture root. */}
       <div id="report-root" className="space-y-6">
+        {/* A section that could not be gathered is named here rather than
+            silently absent — otherwise the report reads as though the brand
+            had no data for it. */}
+        {payload.missingSections && payload.missingSections.length > 0 && (
+          <Card className="border-amber-500/40">
+            <CardContent className="py-4 text-sm text-muted-foreground">
+              {t('missingSections')}{' '}
+              <span className="text-foreground">
+                {payload.missingSections.map((s) => t(`sections.${s}`)).join(', ')}
+              </span>
+            </CardContent>
+          </Card>
+        )}
+
         <Card>
           <CardHeader>
             <CardTitle className="text-base">{t('executiveSummary')}</CardTitle>

--- a/web/src/lib/actions/reports.ts
+++ b/web/src/lib/actions/reports.ts
@@ -19,7 +19,7 @@ import {
 } from '@/lib/actions/tracking';
 import { getCitationsOverview, type CitationsSourceBreakdown } from '@/lib/actions/citations';
 import { getShoppingKpis } from '@/lib/actions/shopping';
-import { extractHostname, type SourceCategory } from '@/lib/citations/classify';
+import { type SourceCategory } from '@/lib/citations/classify';
 import {
   getReportTemplate,
   ALL_REPORT_SECTIONS,
@@ -166,6 +166,12 @@ export interface ReportPayload {
   brandName: string;
   /** AI-generated executive summary (plain prose). */
   summaryText: string;
+  /**
+   * Sections that were asked for but could not be gathered. A report is
+   * generated without them rather than not at all, and this is how the page
+   * says which ones are missing instead of leaving the reader to guess.
+   */
+  missingSections?: ReportSection[];
   insights?: InsightsSummary;
   /** Prompt-level Visibility Rate — leads the KPI row (#492); absent on reports generated before this shipped. */
   visibilityRate?: ReportVisibilityRate;
@@ -231,14 +237,6 @@ const REPORT_TOP_DOMAINS = 10;
 const REPORT_PROMPT_COUNT = 5;
 
 /**
- * Every full-window prompt_results scan must page: PostgREST silently caps a
- * select at 1000 rows, which on busy brands computes a report section from a
- * truncated window (the #430/#464 defect family).
- */
-const SCAN_PAGE_SIZE = 1000;
-const SCAN_MAX_ROWS = 50_000;
-
-/**
  * Best/worst prompts by prompt-level Visibility Rate WITHIN the report period
  * — the share of runs the brand actually appeared in, not an average score
  * that zero-visibility runs dilute into misleading single digits (#562).
@@ -246,6 +244,18 @@ const SCAN_MAX_ROWS = 50_000;
  * custom historical ranges — so reports aggregate over [dateFrom, dateTo]
  * directly (same shape: exclude chatgpt-shopping, one row per run).
  */
+interface PromptPerfRow {
+  prompt_text: string | null;
+  runs: number;
+  visible_runs: number;
+  mention_answers: number;
+  citation_answers: number;
+  total_mentions: number;
+  sum_visibility: number;
+  pos_sum: number;
+  pos_n: number;
+}
+
 async function getPromptPerformance(
   brandId: string,
   dateFrom: string,
@@ -253,88 +263,32 @@ async function getPromptPerformance(
 ): Promise<{ best: ReportPromptPerf[]; worst: ReportPromptPerf[] }> {
   const supabase = await createClient();
 
-  const acc = new Map<
-    string,
-    {
-      sumVis: number;
-      mentions: number;
-      runs: number;
-      visibleRuns: number;
-      mentionAnswers: number;
-      citationAnswers: number;
-      posSum: number;
-      posN: number;
-    }
-  >();
-  for (let offset = 0; offset < SCAN_MAX_ROWS; offset += SCAN_PAGE_SIZE) {
-    const { data, error } = await supabase
-      .from('prompt_results')
-      .select('prompt_id, visibility_score, mention_count, citation_count, mention_position')
-      .eq('brand_id', brandId)
-      .neq('platform', 'chatgpt-shopping')
-      .gte('created_at', dateFrom)
-      .lte('created_at', dateTo)
-      .order('created_at', { ascending: true })
-      .order('id', { ascending: true })
-      .range(offset, offset + SCAN_PAGE_SIZE - 1);
-    if (error) throw new Error(error.message);
+  const { data, error } = await supabase.rpc('report_prompt_performance', {
+    p_brand_id: brandId,
+    p_date_from: dateFrom,
+    p_date_to: dateTo,
+  });
+  if (error) throw new Error(error.message);
 
-    const batch = data ?? [];
-    for (const r of batch) {
-      const pid = r.prompt_id as string | null;
-      if (!pid) continue;
-      const entry = acc.get(pid) ?? {
-        sumVis: 0,
-        mentions: 0,
-        runs: 0,
-        visibleRuns: 0,
-        mentionAnswers: 0,
-        citationAnswers: 0,
-        posSum: 0,
-        posN: 0,
-      };
-      const mentions = (r.mention_count as number) ?? 0;
-      const citations = (r.citation_count as number) ?? 0;
-      const pos = r.mention_position as number | null;
-      entry.sumVis += (r.visibility_score as number) ?? 0;
-      entry.mentions += mentions;
-      entry.runs += 1;
-      if (mentions > 0 || citations > 0) entry.visibleRuns += 1;
-      if (mentions > 0) entry.mentionAnswers += 1;
-      if (citations > 0) entry.citationAnswers += 1;
-      if (pos !== null && pos !== undefined && pos > 0) {
-        entry.posSum += 1 / pos;
-        entry.posN += 1;
-      }
-      acc.set(pid, entry);
-    }
+  const rows = (data ?? []) as unknown as PromptPerfRow[];
 
-    if (batch.length < SCAN_PAGE_SIZE) break;
-  }
-  if (acc.size === 0) return { best: [], worst: [] };
-
-  const { data: promptRows } = await supabase
-    .from('prompts')
-    .select('id, text')
-    .in('id', [...acc.keys()]);
-  const textById = new Map((promptRows ?? []).map((p) => [p.id as string, p.text as string]));
-
-  const ranked = [...acc.entries()]
-    .map(([pid, v]) => ({
-      text: textById.get(pid) ?? '',
-      avgVisibility: Math.round((v.sumVis / v.runs) * 10) / 10,
-      visibilityRate: Math.round((v.visibleRuns / v.runs) * 1000) / 10,
+  const ranked = rows
+    .filter((r) => r.runs > 0)
+    .map((r) => ({
+      text: r.prompt_text ?? '',
+      avgVisibility: Math.round((r.sum_visibility / r.runs) * 10) / 10,
+      visibilityRate: Math.round((r.visible_runs / r.runs) * 1000) / 10,
       // AI Visibility Score over this prompt's answers — same blend as the
       // All Prompts column, so a prompt reads identically in a report.
       score:
         computeAiVisibilityScore({
-          answers: v.runs,
-          mentionAnswers: v.mentionAnswers,
-          citationAnswers: v.citationAnswers,
-          positionFactor: v.posN > 0 ? v.posSum / v.posN : null,
+          answers: r.runs,
+          mentionAnswers: r.mention_answers,
+          citationAnswers: r.citation_answers,
+          positionFactor: r.pos_n > 0 ? r.pos_sum / r.pos_n : null,
         }) ?? 0,
-      totalMentions: v.mentions,
-      runs: v.runs,
+      totalMentions: r.total_mentions,
+      runs: r.runs,
     }))
     .filter((p) => p.text)
     .sort((a, b) => b.score - a.score || b.totalMentions - a.totalMentions);
@@ -424,6 +378,23 @@ const REPORT_TOPIC_COUNT = 8;
  * getPromptPerformance: one paged prompt_results scan spanning both windows,
  * then resolve topic names.
  */
+interface TopicPerfRow {
+  topic_name: string | null;
+  runs: number;
+  visible_runs: number;
+  mention_answers: number;
+  citation_answers: number;
+  sum_visibility: number;
+  pos_sum: number;
+  pos_n: number;
+  prev_runs: number;
+  prev_visible_runs: number;
+  prev_mention_answers: number;
+  prev_citation_answers: number;
+  prev_pos_sum: number;
+  prev_pos_n: number;
+}
+
 async function getTopicPerformance(
   brandId: string,
   dateFrom: string,
@@ -432,143 +403,44 @@ async function getTopicPerformance(
   const supabase = await createClient();
   const prev = previousWindow(dateFrom, dateTo);
 
-  // Two windows in one scan hits the 1000-row cap even sooner than the
-  // single-window scans, so page it.
-  const rows: {
-    prompt_id: string | null;
-    visibility_score: number | null;
-    mention_count: number | null;
-    citation_count: number | null;
-    mention_position: number | null;
-    created_at: string;
-  }[] = [];
-  for (let offset = 0; offset < SCAN_MAX_ROWS; offset += SCAN_PAGE_SIZE) {
-    const { data, error } = await supabase
-      .from('prompt_results')
-      .select(
-        'prompt_id, visibility_score, mention_count, citation_count, mention_position, created_at',
-      )
-      .eq('brand_id', brandId)
-      .neq('platform', 'chatgpt-shopping')
-      .gte('created_at', prev.from)
-      .lte('created_at', dateTo)
-      .order('created_at', { ascending: true })
-      .order('id', { ascending: true })
-      .range(offset, offset + SCAN_PAGE_SIZE - 1);
-    if (error) throw new Error(error.message);
+  const { data, error } = await supabase.rpc('report_topic_performance', {
+    p_brand_id: brandId,
+    p_date_from: dateFrom,
+    p_date_to: dateTo,
+    p_prev_from: prev.from,
+  });
+  if (error) throw new Error(error.message);
 
-    const batch = data ?? [];
-    rows.push(...batch);
-    if (batch.length < SCAN_PAGE_SIZE) break;
-  }
-  if (rows.length === 0) return [];
+  const rows = (data ?? []) as unknown as TopicPerfRow[];
 
-  const promptIds = [...new Set(rows.map((r) => r.prompt_id as string).filter(Boolean))];
-  const { data: promptRows } = await supabase
-    .from('prompts')
-    .select('id, topic_id')
-    .in('id', promptIds);
-  const topicByPrompt = new Map(
-    (promptRows ?? []).filter((p) => p.topic_id).map((p) => [p.id as string, p.topic_id as string]),
-  );
-  if (topicByPrompt.size === 0) return [];
-
-  interface Acc {
-    sumVis: number;
-    n: number;
-    visible: number;
-    mentionAnswers: number;
-    citationAnswers: number;
-    posSum: number;
-    posN: number;
-    prevN: number;
-    prevVisible: number;
-    prevMentionAnswers: number;
-    prevCitationAnswers: number;
-    prevPosSum: number;
-    prevPosN: number;
-  }
-  const byTopic = new Map<string, Acc>();
-  for (const r of rows) {
-    const topicId = topicByPrompt.get(r.prompt_id as string);
-    if (!topicId) continue;
-    const acc = byTopic.get(topicId) ?? {
-      sumVis: 0,
-      n: 0,
-      visible: 0,
-      mentionAnswers: 0,
-      citationAnswers: 0,
-      posSum: 0,
-      posN: 0,
-      prevN: 0,
-      prevVisible: 0,
-      prevMentionAnswers: 0,
-      prevCitationAnswers: 0,
-      prevPosSum: 0,
-      prevPosN: 0,
-    };
-    const mentions = (r.mention_count as number | null) ?? 0;
-    const citations = (r.citation_count as number | null) ?? 0;
-    const pos = r.mention_position as number | null;
-    const isVisible = mentions > 0 || citations > 0;
-    if ((r.created_at as string) >= dateFrom) {
-      acc.sumVis += r.visibility_score ?? 0;
-      acc.n += 1;
-      if (isVisible) acc.visible += 1;
-      if (mentions > 0) acc.mentionAnswers += 1;
-      if (citations > 0) acc.citationAnswers += 1;
-      if (pos !== null && pos !== undefined && pos > 0) {
-        acc.posSum += 1 / pos;
-        acc.posN += 1;
-      }
-    } else {
-      acc.prevN += 1;
-      if (isVisible) acc.prevVisible += 1;
-      if (mentions > 0) acc.prevMentionAnswers += 1;
-      if (citations > 0) acc.prevCitationAnswers += 1;
-      if (pos !== null && pos !== undefined && pos > 0) {
-        acc.prevPosSum += 1 / pos;
-        acc.prevPosN += 1;
-      }
-    }
-    byTopic.set(topicId, acc);
-  }
-
-  const { data: topicRows } = await supabase
-    .from('topics')
-    .select('id, name')
-    .in('id', [...byTopic.keys()]);
-  const nameById = new Map((topicRows ?? []).map((t) => [t.id as string, t.name as string]));
-
-  return [...byTopic.entries()]
-    .filter(([id, acc]) => acc.n > 0 && nameById.has(id))
-    .map(([id, acc]) => {
-      const rate = Math.round((acc.visible / acc.n) * 1000) / 10;
+  return rows
+    .filter((r) => r.runs > 0 && r.topic_name)
+    .map((r) => {
       // AI Visibility Score over the topic's answers, per window — same
       // blend as the Topics page so the two surfaces agree.
       const score =
         computeAiVisibilityScore({
-          answers: acc.n,
-          mentionAnswers: acc.mentionAnswers,
-          citationAnswers: acc.citationAnswers,
-          positionFactor: acc.posN > 0 ? acc.posSum / acc.posN : null,
+          answers: r.runs,
+          mentionAnswers: r.mention_answers,
+          citationAnswers: r.citation_answers,
+          positionFactor: r.pos_n > 0 ? r.pos_sum / r.pos_n : null,
         }) ?? 0;
       const prevScore =
-        acc.prevN > 0
+        r.prev_runs > 0
           ? (computeAiVisibilityScore({
-              answers: acc.prevN,
-              mentionAnswers: acc.prevMentionAnswers,
-              citationAnswers: acc.prevCitationAnswers,
-              positionFactor: acc.prevPosN > 0 ? acc.prevPosSum / acc.prevPosN : null,
+              answers: r.prev_runs,
+              mentionAnswers: r.prev_mention_answers,
+              citationAnswers: r.prev_citation_answers,
+              positionFactor: r.prev_pos_n > 0 ? r.prev_pos_sum / r.prev_pos_n : null,
             }) ?? 0)
           : null;
       return {
-        name: nameById.get(id)!,
-        avgVisibility: round1(acc.sumVis / acc.n),
-        visibilityRate: rate,
+        name: r.topic_name!,
+        avgVisibility: round1(r.sum_visibility / r.runs),
+        visibilityRate: Math.round((r.visible_runs / r.runs) * 1000) / 10,
         score,
         change: prevScore === null ? null : round1(score - prevScore),
-        results: acc.n,
+        results: r.runs,
       };
     })
     .sort((a, b) => b.results - a.results || b.score - a.score)
@@ -818,100 +690,36 @@ async function getMentionEvidence(
  * (#429). Needs its own paginated scan: the citations overview aggregates
  * URLs but doesn't keep the prompt attribution the evidence section is for.
  */
+interface CitationEvidenceRow {
+  url: string;
+  domain: string;
+  title: string;
+  total_citations: number;
+  sourced_prompts: string[] | null;
+}
+
 async function getCitationEvidence(
   brandId: string,
   dateFrom: string,
   dateTo: string,
 ): Promise<ReportCitationEvidence[]> {
   const supabase = await createClient();
-  const PAGE_SIZE = 1000;
-  const MAX_ROWS = 50_000;
 
-  interface UrlAgg {
-    url: string;
-    domain: string;
-    title: string;
-    count: number;
-    promptIds: Set<string>;
-  }
-  const byUrl = new Map<string, UrlAgg>();
+  const { data, error } = await supabase.rpc('report_citation_evidence', {
+    p_brand_id: brandId,
+    p_date_from: dateFrom,
+    p_date_to: dateTo,
+    p_limit: REPORT_EVIDENCE_COUNT,
+    p_prompts_per_url: EVIDENCE_PROMPTS_PER_URL,
+  });
+  if (error) throw new Error(error.message);
 
-  for (let offset = 0; offset < MAX_ROWS; offset += PAGE_SIZE) {
-    const { data, error } = await supabase
-      .from('prompt_results')
-      .select('prompt_id, citations')
-      .eq('brand_id', brandId)
-      .neq('platform', 'chatgpt-shopping')
-      .gte('created_at', dateFrom)
-      .lte('created_at', dateTo)
-      .order('created_at', { ascending: true })
-      .order('id', { ascending: true })
-      .range(offset, offset + PAGE_SIZE - 1);
-    if (error) throw new Error(error.message);
-
-    const batch = (data ?? []) as Array<{
-      prompt_id: string | null;
-      citations: Array<{ url?: string; title?: string }> | null;
-    }>;
-
-    for (const row of batch) {
-      const citations = Array.isArray(row.citations) ? row.citations : [];
-      for (const cite of citations) {
-        if (!cite?.url) continue;
-        const host = extractHostname(cite.url);
-        if (!host) continue;
-        // Same URL normalization the Citations page uses, so the evidence
-        // list lines up with the overview's Top URLs.
-        let normalized = cite.url;
-        try {
-          const parsed = new URL(cite.url);
-          parsed.search = '';
-          parsed.hash = '';
-          normalized = parsed.toString().replace(/\/$/, '');
-        } catch {
-          // leave as-is
-        }
-        const agg = byUrl.get(normalized) ?? {
-          url: normalized,
-          domain: host,
-          title: cite.title || '',
-          count: 0,
-          promptIds: new Set<string>(),
-        };
-        agg.count += 1;
-        if (!agg.title && cite.title) agg.title = cite.title;
-        if (row.prompt_id) agg.promptIds.add(row.prompt_id);
-        byUrl.set(normalized, agg);
-      }
-    }
-
-    if (batch.length < PAGE_SIZE) break;
-  }
-
-  const top = [...byUrl.values()]
-    .sort((a, b) => b.count - a.count || a.url.localeCompare(b.url))
-    .slice(0, REPORT_EVIDENCE_COUNT);
-  if (top.length === 0) return [];
-
-  const allPromptIds = [...new Set(top.flatMap((u) => [...u.promptIds]))];
-  const promptTextById = new Map<string, string>();
-  if (allPromptIds.length > 0) {
-    const { data: promptRows } = await supabase
-      .from('prompts')
-      .select('id, text')
-      .in('id', allPromptIds);
-    for (const p of promptRows ?? []) promptTextById.set(p.id as string, p.text as string);
-  }
-
-  return top.map((u) => ({
-    url: u.url,
-    domain: u.domain,
-    title: u.title,
-    totalCitations: u.count,
-    sourcedPrompts: [...u.promptIds]
-      .map((id) => promptTextById.get(id))
-      .filter((t): t is string => Boolean(t))
-      .slice(0, EVIDENCE_PROMPTS_PER_URL),
+  return ((data ?? []) as unknown as CitationEvidenceRow[]).map((r) => ({
+    url: r.url,
+    domain: r.domain,
+    title: r.title,
+    totalCitations: r.total_citations,
+    sourcedPrompts: r.sourced_prompts ?? [],
   }));
 }
 
@@ -965,13 +773,38 @@ export async function createReport(
 
   // 1. Gather the metric snapshot through the existing analytics actions —
   //    only the picked sections (null = section not gathered).
+  //
+  //    A section that fails does not take the report with it. Losing one
+  //    module is a gap the reader can see; losing all fourteen because the
+  //    last one timed out is a report that never existed. What went missing is
+  //    recorded so the output can say so rather than quietly shrink.
+  const failed = new Set<ReportSection>();
+  async function section<T>(name: ReportSection, run: () => Promise<T>): Promise<T | null> {
+    try {
+      return await run();
+    } catch (err) {
+      console.error(`[reports] section "${name}" failed for brand ${brandId}:`, err);
+      failed.add(name);
+      return null;
+    }
+  }
+  const pick = <T>(name: ReportSection, run: () => Promise<T>) =>
+    has(name) ? section(name, run) : Promise.resolve(null);
+
+  //    Two waves rather than one. The first holds the sections backed by the
+  //    aggregate RPCs, which read the whole window in a single statement and
+  //    are therefore the ones that run out of the database's per-statement
+  //    time budget when everything else competes for the same I/O.
+  const [insights, visibilityRate, sov, comparison, trend] = await Promise.all([
+    pick('kpis', () => getInsightsSummary(brandId, range)),
+    pick('kpis', () => getReportVisibilityRate(brandId, range)),
+    pick('shareOfVoice', () => getShareOfVoiceData(brandId, range)),
+    pick('competitors', () => getCompetitorComparison(brandId, range)),
+    pick('trend', () => getVisibilityRateTrend(brandId, range)),
+  ]);
+
   const [
-    insights,
-    visibilityRate,
-    sov,
-    comparison,
     citations,
-    trend,
     promptPerformance,
     mentionEvidence,
     citationEvidence,
@@ -981,22 +814,17 @@ export async function createReport(
     shoppingVisibility,
     auditScore,
   ] = await Promise.all([
-    has('kpis') ? getInsightsSummary(brandId, range) : null,
-    has('kpis') ? getReportVisibilityRate(brandId, range) : null,
-    has('shareOfVoice') ? getShareOfVoiceData(brandId, range) : null,
-    has('competitors') ? getCompetitorComparison(brandId, range) : null,
-    has('citations')
-      ? getCitationsOverview(brandId, { datePreset: 'custom', dateFrom, dateTo })
-      : null,
-    has('trend') ? getVisibilityRateTrend(brandId, range) : null,
-    has('promptPerformance') ? getPromptPerformance(brandId, dateFrom, dateTo) : null,
-    has('mentionEvidence') ? getMentionEvidence(brandId, brandName, dateFrom, dateTo) : null,
-    has('citationEvidence') ? getCitationEvidence(brandId, dateFrom, dateTo) : null,
-    has('queryFanout') ? getFanoutSnapshot(brandId, dateFrom, dateTo) : null,
-    has('topicPerformance') ? getTopicPerformance(brandId, dateFrom, dateTo) : null,
-    has('aiTraffic') ? getTrafficSnapshot(brandId, dateFrom, dateTo) : null,
-    has('shoppingVisibility') ? getShoppingSnapshot(brandId, dateFrom, dateTo) : null,
-    has('auditScore') ? getAuditSnapshot(brandId, dateTo) : null,
+    pick('citations', () =>
+      getCitationsOverview(brandId, { datePreset: 'custom', dateFrom, dateTo }),
+    ),
+    pick('promptPerformance', () => getPromptPerformance(brandId, dateFrom, dateTo)),
+    pick('mentionEvidence', () => getMentionEvidence(brandId, brandName, dateFrom, dateTo)),
+    pick('citationEvidence', () => getCitationEvidence(brandId, dateFrom, dateTo)),
+    pick('queryFanout', () => getFanoutSnapshot(brandId, dateFrom, dateTo)),
+    pick('topicPerformance', () => getTopicPerformance(brandId, dateFrom, dateTo)),
+    pick('aiTraffic', () => getTrafficSnapshot(brandId, dateFrom, dateTo)),
+    pick('shoppingVisibility', () => getShoppingSnapshot(brandId, dateFrom, dateTo)),
+    pick('auditScore', () => getAuditSnapshot(brandId, dateTo)),
   ]);
 
   // Adapt VisibilityRateTrendData → VisibilityTrendPoint[] so the report
@@ -1023,6 +851,7 @@ export async function createReport(
 
   const snapshot: Omit<ReportPayload, 'summaryText'> = {
     brandName,
+    ...(failed.size > 0 ? { missingSections: [...failed] } : {}),
     ...(insights ? { insights } : {}),
     ...(visibilityRate ? { visibilityRate } : {}),
     ...(visibilityTrend ? { visibilityTrend } : {}),
@@ -1071,11 +900,19 @@ export async function createReport(
     },
     body: JSON.stringify({ brandId, snapshot, dateFrom, dateTo, template: template.id }),
   });
-  if (!res.ok) {
+  //    The prose is the one part of a report the reader can do without. If it
+  //    cannot be written, the figures are still worth keeping — the page shows
+  //    no summary, which is visible on its own.
+  let summary = '';
+  if (res.ok) {
+    ({ summary } = (await res.json()) as { summary: string });
+  } else {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.message || `Summary generation failed: ${res.status}`);
+    console.error(
+      `[reports] summary generation failed for brand ${brandId}:`,
+      body.message || res.status,
+    );
   }
-  const { summary } = (await res.json()) as { summary: string };
 
   const payload: ReportPayload = { ...snapshot, summaryText: summary };
 

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -2331,6 +2331,66 @@ export type Database = {
           visible_runs: number
         }[]
       }
+      report_citation_evidence: {
+        Args: {
+          p_brand_id: string
+          p_date_from: string
+          p_date_to: string
+          p_limit?: number
+          p_prompts_per_url?: number
+        }
+        Returns: {
+          domain: string
+          sourced_prompts: string[]
+          title: string
+          total_citations: number
+          url: string
+        }[]
+      }
+      report_prompt_performance: {
+        Args: {
+          p_brand_id: string
+          p_date_from: string
+          p_date_to: string
+        }
+        Returns: {
+          citation_answers: number
+          mention_answers: number
+          pos_n: number
+          pos_sum: number
+          prompt_id: string
+          prompt_text: string
+          runs: number
+          sum_visibility: number
+          total_mentions: number
+          visible_runs: number
+        }[]
+      }
+      report_topic_performance: {
+        Args: {
+          p_brand_id: string
+          p_date_from: string
+          p_date_to: string
+          p_prev_from: string
+        }
+        Returns: {
+          citation_answers: number
+          mention_answers: number
+          pos_n: number
+          pos_sum: number
+          prev_citation_answers: number
+          prev_mention_answers: number
+          prev_pos_n: number
+          prev_pos_sum: number
+          prev_runs: number
+          prev_visible_runs: number
+          runs: number
+          sum_visibility: number
+          topic_id: string
+          topic_name: string
+          visible_runs: number
+        }[]
+      }
       share_of_voice_aggregates: {
         Args: {
           p_brand_id: string


### PR DESCRIPTION
## Summary

Generating a report with most sections selected produced **nothing at all** — no report row, just a generic failure toast.

The database logs name the cause exactly. Nine seconds into a run, six statements were cancelled at once:

```
10:39:49  generation starts
10:39:58  canceling statement due to statement timeout  (x6)
```

Six cancellations, six `500`s, and they map onto three sections:

| Section | Statement |
|---|---|
| Trend | `visibility_rate_trend`, `ai_visibility_aggregates` x2 |
| Competitors | `competitor_aggregates`, `ai_visibility_aggregates` |
| KPIs | `ai_visibility_aggregates` |

`authenticated` has an 8s `statement_timeout`. Those statements went past it — but they are not slow on their own. Measured on an idle database, `ai_visibility_aggregates` takes 1.7s.

**The report was competing with itself.** Three other sections computed their figures by paging every matching `prompt_results` row into Node: dozens of sequential round trips each, running at the same time as the aggregates, against the same tables. The aggregate statements were the victims; the row scans were most of the cause.

`Promise.all` finished the job: one rejection discarded the sections that had succeeded.

## What changed

### The three scans aggregate in SQL

They now return one row per prompt, per topic and per cited URL instead of one per answer.

| Section | Before | After |
|---|---|---|
| Prompt performance | 12,370 rows downloaded | 308 rows, **53 ms** |
| Topic performance | ~51,000 rows over a 60-day span | 17 rows, **501 ms** |
| Citation evidence | every row's `citations` column | 10 rows |

Both figures are `EXPLAIN ANALYZE` against the brand this was reported on.

### A fourth section, found while this was in review

`getFanoutSnapshot` read its window the same way, and worse: no `.range()`, no pagination, and **no `.order()` either**, so the 1000 rows PostgREST returns were not even a defined slice.

The effect was visible in a real report. Every one of its ten fan-out entries came out at `timesSearched: 2`, listed alphabetically because the counts were all tied — the signature of ranking inside an arbitrary twelfth of the data. The genuine top query had been searched **24** times and was absent from the list entirely.

Now aggregated in SQL like the other three (`00064`), 220ms for that window, with the same counting rules: a sub-query counts once per answer however often that answer repeats it, and an engine is the item's own `source_platform` when it has one, otherwise the answer's platform.

**Fixing the rows did not change which engines appear**, and that turned out to matter more than the truncation. Ranking by how many answers ran the identical string favours engines that reuse their phrasing:

| Engine | Distinct sub-queries | Answers | Top repeat |
|---|---|---|---|
| ChatGPT | **3,341** | 1,286 | 9 |
| Perplexity | 952 | 1,857 | 16 |
| Copilot | 782 | 2,038 | 18 |

ChatGPT fans out the most and reaches the top ten least, because it rephrases every time. Read on its own the table says ChatGPT does not fan out; it fans out more than the other two combined.

So each engine now carries **its distinct sub-query count and the answers those came from, above the table** (`00065`). Variety and volume point in opposite directions here — Copilot fans out on more answers, ChatGPT with more different queries — which one number could not have shown.

The ranking itself is untouched. Whether the top ten should be picked per engine is a larger question about what the section is for, and is deliberately left open.

### A ceiling that was quietly truncating monthly reports

The scans stopped at 50,000 rows. Topic performance reads **twice** the report window to compute its delta, so a 30-day report already spans 60 days — past the ceiling on this brand, and growing daily. Its figures were computed from a truncated window with nothing saying so. Aggregating in SQL removes the ceiling rather than raising it.

### The scoring stays in TypeScript

The functions return the raw counts and sums that `computeAiVisibilityScore` folds — not finished scores. The blend is shared with the Prompts and Topics pages; a second copy in SQL would be a second thing to keep in step, and the first divergence would show up as a report disagreeing with the page it came from.

### One failed section no longer costs the whole report

Gathering runs in two waves, aggregates first, and a section that throws is recorded instead of propagating. **The page names what is missing**, so an absent section cannot be read as a brand with no data.

The AI summary degrades the same way. Prose is the one part of a report a reader can do without; losing the figures with it was never the right trade.

### On `report_citation_evidence`

It groups on the URL with the query string removed. `citation_urls` keeps `?utm_source=` and friends as separate rows, so grouping on it directly listed the same article three times — the section's own normalization, now in SQL.

It is `SECURITY DEFINER` because `citation_urls` carries RLS with no select policy, which is why `citations_urls` (00061) is defined that way too. Unlike those, this one **checks that the caller belongs to the brand's org** rather than trusting the brand id it was handed.

## Related issue

None — reported directly from testing.

## Type of change

- [x] `fix` — Bug fix

## Migration

`00063_report_aggregate_rpcs.sql`, `00064_report_query_fanout_rpc.sql` and `00065_report_query_fanout_engines.sql`. **All three already applied to the hosted database.** Unlike a policy change, this one is additive — three new functions nothing referenced yet — so applying it before the code that calls it is the safe order, not the risky one.

## How to test

Needs a brand with enough data to have failed before — several thousand answers in the window.

1. Generate a report with **every section selected** over 7 days. Expected: it generates. Previously nothing was saved.
2. Same with **30 days**, and with **90 days**. Expected: all generate, and the topic figures now cover the whole window rather than the first 50,000 rows of it.
3. Compare a generated report's Prompts and Topics sections against the Prompts and Topics pages for the same range. Expected: the same scores — the blend did not move.
4. Check the Citation Evidence list. Expected: one entry per page, not one per tracking-parameter variant.
5. Check the **Query Fan-out** section. Expected: counts well above 2 and a list that is not alphabetical, and a per-engine coverage line above the table naming every engine that fanned out — including ones absent from the table itself.
6. Generate with only the Weekly Visibility defaults. Expected: unchanged.

## Verification already done

- Read the failure out of `postgres_logs` and `edge_logs` rather than inferring it: six `canceling statement due to statement timeout` entries matching six `500`s, and each mapped to its call site in the code.
- `EXPLAIN ANALYZE` on all five new functions against production data — the timings above.
- Fan-out checked against the report that surfaced it: the stored payload's ten entries all read `timesSearched: 2`, while the new function returns 24, 19, 18, 17 for the same window.
- `report_citation_evidence` exercised under a real JWT: returns rows for a member of the brand's org and **zero rows for a user outside it**.
- Confirmed the URL grouping merges variants: three `developers.google.com` rows at 413/379/370 become one at 1,227.
- `yarn typecheck`, `yarn lint` (0 errors), `yarn format:check`, `yarn test` (90 passing) and `yarn build` all pass from `web/`.

**Not covered by tests.** This repo has no test harness that can reach a server action or a Postgres function, so the checks above are manual. The section-failure path in particular has no automated proof — steps 1 and 2 are what confirm it.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
