### PR TITLE
Fix(slugify): transliterate non ascii

### DIFF
--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -9,6 +9,7 @@ import { getPromptCapacity, savePromptSet } from '@/lib/actions/prompt';
 import { triggerTrackingCheck } from '@/lib/actions/tracking';
 import { addCompetitor, getCompetitors } from '@/lib/actions/competitor';
 import { getFaviconUrl } from '@/lib/favicon';
+import { slugify } from '@/lib/slug';
 import { useBrandStore } from '@/stores/use-brand-store';
 import { REGIONS, US_STATES, LANGUAGES } from '@/config/prompt-options';
 import { ALL_MODELS, ALL_SCRAPERS } from '@/config/prompt-options';
@@ -511,14 +512,7 @@ export default function OnboardingPage() {
       let orgId = profile?.organization_id;
 
       if (!orgId) {
-        const slug =
-          brandName
-            .toLowerCase()
-            .trim()
-            .replace(/\s+/g, '-')
-            .replace(/[^a-z0-9-]/g, '')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, '') || `org-${Date.now()}`;
+        const slug = slugify(brandName) || `org-${Date.now()}`;
 
         const { data: existing } = await supabase
           .from('organizations')

--- a/web/src/lib/actions/brand.ts
+++ b/web/src/lib/actions/brand.ts
@@ -3,17 +3,8 @@
 import { createClient } from '@/lib/supabase/server';
 import { revalidatePath } from 'next/cache';
 import { enforceLimit } from '@/lib/guards/plan-guard';
+import { slugify } from '@/lib/slug';
 import type { Brand, BrandDomain } from '@/types';
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-}
 
 function mapDomainRow(d: Record<string, unknown>): BrandDomain {
   return {

--- a/web/src/lib/actions/organization.ts
+++ b/web/src/lib/actions/organization.ts
@@ -2,16 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { revalidatePath } from 'next/cache';
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-}
+import { slugify } from '@/lib/slug';
 
 export async function createOrganization(name: string) {
   const supabase = await createClient();

--- a/web/src/lib/slug.test.ts
+++ b/web/src/lib/slug.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest';
+import { slugify } from './slug.js';
+
+test('plain ASCII names lowercase and hyphenate', () => {
+  expect(slugify('Hello World')).toBe('hello-world');
+  expect(slugify('Acme Corp')).toBe('acme-corp');
+});
+
+test('accented Latin letters are transliterated, not deleted', () => {
+  expect(slugify('Öz Güven')).toBe('oz-guven');
+  expect(slugify('Ürün')).toBe('urun');
+  expect(slugify('Müller')).toBe('muller');
+  expect(slugify('Çiğdem')).toBe('cigdem');
+  expect(slugify('café')).toBe('cafe');
+});
+
+test('Turkish letters that do not decompose are handled', () => {
+  expect(slugify('Şeker')).toBe('seker');
+  expect(slugify('Ağaç')).toBe('agac');
+});
+
+test('Turkish dotless/dotted i is pinned to i regardless of lowercasing', () => {
+  expect(slugify('Işık')).toBe('isik');
+  expect(slugify('İstanbul')).toBe('istanbul');
+});
+
+test('names that used to collapse to the same slug now stay distinct', () => {
+  expect(slugify('Ağaç')).not.toBe(slugify('Aa'));
+});
+
+test('German ß, Nordic ø, and Polish ł are transliterated', () => {
+  expect(slugify('Straße')).toBe('strasse');
+  expect(slugify('Nørgaard')).toBe('norgaard');
+  expect(slugify('Łódź')).toBe('lodz');
+});
+
+test('whitespace collapses and edge hyphens are trimmed', () => {
+  expect(slugify('  Öz   Güven  ')).toBe('oz-guven');
+  expect(slugify('--Ürün--')).toBe('urun');
+});
+
+test('returns an empty string when nothing survives', () => {
+  expect(slugify('!!!')).toBe('');
+  expect(slugify('   ')).toBe('');
+});

--- a/web/src/lib/slug.ts
+++ b/web/src/lib/slug.ts
@@ -1,0 +1,52 @@
+// Letters that Unicode NFD does not decompose on its own (Turkish dotless/dotted
+// i, German ß, Nordic ø, Polish ł, …), plus the Turkish I/ı lowercasing case.
+// This map is the single source of truth for the special-case set: the pattern
+// below is derived from its keys, and every other non-ASCII letter falls through
+// to the NFD pass in `slugify` (é → e, ü → u, ç → c).
+const TRANSLITERATIONS: Record<string, string> = {
+  ı: 'i',
+  İ: 'i',
+  I: 'i',
+  ş: 's',
+  Ş: 's',
+  ğ: 'g',
+  Ğ: 'g',
+  ß: 'ss',
+  ø: 'o',
+  Ø: 'o',
+  ł: 'l',
+  Ł: 'l',
+  đ: 'd',
+  Đ: 'd',
+  ð: 'd',
+  Ð: 'd',
+  þ: 'th',
+  Þ: 'th',
+  æ: 'ae',
+  Æ: 'ae',
+  œ: 'oe',
+  Œ: 'oe',
+};
+
+const TRANSLITERATION_PATTERN = new RegExp(`[${Object.keys(TRANSLITERATIONS).join('')}]`, 'g');
+
+/**
+ * Turn a display name into a URL/filename-safe slug.
+ *
+ * Non-ASCII letters are transliterated rather than deleted, so `Ürün` becomes
+ * `urun` (not `rn`) and every CSV/PDF export named after the slug keeps the
+ * brand's name. Returns an empty string when nothing survives; callers supply
+ * their own fallback for that case.
+ */
+export function slugify(text: string): string {
+  return text
+    .replace(TRANSLITERATION_PATTERN, (ch) => TRANSLITERATIONS[ch] ?? ch)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}


### PR DESCRIPTION
## Summary

slugify was stripping every character outside [a-z0-9-], which deleted accented and non-ASCII letters instead of transliterating them. Ürün came out as rn, so CSV/PDF exports were named ansvisor_rn_…, and it collided more than it should (Ağaç and Aa both produced aa). Given how many brands are Turkish, this hollowed names out fairly often.

This PR transliterates before stripping. An explicit map handles the letters Unicode NFD doesn't decompose on its own (Turkish ı/ş/ğ, German ß, Nordic ø, Polish ł, etc.) and pins the Turkish I/ı lowercasing case to i. An NFD pass then covers the rest of Latin-1 (é→e, ü→u, ç→c). Ürün now slugifies to urun.

It also pulls the three drifted copies of this logic in brand.ts, organization.ts, and the inline chain in onboarding/page.tsx and turns them into one shared helper at web/src/lib/slug.ts, with each call site keeping its own fallback prefix (brand-, org-). New unit tests sit next to csv.test.ts and include Işık for the Turkish lowercase gotcha. Existing slugs are intentionally not backfilled.

## Related issue

Closes #760

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR