### PR TITLE
fix(reports): rank query fan-out over the whole window, and show per-engine coverage

### DIFF
--- a/supabase/migrations/00064_report_query_fanout_rpc.sql
+++ b/supabase/migrations/00064_report_query_fanout_rpc.sql
@@ -1,0 +1,58 @@
+-- Query fan-out: the fourth report section that read its window through an
+-- unpaginated select.
+--
+-- 00063 moved prompt performance, topic performance and citation evidence into
+-- SQL. getFanoutSnapshot was missed, and it was the worst of the four: no
+-- .range(), no pagination, and no .order() either. PostgREST caps a select at
+-- 1000 rows, so on a brand with ~12k answers in the window the section ranked
+-- sub-queries over an arbitrary twelfth of the data. Every row in the affected
+-- report came out at timesSearched = 2 and the list fell back to alphabetical
+-- order, while the real top query had been searched 24 times.
+--
+-- Counting matches the fold this replaces: a sub-query counts once per answer
+-- however many times that answer repeats it, and an engine is the item's own
+-- source_platform when it has one, otherwise the answer's platform.
+CREATE OR REPLACE FUNCTION "public"."report_query_fanout"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz,
+  "p_limit" integer DEFAULT 10
+)
+RETURNS TABLE(
+  "query" text,
+  "engines" text[],
+  "times_searched" bigint
+)
+LANGUAGE "sql"
+STABLE
+SET "search_path" TO 'public'
+AS $$
+  WITH items AS (
+    SELECT
+      pr.id AS result_id,
+      btrim(regexp_replace(it->>'query', '\s+', ' ', 'g')) AS display,
+      coalesce(nullif(it->>'source_platform', ''), pr.platform) AS engine
+    FROM prompt_results pr
+    CROSS JOIN LATERAL jsonb_array_elements(pr.search_queries) it
+    WHERE pr.brand_id = p_brand_id
+      AND pr.created_at >= p_date_from
+      AND pr.created_at <= p_date_to
+      AND jsonb_typeof(pr.search_queries) = 'array'
+      AND it->>'query' IS NOT NULL
+  ),
+  cleaned AS (
+    SELECT result_id, display, lower(display) AS qkey, engine
+    FROM items
+    WHERE display <> ''
+  )
+  SELECT
+    min(display) AS query,
+    array_agg(DISTINCT engine ORDER BY engine) FILTER (WHERE engine IS NOT NULL) AS engines,
+    count(DISTINCT result_id) AS times_searched
+  FROM cleaned
+  GROUP BY qkey
+  ORDER BY count(DISTINCT result_id) DESC, min(display)
+  LIMIT p_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION "public"."report_query_fanout"(uuid, timestamptz, timestamptz, integer) TO "authenticated";

