### PR TITLE
fix(web): align mobile navigation preferences

### DIFF
--- a/web/src/components/layout/mobile-nav.tsx
+++ b/web/src/components/layout/mobile-nav.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { usePathname, Link } from '@/i18n/navigation';
 import { dashboardNav } from '@/config/dashboard';
+import { getDashboardNavLabel, shouldShowDashboardNavItem } from '@/lib/dashboard-navigation';
 import { useFeatureGate } from '@/hooks/use-feature-gate';
 import { useAgentKeyStatus } from '@/hooks/use-agent-key-status';
 import { siteConfig } from '@/config/site';
@@ -27,7 +28,9 @@ export function MobileNav() {
   // so at most one network request is made even when both components mount.
   const agentKeyStatus = useAgentKeyStatus(isCloud);
   const agentKeyMissing = isCloud && agentKeyStatus === 'missing';
-  const { activeBrandId } = useBrandStore();
+  const activeBrandId = useBrandStore((s) => s.activeBrandId);
+  const activeBrand = useBrandStore((s) => s.brands.find((b) => b.id === s.activeBrandId) ?? null);
+  const brandPrefs = { shoppingModeEnabled: !!activeBrand?.shoppingModeEnabled };
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   // Hydration guard — see sidebar.tsx for the rationale; the two
@@ -39,21 +42,6 @@ export function MobileNav() {
   }, []);
 
   const logoSrc = mounted && resolvedTheme === 'dark' ? '/logo_dark.svg' : '/logo_light.svg';
-
-  const getLabel = (title: string): string => {
-    const map: Record<string, string> = {
-      Overview: t('overview'),
-      Brands: tBrands('title'),
-      'Answer Engine Insights': t('insights'),
-      'AI Traffic Analytics': t('traffic'),
-      Prompts: t('prompts'),
-      'Content Optimization': t('content'),
-      Citations: t('citations'),
-      Reports: t('reports'),
-      Settings: t('settings'),
-    };
-    return map[title] ?? title;
-  };
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -89,17 +77,21 @@ export function MobileNav() {
                   )}
                 >
                   <MessageSquareText className="h-4 w-4 shrink-0" />
