### PR TITLE
fix(pulse): stop the catch-up sweep from pulsing manual and backfill runs

### DIFF
--- a/server/src/lib/pulse/engine.js
+++ b/server/src/lib/pulse/engine.js
@@ -322,6 +322,11 @@ export async function generatePulseForBrand(brandId, { pulseDate: pulseDateOverr
  * (brand_id, pulse_date) key stops the same day being sent twice, and the
  * window key (#701) stops the recovery pulse repeating a run that today's own
  * pulse is about to report — the two dates disagree, the data does not.
+ *
+ * Cron runs only: the pulse trigger never fires for manual/immediate runs, so
+ * those are not "missed" pulses to recover. Sweeping them mailed every new
+ * brand twice on its first morning — once at cycle start for yesterday's
+ * onboarding run, once when its own daily run completed an hour later.
  */
 export async function runPulseCatchUp() {
   try {
@@ -329,6 +334,7 @@ export async function runPulseCatchUp() {
     const { data: runs, error } = await supabaseAdmin
       .from('tracking_runs')
       .select('brand_id, completed_at')
+      .eq('source', 'cron')
       .not('completed_at', 'is', null)
       .gte('completed_at', since)
       .order('completed_at', { ascending: false });

--- a/server/src/lib/pulse/engine.test.js
+++ b/server/src/lib/pulse/engine.test.js
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The module imports the supabase admin client, whose config hard-exits when
 // SUPABASE_* env is absent (as in CI) — stub it before the import chain.
-vi.mock('../../config/supabase.js', () => ({ default: {} }));
+const from = vi.fn();
+vi.mock('../../config/supabase.js', () => ({ default: { from: (...a) => from(...a) } }));
 
-import { pulseWindowKey } from './engine.js';
+import { pulseWindowKey, runPulseCatchUp } from './engine.js';
 
 /**
  * Pulse window dedupe (#701).
@@ -53,5 +54,79 @@ describe('pulseWindowKey', () => {
 
   it('returns null when a run-anchored window has no end, rather than a false match', () => {
     expect(pulseWindowKey({ window: { runAnchored: true } })).toBeNull();
+  });
+});
+
+/**
+ * Catch-up sweep scope: only cron runs can have a "missed" pulse, because the
+ * pulse trigger never fires for manual or backfill runs in the first place.
+ * Sweeping those mailed every new brand twice on its first morning — the
+ * onboarding run (deliberately unpulsed) was "recovered" at cycle start, then
+ * the brand's own daily run pulsed an hour later.
+ */
+describe('runPulseCatchUp', () => {
+  // Minimal filtering query fake: applies eq/not/gte predicates to the given
+  // rows and resolves like postgrest ({ data, count, error: null }).
+  function fakeTable(rows) {
+    const filters = [];
+    const matches = () => rows.filter((r) => filters.every((f) => f(r)));
+    const builder = {
+      select: () => builder,
+      eq: (col, val) => (filters.push((r) => r[col] === val), builder),
+      gte: (col, val) => (filters.push((r) => r[col] >= val), builder),
+      not: (col, op, val) => {
+        if (op === 'is' && val === null) filters.push((r) => r[col] !== null);
+        return builder;
+      },
+      order: () => builder,
+      then: (resolve) => {
+        const data = matches();
+        return Promise.resolve({ data, count: data.length, error: null }).then(resolve);
+      },
+    };
+    return builder;
+  }
+
+  let queriedTables;
+
+  beforeEach(() => {
+    from.mockReset();
+    queriedTables = [];
+  });
+
+  function tables(fixtures) {
+    from.mockImplementation((table) => {
+      queriedTables.push(table);
+      return fakeTable(fixtures[table] ?? []);
+    });
+  }
+
+  const recent = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+  it('ignores manual and backfill runs — they were never owed a pulse', async () => {
+    tables({
+      tracking_runs: [
+        { brand_id: 'new-brand', completed_at: recent, source: 'manual' },
+        { brand_id: 'old-brand', completed_at: recent, source: 'backfill' },
+      ],
+    });
+
+    const res = await runPulseCatchUp();
+
+    expect(res).toEqual({ sent: 0, skipped: 0 });
+    expect(queriedTables).not.toContain('sent_pulses');
+  });
+
+  it('still considers a cron run with no pulse row after it', async () => {
+    tables({
+      tracking_runs: [{ brand_id: 'brand-1', completed_at: recent, source: 'cron' }],
+      // A pulse already recorded after the run: the sweep looks, then skips.
+      sent_pulses: [{ brand_id: 'brand-1', created_at: new Date().toISOString() }],
+    });
+
+    const res = await runPulseCatchUp();
+
+    expect(res).toEqual({ sent: 0, skipped: 0 });
+    expect(queriedTables).toContain('sent_pulses');
   });
 });


### PR DESCRIPTION
## Summary

Every newly added brand received **two Daily Pulse emails on its first morning**: one at the very start of the daily cycle (~02:00 UTC) and one when its own daily run completed an hour or two later. From the second day on, only one arrived — which pointed straight at something that only runs once per run history.

Root cause: the catch-up sweep (`runPulseCatchUp`) recovers pulses for completed tracking runs that have no pulse row after them, but it never checked the run's `source`. The onboarding run a brand performs on creation is a full, stamped run with `source: 'manual'` — and it is *deliberately* unpulsed (the pulse trigger in `job-runner` skips immediate/manual runs). The sweep couldn't tell "skipped on purpose" from "missed", so at the start of the next daily cycle it "recovered" the onboarding run as a pulse dated to the creation day. The brand's own first cron run then pulsed normally the same morning with a different window key, so the #701 same-window guard (correctly) saw two different runs and let both through.

Confirmed against production data: 8 of the 9 brands created in the last week show the exact signature — first pulse at 02:00–02:01 with `pulse_date` = creation day and a window anchored to the onboarding run's completion time, second pulse later the same morning from the brand's own run.

The fix scopes the sweep to `source = 'cron'` runs: the pulse trigger only ever fires for cron runs, so only cron runs can have a *missed* pulse. This also excludes `backfill` runs. The sweep's actual job — recovering cron pulses eaten by a deploy/crash — is unchanged, and brands still get no email on the day they are created (existing intended behavior).

## Related issue

None — reported directly.

## Type of change

- [x] `fix` — Bug fix

## How to test

- `cd server && yarn test` — new `runPulseCatchUp` tests cover both directions: manual/backfill runs are never considered, cron runs still are.
- End-to-end: add a new brand, let onboarding tracking complete; next morning exactly one pulse email should arrive (after the brand's own daily run), with nothing sent at cycle start.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (server)
- [x] `yarn format:check` passes (server)
- [x] `yarn test` passes (server, 384 tests)
- [x] Changes are focused — one concern per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)