--- a/supabase/migrations/00065_report_query_fanout_engines.sql
+++ b/supabase/migrations/00065_report_query_fanout_engines.sql
@@ -1,0 +1,50 @@
+-- Per-engine fan-out coverage, to sit beside the top-ten table.
+--
+-- That table ranks sub-queries by how many answers ran the identical string,
+-- which quietly measures how much an engine reuses its phrasing rather than
+-- how much it fans out. On the brand this came from, ChatGPT issued 3,341
+-- distinct sub-queries against Copilot's 782 -- and appeared in the top ten
+-- exactly never, because its top string repeated 9 times to Copilot's 18.
+--
+-- A reader concluded ChatGPT does not fan out. It fans out the most. The
+-- ranking is a separate question; this gives the section the two numbers that
+-- stop the table from being read as the whole story.
+CREATE OR REPLACE FUNCTION "public"."report_query_fanout_engines"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz
+)
+RETURNS TABLE(
+  "engine" text,
+  "distinct_queries" bigint,
+  "answers_with_fanout" bigint
+)
+LANGUAGE "sql"
+STABLE
+SET "search_path" TO 'public'
+AS $$
+  WITH cleaned AS (
+    SELECT
+      pr.id AS result_id,
+      lower(btrim(regexp_replace(it->>'query', '\s+', ' ', 'g'))) AS qkey,
+      coalesce(nullif(it->>'source_platform', ''), pr.platform) AS engine
+    FROM prompt_results pr
+    CROSS JOIN LATERAL jsonb_array_elements(pr.search_queries) it
+    WHERE pr.brand_id = p_brand_id
+      AND pr.created_at >= p_date_from
+      AND pr.created_at <= p_date_to
+      AND jsonb_typeof(pr.search_queries) = 'array'
+      AND it->>'query' IS NOT NULL
+  )
+  SELECT
+    engine,
+    count(DISTINCT qkey) AS distinct_queries,
+    count(DISTINCT result_id) AS answers_with_fanout
+  FROM cleaned
+  WHERE qkey <> ''
+    AND engine IS NOT NULL
+  GROUP BY engine
+  ORDER BY count(DISTINCT qkey) DESC, engine;
+$$;
+
+GRANT EXECUTE ON FUNCTION "public"."report_query_fanout_engines"(uuid, timestamptz, timestamptz) TO "authenticated";

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6577,3 +6577,65 @@ GRANT EXECUTE ON FUNCTION "public"."report_prompt_performance"(uuid, timestamptz
 GRANT EXECUTE ON FUNCTION "public"."report_topic_performance"(uuid, timestamptz, timestamptz, timestamptz) TO "authenticated";
 GRANT EXECUTE ON FUNCTION "public"."report_citation_evidence"(uuid, timestamptz, timestamptz, integer, integer) TO "authenticated";
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00064_report_query_fanout_rpc.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Query fan-out: the fourth report section that read its window through an
+-- unpaginated select.
+--
+-- 00063 moved prompt performance, topic performance and citation evidence into
+-- SQL. getFanoutSnapshot was missed, and it was the worst of the four: no
+-- .range(), no pagination, and no .order() either. PostgREST caps a select at
+-- 1000 rows, so on a brand with ~12k answers in the window the section ranked
+-- sub-queries over an arbitrary twelfth of the data. Every row in the affected
+-- report came out at timesSearched = 2 and the list fell back to alphabetical
+-- order, while the real top query had been searched 24 times.
+--
+-- Counting matches the fold this replaces: a sub-query counts once per answer
+-- however many times that answer repeats it, and an engine is the item's own
+-- source_platform when it has one, otherwise the answer's platform.
+CREATE OR REPLACE FUNCTION "public"."report_query_fanout"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz,
+  "p_limit" integer DEFAULT 10
+)
+RETURNS TABLE(
+  "query" text,
+  "engines" text[],
+  "times_searched" bigint
+)
+LANGUAGE "sql"
+STABLE
+SET "search_path" TO 'public'
+AS $$
+  WITH items AS (
+    SELECT
+      pr.id AS result_id,
+      btrim(regexp_replace(it->>'query', '\s+', ' ', 'g')) AS display,
+      coalesce(nullif(it->>'source_platform', ''), pr.platform) AS engine
+    FROM prompt_results pr
+    CROSS JOIN LATERAL jsonb_array_elements(pr.search_queries) it
+    WHERE pr.brand_id = p_brand_id
+      AND pr.created_at >= p_date_from
+      AND pr.created_at <= p_date_to
+      AND jsonb_typeof(pr.search_queries) = 'array'
+      AND it->>'query' IS NOT NULL
+  ),
+  cleaned AS (
+    SELECT result_id, display, lower(display) AS qkey, engine
+    FROM items
+    WHERE display <> ''
+  )
+  SELECT
+    min(display) AS query,
+    array_agg(DISTINCT engine ORDER BY engine) FILTER (WHERE engine IS NOT NULL) AS engines,
+    count(DISTINCT result_id) AS times_searched
+  FROM cleaned
+  GROUP BY qkey
+  ORDER BY count(DISTINCT result_id) DESC, min(display)
+  LIMIT p_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION "public"."report_query_fanout"(uuid, timestamptz, timestamptz, integer) TO "authenticated";
+

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6639,3 +6639,57 @@ $$;
 
 GRANT EXECUTE ON FUNCTION "public"."report_query_fanout"(uuid, timestamptz, timestamptz, integer) TO "authenticated";
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00065_report_query_fanout_engines.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Per-engine fan-out coverage, to sit beside the top-ten table.
+--
+-- That table ranks sub-queries by how many answers ran the identical string,
+-- which quietly measures how much an engine reuses its phrasing rather than
+-- how much it fans out. On the brand this came from, ChatGPT issued 3,341
+-- distinct sub-queries against Copilot's 782 -- and appeared in the top ten
+-- exactly never, because its top string repeated 9 times to Copilot's 18.
+--
+-- A reader concluded ChatGPT does not fan out. It fans out the most. The
+-- ranking is a separate question; this gives the section the two numbers that
+-- stop the table from being read as the whole story.
+CREATE OR REPLACE FUNCTION "public"."report_query_fanout_engines"(
+  "p_brand_id" uuid,
+  "p_date_from" timestamptz,
+  "p_date_to" timestamptz
+)
+RETURNS TABLE(
+  "engine" text,
+  "distinct_queries" bigint,
+  "answers_with_fanout" bigint
+)
+LANGUAGE "sql"
+STABLE
+SET "search_path" TO 'public'
+AS $$
+  WITH cleaned AS (
+    SELECT
+      pr.id AS result_id,
+      lower(btrim(regexp_replace(it->>'query', '\s+', ' ', 'g'))) AS qkey,
+      coalesce(nullif(it->>'source_platform', ''), pr.platform) AS engine
+    FROM prompt_results pr
+    CROSS JOIN LATERAL jsonb_array_elements(pr.search_queries) it
+    WHERE pr.brand_id = p_brand_id
+      AND pr.created_at >= p_date_from
+      AND pr.created_at <= p_date_to
+      AND jsonb_typeof(pr.search_queries) = 'array'
+      AND it->>'query' IS NOT NULL
+  )
+  SELECT
+    engine,
+    count(DISTINCT qkey) AS distinct_queries,
+    count(DISTINCT result_id) AS answers_with_fanout
+  FROM cleaned
+  WHERE qkey <> ''
+    AND engine IS NOT NULL
+  GROUP BY engine
+  ORDER BY count(DISTINCT qkey) DESC, engine;
+$$;
+
+GRANT EXECUTE ON FUNCTION "public"."report_query_fanout_engines"(uuid, timestamptz, timestamptz) TO "authenticated";
+

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -614,6 +614,7 @@
     "worstPrompts": "Weakest Prompts",
     "queryFanout": "Query Fan-out",
     "queryFanoutDescription": "Sub-queries answer engines actually ran while answering your tracked prompts.",