-                  Prompts
+                  {t('prompts')}
                 </span>
               </Link>
             )}
             {dashboardNav.flatMap((group) =>
               group.items.map((item) => {
+                if (!shouldShowDashboardNavItem(item, brandPrefs)) {
+                  return null;
+                }
+
                 const isActive =
                   item.href === '/dashboard'
                     ? pathname === '/dashboard'
                     : pathname.startsWith(item.href);
-                const label = getLabel(item.title);
+                const label = getDashboardNavLabel(item.title, t, tBrands);
 
                 // Dynamic badge override: show "Set up" on the Agent item
                 // when the org has no Anthropic key saved (cloud only).

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { usePathname, Link } from '@/i18n/navigation';
 import { dashboardNav } from '@/config/dashboard';
+import { getDashboardNavLabel, shouldShowDashboardNavItem } from '@/lib/dashboard-navigation';
 import { useSidebarStore } from '@/stores/use-sidebar-store';
 import { useBrandStore } from '@/stores/use-brand-store';
 import { useFeatureGate } from '@/hooks/use-feature-gate';
@@ -50,22 +51,6 @@ export function Sidebar() {
   }, []);
 
   const logoSrc = mounted && resolvedTheme === 'dark' ? '/logo_dark.svg' : '/logo_light.svg';
-
-  const navKeyMap: Record<string, () => string> = {
-    Overview: () => t('overview'),
-    Brands: () => tBrands('title'),
-    Agent: () => t('agent'),
-    'Answer Engine Insights': () => t('insights'),
-    'AI Traffic Analytics': () => t('traffic'),
-    Prompts: () => t('prompts'),
-    Topics: () => t('topics'),
-    'Content Optimization': () => t('content'),
-    'Site Audit': () => t('audit'),
-    Citations: () => t('citations'),
-    Shopping: () => t('shopping'),
-    Reports: () => t('reports'),
-    Settings: () => t('settings'),
-  };
 
   return (
     <aside
@@ -113,10 +98,7 @@ export function Sidebar() {
             {group.title && isCollapsed && i > 0 && <Separator className="my-2" />}
             <nav className="space-y-0.5">
               {group.items.map((item) => {
-                // Hide entirely if a required brand preference is off — the
-                // user shouldn't see "Shopping (upgrade)" when the active
-                // brand simply isn't in e-commerce.
-                if (item.requiresBrandPref && !brandPrefs[item.requiresBrandPref]) {
+                if (!shouldShowDashboardNavItem(item, brandPrefs)) {
                   return null;
                 }
 
@@ -124,8 +106,7 @@ export function Sidebar() {
                   item.href === '/dashboard'
                     ? pathname === '/dashboard'
                     : pathname.startsWith(item.href);
-                const labelFn = navKeyMap[item.title];
-                const label = labelFn ? labelFn() : item.title;
+                const label = getDashboardNavLabel(item.title, t, tBrands);
 
                 // Dynamic badge override: show "Set up" on the Agent item
                 // when the org has no Anthropic key saved (cloud only).

--- a/web/src/lib/dashboard-navigation.test.ts
+++ b/web/src/lib/dashboard-navigation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { dashboardNav } from '@/config/dashboard';
+import {
+  dashboardNavLabelKeys,
+  getDashboardNavLabel,
+  shouldShowDashboardNavItem,
+} from '@/lib/dashboard-navigation';
+
+const translateNav = (key: string) => `nav.${key}`;
+const translateBrands = (key: string) => `brands.${key}`;
+
+describe('getDashboardNavLabel', () => {
+  it('maps every dashboard item through an i18n key', () => {
+    const titles = dashboardNav.flatMap((group) => group.items.map((item) => item.title));
+
+    expect(Object.keys(dashboardNavLabelKeys).sort()).toEqual([...titles].sort());
+
+    for (const title of titles) {
+      expect(getDashboardNavLabel(title, translateNav, translateBrands)).not.toBe(title);
+    }
+  });
+
+  it('uses the brands namespace only for Brands', () => {
+    expect(getDashboardNavLabel('Brands', translateNav, translateBrands)).toBe('brands.title');
+    expect(getDashboardNavLabel('Shopping', translateNav, translateBrands)).toBe('nav.shopping');
+  });
+
+  it('leaves an unknown title unchanged', () => {
+    expect(getDashboardNavLabel('Unknown', translateNav, translateBrands)).toBe('Unknown');
+  });
+});
+
+describe('shouldShowDashboardNavItem', () => {
+  const shopping = dashboardNav
+    .flatMap((group) => group.items)
+    .find((item) => item.title === 'Shopping')!;
+
+  it('hides Shopping when the active brand has shopping mode disabled', () => {
+    expect(shouldShowDashboardNavItem(shopping, { shoppingModeEnabled: false })).toBe(false);
+  });
+
+  it('shows Shopping when the active brand enables shopping mode', () => {
+    expect(shouldShowDashboardNavItem(shopping, { shoppingModeEnabled: true })).toBe(true);
+  });
+});

--- a/web/src/lib/dashboard-navigation.ts
+++ b/web/src/lib/dashboard-navigation.ts
@@ -1,0 +1,38 @@
+import type { BrandPrefKey, NavItem } from '@/config/dashboard';
+
+type Translator = (key: string) => string;
+
+type NavLabelKey = { namespace: 'nav'; key: string } | { namespace: 'brands'; key: 'title' };
+
+/** Every dashboard title rendered from dashboardNav is resolved through this
+ * map. Keeping it outside either layout component prevents the desktop and
+ * mobile menus from silently falling out of sync. */
+export const dashboardNavLabelKeys: Record<string, NavLabelKey> = {
+  Brands: { namespace: 'brands', key: 'title' },
+  Agent: { namespace: 'nav', key: 'agent' },
+  'Answer Engine Insights': { namespace: 'nav', key: 'insights' },
+  'AI Traffic Analytics': { namespace: 'nav', key: 'traffic' },
+  Prompts: { namespace: 'nav', key: 'prompts' },
+  Topics: { namespace: 'nav', key: 'topics' },
+  'Content Optimization': { namespace: 'nav', key: 'content' },
+  'Site Audit': { namespace: 'nav', key: 'audit' },
+  Citations: { namespace: 'nav', key: 'citations' },
+  Shopping: { namespace: 'nav', key: 'shopping' },
+  Reports: { namespace: 'nav', key: 'reports' },
+};
+
+export function getDashboardNavLabel(title: string, t: Translator, tBrands: Translator): string {
+  const label = dashboardNavLabelKeys[title];
+  if (!label) return title;
+
+  return label.namespace === 'brands' ? tBrands(label.key) : t(label.key);
+}
+
+/** Brand preferences hide a navigation item entirely; they are intentionally
+ * separate from plan gates, which render a visible but disabled item. */
+export function shouldShowDashboardNavItem(
+  item: NavItem,
+  brandPrefs: Record<BrandPrefKey, boolean>,
+): boolean {
+  return !item.requiresBrandPref || brandPrefs[item.requiresBrandPref];
+}


### PR DESCRIPTION
## Summary
- share dashboard-label translation and brand-preference visibility rules between desktop and mobile navigation
- hide Shopping in mobile navigation when the active brand has shopping mode disabled
- route all dashboard labels and the brand-scoped Prompts link through i18n
- add focused tests for navigation label coverage and Shopping visibility

Fixes #766

## Validation
- `yarn test` (18 files, 103 tests)
- `yarn typecheck`
- `yarn lint` (passes with 7 existing warnings in untouched files)
- `yarn format:check`
- `npm run version:check`

## Build note
`yarn build` compiles and completes TypeScript validation, but page-data collection needs real server-side Supabase configuration (`supabaseUrl` and `supabaseKey`), which is intentionally not present in this local environment.

## Screenshots
Not included: the full authenticated Supabase-backed app was not run locally.