### PR TITLE
docs: retitle the README to Ansvisor — Open-Source AI Search Intelligence Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 </div>
 
-# Ansvisor - Open-source AI Visibility Platform for AI Search
+# Ansvisor — Open-Source AI Search Intelligence Platform
 
 **[Official website](https://www.ansvisor.com)**
 


### PR DESCRIPTION
## Summary

The README's H1 becomes:

```
# Ansvisor — Open-Source AI Search Intelligence Platform
```

It read `# Ansvisor - Open-source AI Visibility Platform for AI Search`, which named the category twice — "AI Visibility Platform **for AI Search**" — and described a narrower product than the repository now contains. Citations, competitor intelligence, content opportunities, AI traffic analytics and the site audit are not visibility tracking.

This matches the wording now on the [organization profile](https://github.com/ansvisor), so the first line a visitor reads is the same in both places.

The dash is an em dash, as in the org profile, and `Open-Source` is capitalised on both sides of the hyphen since it sits inside a title.

## Related issue

None — wording decided directly.

## Type of change

- [x] `docs` — Documentation only

## How to test

Open `README.md` and read the first heading. Nothing else changed: one line, no links, badges or anchors touched.

## Verification already done

- Searched `README.md`, `docs/` and `.github/` for the old title: no other copy to keep in step.
- The diff is one line.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Changes are focused — one concern per PR