+    "fanoutCoverage": "{queries} distinct sub-queries across {answers} answers",
     "notFound": "Report not found.",
     "backToReports": "Back to Reports",
     "generatedOn": "Generated on",

--- a/web/src/app/[locale]/(dashboard)/dashboard/reports/[id]/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/reports/[id]/page.tsx
@@ -582,6 +582,25 @@ export default function ReportDetailPage() {
               <p className="text-sm text-muted-foreground">{t('queryFanoutDescription')}</p>
             </CardHeader>
             <CardContent>
+              {/* The table ranks by repeats of the same string, which favours
+                  engines that reuse their phrasing. Without this an engine that
+                  searches the most but rephrases every time reads as one that
+                  does not fan out at all. */}
+              {payload.queryFanoutEngines && payload.queryFanoutEngines.length > 0 && (
+                <div className="mb-4 flex flex-wrap gap-x-6 gap-y-1 text-sm text-muted-foreground">
+                  {payload.queryFanoutEngines.map((e) => (
+                    <span key={e.engine}>
+                      <span className="text-foreground">
+                        {PLATFORM_LABELS[e.engine] ?? e.engine}
+                      </span>{' '}
+                      {t('fanoutCoverage', {
+                        queries: e.distinctQueries,
+                        answers: e.answersWithFanout,
+                      })}
+                    </span>
+                  ))}
+                </div>
+              )}
               <Table>
                 <TableHeader>
                   <TableRow>

--- a/web/src/lib/actions/reports.ts
+++ b/web/src/lib/actions/reports.ts
@@ -309,53 +309,32 @@ const REPORT_FANOUT_COUNT = 10;
  * grouping) but bounded to [dateFrom, dateTo] instead of a rolling window
  * anchored to "now", which would lie for historical custom ranges.
  */
+interface FanoutRow {
+  query: string;
+  engines: string[] | null;
+  times_searched: number;
+}
+
 async function getFanoutSnapshot(
   brandId: string,
   dateFrom: string,
   dateTo: string,
 ): Promise<ReportFanoutQuery[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
-    .from('prompt_results')
-    .select('platform, search_queries')
-    .eq('brand_id', brandId)
-    .gte('created_at', dateFrom)
-    .lte('created_at', dateTo);
+
+  const { data, error } = await supabase.rpc('report_query_fanout', {
+    p_brand_id: brandId,
+    p_date_from: dateFrom,
+    p_date_to: dateTo,
+    p_limit: REPORT_FANOUT_COUNT,
+  });
   if (error) throw new Error(error.message);
 
-  const normalize = (raw: string) => raw.replace(/\s+/g, ' ').trim();
-  const byQuery = new Map<string, { display: string; engines: Set<string>; count: number }>();
-
-  for (const row of data ?? []) {
-    const items = Array.isArray(row.search_queries)
-      ? (row.search_queries as { query?: unknown; source_platform?: unknown }[])
-      : [];
-    const seenInRow = new Set<string>();
-    for (const item of items) {
-      const q = typeof item?.query === 'string' ? normalize(item.query) : '';
-      if (!q) continue;
-      const key = q.toLowerCase();
-      let acc = byQuery.get(key);
-      if (!acc) {
-        acc = { display: q, engines: new Set(), count: 0 };
-        byQuery.set(key, acc);
-      }
-      const sp =
-        typeof item?.source_platform === 'string' && item.source_platform
-          ? item.source_platform
-          : (row.platform as string | null);
-      if (sp) acc.engines.add(sp);
-      if (!seenInRow.has(key)) {
-        acc.count += 1;
-        seenInRow.add(key);
-      }
-    }
-  }
-
-  return [...byQuery.values()]
-    .sort((a, b) => b.count - a.count || a.display.localeCompare(b.display))
-    .slice(0, REPORT_FANOUT_COUNT)
-    .map((a) => ({ query: a.display, engines: [...a.engines].sort(), timesSearched: a.count }));
+  return ((data ?? []) as unknown as FanoutRow[]).map((r) => ({
+    query: r.query,
+    engines: r.engines ?? [],
+    timesSearched: r.times_searched,
+  }));
 }
 
 const round1 = (n: number) => Math.round(n * 10) / 10;

--- a/web/src/lib/actions/reports.ts
+++ b/web/src/lib/actions/reports.ts
@@ -68,6 +68,21 @@ export interface ReportFanoutQuery {
   timesSearched: number;
 }
 
+/**
+ * How much each engine fanned out, beside the top-ten table.
+ *
+ * That table ranks by how many answers ran the identical string, which favours
+ * engines that reuse their phrasing — an engine can search the most and place
+ * in the top ten the least. These two numbers separate variety from volume so
+ * the table is not read as the whole picture.
+ */
+export interface ReportFanoutEngine {
+  /** Platform slug as stored on the result (UI maps to a label). */
+  engine: string;
+  distinctQueries: number;
+  answersWithFanout: number;
+}
+
 /** One concrete brand mention: which prompt, where, and the passage (#429). */
 export interface ReportMentionEvidence {
   promptText: string;
@@ -188,6 +203,8 @@ export interface ReportPayload {
   citationEvidence?: ReportCitationEvidence[];
   /** Most-run observed fan-out sub-queries in the period. */
   queryFanout?: ReportFanoutQuery[];
+  /** Per-engine fan-out coverage; absent on reports generated before it shipped. */
+  queryFanoutEngines?: ReportFanoutEngine[];
   /** Per-topic visibility with deltas vs the previous window. */
   topicPerformance?: ReportTopicPerf[];
   /** Real AI-referred visits in the period. */
@@ -315,26 +332,49 @@ interface FanoutRow {
   times_searched: number;
 }
 
+interface FanoutEngineRow {
+  engine: string;
+  distinct_queries: number;
+  answers_with_fanout: number;
+}
+
 async function getFanoutSnapshot(
   brandId: string,
   dateFrom: string,
   dateTo: string,
-): Promise<ReportFanoutQuery[]> {
+): Promise<{ queries: ReportFanoutQuery[]; engines: ReportFanoutEngine[] }> {
   const supabase = await createClient();
 
-  const { data, error } = await supabase.rpc('report_query_fanout', {
-    p_brand_id: brandId,
-    p_date_from: dateFrom,
-    p_date_to: dateTo,
-    p_limit: REPORT_FANOUT_COUNT,
-  });
-  if (error) throw new Error(error.message);
+  // The ranking and the coverage read the same rows for the same window, so
+  // they go together and either both land or neither does.
+  const [topRes, engineRes] = await Promise.all([
+    supabase.rpc('report_query_fanout', {
+      p_brand_id: brandId,
+      p_date_from: dateFrom,
+      p_date_to: dateTo,
+      p_limit: REPORT_FANOUT_COUNT,
+    }),
+    supabase.rpc('report_query_fanout_engines', {
+      p_brand_id: brandId,
+      p_date_from: dateFrom,
+      p_date_to: dateTo,
+    }),
+  ]);
+  if (topRes.error) throw new Error(topRes.error.message);
+  if (engineRes.error) throw new Error(engineRes.error.message);
 
-  return ((data ?? []) as unknown as FanoutRow[]).map((r) => ({
-    query: r.query,
-    engines: r.engines ?? [],
-    timesSearched: r.times_searched,
-  }));
+  return {
+    queries: ((topRes.data ?? []) as unknown as FanoutRow[]).map((r) => ({
+      query: r.query,
+      engines: r.engines ?? [],
+      timesSearched: r.times_searched,
+    })),
+    engines: ((engineRes.data ?? []) as unknown as FanoutEngineRow[]).map((r) => ({
+      engine: r.engine,
+      distinctQueries: r.distinct_queries,
+      answersWithFanout: r.answers_with_fanout,
+    })),
+  };
 }
 
 const round1 = (n: number) => Math.round(n * 10) / 10;
@@ -837,7 +877,12 @@ export async function createReport(
     ...(promptPerformance ? { promptPerformance } : {}),
     ...(mentionEvidence && mentionEvidence.length > 0 ? { mentionEvidence } : {}),
     ...(citationEvidence && citationEvidence.length > 0 ? { citationEvidence } : {}),
-    ...(queryFanout ? { queryFanout } : {}),
+    ...(queryFanout && queryFanout.queries.length > 0
+      ? {
+          queryFanout: queryFanout.queries,
+          ...(queryFanout.engines.length > 0 ? { queryFanoutEngines: queryFanout.engines } : {}),
+        }
+      : {}),
     ...(topicPerformance && topicPerformance.length > 0 ? { topicPerformance } : {}),
     ...(aiTraffic ? { aiTraffic } : {}),
     ...(shoppingVisibility ? { shoppingVisibility } : {}),

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -2347,6 +2347,18 @@ export type Database = {
           url: string
         }[]
       }
+      report_query_fanout_engines: {
+        Args: {
+          p_brand_id: string
+          p_date_from: string
+          p_date_to: string
+        }
+        Returns: {
+          answers_with_fanout: number
+          distinct_queries: number
+          engine: string
+        }[]
+      }
       report_query_fanout: {
         Args: {
           p_brand_id: string

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -2347,6 +2347,19 @@ export type Database = {
           url: string
         }[]
       }
+      report_query_fanout: {
+        Args: {
+          p_brand_id: string
+          p_date_from: string
+          p_date_to: string
+          p_limit?: number
+        }
+        Returns: {
+          engines: string[]
+          query: string
+          times_searched: number
+        }[]
+      }
       report_prompt_performance: {
         Args: {
           p_brand_id: string


### PR DESCRIPTION
## Summary

Follow-up to #762, from a report where Query Fan-out listed only two of the three engines that had actually fanned out. Two separate things were wrong.

### The section ranked over an arbitrary 1000 rows

`getFanoutSnapshot` was the fourth section reading its window through an unpaginated select, and the worst of the four: no `.range()`, no pagination, and **no `.order()` either**, so the 1000 rows PostgREST returns were not even a defined slice.

On a brand with ~12,000 answers in the window that is a twelfth of the data, and almost nothing repeats inside a twelfth. The symptom is visible in the stored payload: **all ten entries came out at `timesSearched: 2`**, listed alphabetically because every count was tied. The real top query had been searched **24** times and was not in the list at all.

Now aggregated in SQL alongside the three from #762 (`00064`) — 220ms for that window — with the counting rules the fold used: a sub-query counts once per answer however often that answer repeats it, and an engine is the item's own `source_platform` when it has one, otherwise the answer's platform.

### Fixing the rows did not bring the missing engine back

This is the part worth reading. Reading the *right* 12,000 rows produces the same two engines, because the ranking measures something other than what the section claims to.

| Engine | Distinct sub-queries | Answers | Top repeat |
|---|---|---|---|
| ChatGPT | **3,341** | 1,286 | 9 |
| Perplexity | 952 | 1,857 | 16 |
| Copilot | 782 | 2,038 | 18 |

Ranking by how many answers ran the *identical string* rewards an engine for reusing its phrasing. ChatGPT rephrases every time, so it issues more distinct sub-queries than the other two combined and never places in the top ten.

A reader concludes ChatGPT does not fan out. It fans out the most.

So each engine now carries **its distinct sub-query count and the answers those came from, above the table** (`00065`). Two numbers rather than one because they point in opposite directions here — Copilot fans out on more answers, ChatGPT with more different queries — and either alone would mislead in its own way.

The ranking itself is untouched. Whether the top ten should be picked per engine is a larger question about what the section is for; this makes the current table honest rather than answering it.

## Related issue

None — reported directly from testing, on the report generated after #762.

## Type of change

- [x] `fix` — Bug fix

## Migrations

`00064_report_query_fanout_rpc.sql` and `00065_report_query_fanout_engines.sql`. **Both already applied to the hosted database.** Additive — two new functions nothing referenced yet — so applying before the code that calls them is the safe order.

## How to test

Needs a brand with several thousand answers in the window.

1. Generate a report including **Fan-out** over 7 days.
2. Check the table. Expected: counts well clear of 2, in descending order, not alphabetical.
3. Check the line above the table. Expected: every engine that fanned out, **including ones absent from the table**, each with its distinct sub-query count and answer count.
4. Compare the top query against the Prompts page for the same range.
5. Open a report generated before this. Expected: table as before, no coverage line — the payload has no such field.

## Verification already done

- `EXPLAIN ANALYZE` on both functions against production data: 220ms and 190ms for a 7-day window on the brand in question.
- Checked the new function against the payload that surfaced this: stored entries all `timesSearched: 2`, new output 24 / 19 / 18 / 17.
- The coverage figures in the table above are that function's real output, not an estimate.
- `yarn typecheck`, `yarn lint` (0 errors), `yarn format:check`, `yarn test` (90 passing) and `yarn build` pass from `web/`.

**Not covered by tests** — same limitation as #762: nothing in this repo can reach a server action or a Postgres function.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
