### PR TITLE
perf(citations): read the per-URL detail page from the citation rows

### DIFF
--- a/supabase/migrations/00067_citation_url_detail_rpcs.sql
+++ b/supabase/migrations/00067_citation_url_detail_rpcs.sql
@@ -1,0 +1,236 @@
+-- Read the per-URL citation detail page from prompt_result_citations (#732),
+-- phase 3.
+--
+-- Phase 2 moved the Citations overview onto the citation rows and left the
+-- detail page behind. It still pages every answer in the window out to the app
+-- tier and looks for one URL in JavaScript: 60,442 rows carrying 75 MB of
+-- jsonb across 61 sequential requests on the largest brand, to render a page
+-- about a URL cited in 2,084 of them.
+--
+-- The cost is the visible half of the problem. The scan stops at 50,000 rows
+-- and walks the window oldest-first, so that brand's detail page never reached
+-- its newest 10,442 answers — five days of citations missing from the counts
+-- and a "last seen" date five days stale, with nothing on screen to say so.
+--
+-- Matching stays in the app tier on purpose. The page aggregates by
+-- `normalizeCitationUrl`, which folds away query strings and one trailing
+-- slash, and that is not cosmetic: the largest brand's 124,134 distinct cited
+-- URLs collapse to 73,289 under it. Reimplementing those rules in SQL would
+-- make two definitions of the same identity that can drift apart. So SQL
+-- narrows to a domain and the caller normalizes the candidates itself, with
+-- the same function that renders them.
+
+-- ─── Indexes ────────────────────────────────────────────────────────────────
+-- Both replace a narrower index with the same leading column, so no query
+-- loses an access path; the narrow ones are dropped below.
+--
+-- (brand_id, created_at) carrying url_id and prompt_result_id turns the
+-- overview's scan of a brand's citations into an index-only scan: 8,296 ms of
+-- random heap access became 273 ms, and citations_urls went from 11.9 s cold
+-- (over the 8 s statement timeout for `authenticated`) to 2.0 s.
+create index if not exists prompt_result_citations_brand_created_cover_idx
+  on public.prompt_result_citations (brand_id, created_at desc)
+  include (url_id, prompt_result_id);
+
+-- (url_id, brand_id) answers "does this brand cite this URL" from the index
+-- alone. citation_url_candidates probes it once per URL on the domain — 15,736
+-- times for youtube.com — which cost 5,941 ms against the url_id-only index
+-- and 66 ms against this one.
+create index if not exists prompt_result_citations_url_brand_idx
+  on public.prompt_result_citations (url_id, brand_id);
+
+drop index if exists public.prompt_result_citations_brand_created_idx;
+drop index if exists public.prompt_result_citations_url_idx;
+
+-- ─── Domains ────────────────────────────────────────────────────────────────
+-- Unchanged in what it returns; the model list is now built from the distinct
+-- (domain, model) pairs instead of `array_agg(distinct m)` over every
+-- (domain, answer) pair. The old form sorted 580,707 rows into 21,082 groups
+-- and was the larger half of the function's runtime: 7.0 s against 2.8 s here,
+-- which brings the last of the three overview functions under the timeout.
+--
+-- `order by m` keeps the array sorted, which is what array_agg(distinct)
+-- guaranteed and what the page's own sort assumes.
+create or replace function public.citations_domains(
+  p_brand_id uuid,
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  domain text,
+  total_citations bigint,
+  results_citing bigint,
+  models text[]
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+set work_mem to '96MB'
+as $$
+  with pairs as (
+    select cu.domain as d, c.prompt_result_id as rid, count(*) as n,
+           min(coalesce(pr.model_used, pr.platform)) as m
+    from public.prompt_result_citations c
+    join public.prompt_results pr on pr.id = c.prompt_result_id
+    join public.citation_urls cu on cu.id = c.url_id
+    where c.brand_id = p_brand_id
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or (c.created_at >= p_date_from and pr.created_at >= p_date_from))
+      and (p_date_to    is null or (c.created_at <= p_date_to   and pr.created_at <= p_date_to))
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+    group by cu.domain, c.prompt_result_id
+  ),
+  counts as (
+    select d, sum(n)::bigint as tc, count(*)::bigint as rc from pairs group by d
+  ),
+  model_lists as (
+    select d, array_agg(m order by m) as ms
+    from (select distinct d, m from pairs) s
+    group by d
+  )
+  select c.d, c.tc, c.rc, m.ms
+  from counts c join model_lists m on m.d = c.d
+  order by c.tc desc;
+$$;
+
+-- ─── URL detail: candidates ─────────────────────────────────────────────────
+-- Every URL on one domain that this brand has cited, for the caller to
+-- normalize and match. Brand-scoped so an authenticated user cannot enumerate
+-- the cross-tenant URL dictionary a domain at a time.
+--
+-- Deliberately unfiltered by window: which raw URLs fold into the target is a
+-- property of the URL, not of the window, and the occurrence query applies the
+-- window anyway. Filtering here would only make the candidate set depend on
+-- the filter bar, so switching from 7d to 30d could change which variants of a
+-- URL the page considers part of it.
+create or replace function public.citation_url_candidates(
+  p_brand_id uuid,
+  p_domain text
+)
+returns table (
+  id bigint,
+  url text,
+  title text
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+as $$
+  select cu.id, cu.url, cu.title
+  from public.citation_urls cu
+  where cu.domain = p_domain
+    and exists (
+      select 1 from public.prompt_result_citations c
+      where c.url_id = cu.id and c.brand_id = p_brand_id
+    );
+$$;
+
+-- ─── URL detail: occurrences ────────────────────────────────────────────────
+-- One row per answer citing any of p_url_ids, carrying what the detail table
+-- renders. The caller passes the ids its own normalization matched.
+--
+-- `rank` is `position + 1` because `position` is the citation's index in the
+-- provider's original array, which is the ordering the page ranks by: every
+-- one of 20,000 sampled answers has its citations already in startIndex order,
+-- and position survives the entries the row writer drops as unparsable, so it
+-- stays truer to the original array than counting rows would.
+--
+-- `total_sources` counts the answer's citation rows. That is the array length
+-- except where an entry had no recoverable host — one answer in 19,176 on the
+-- largest brand.
+create or replace function public.citation_url_occurrences(
+  p_brand_id uuid,
+  p_url_ids bigint[],
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  result_id uuid,
+  prompt_id uuid,
+  prompt_text text,
+  platform text,
+  model_used text,
+  region text,
+  created_at timestamptz,
+  sentiment text,
+  brand_mentioned boolean,
+  citations_in_answer int,
+  rank int,
+  total_sources int
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+set work_mem to '96MB'
+as $$
+  with hits as (
+    select c.prompt_result_id as rid,
+           count(*)::int as cited,
+           (min(c.position) + 1)::int as rnk
+    from public.prompt_result_citations c
+    where c.brand_id = p_brand_id
+      and c.url_id = any(p_url_ids)
+      and (p_date_from is null or c.created_at >= p_date_from)
+      and (p_date_to   is null or c.created_at <= p_date_to)
+    group by c.prompt_result_id
+  ),
+  answers as (
+    select h.rid, h.cited, h.rnk, pr.prompt_id, pr.platform, pr.model_used,
+           pr.region, pr.created_at, pr.sentiment,
+           coalesce(pr.mention_count, 0) > 0 as mentioned
+    from hits h
+    join public.prompt_results pr on pr.id = h.rid
+    where pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or pr.created_at >= p_date_from)
+      and (p_date_to    is null or pr.created_at <= p_date_to)
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+  ),
+  -- Grouped once and joined, rather than counted per answer in a correlated
+  -- subselect: the subselect re-probed the index for each of the 2,084 rows
+  -- the busiest URL returns.
+  sizes as (
+    select a.prompt_result_id as rid, count(*)::int as total
+    from public.prompt_result_citations a
+    where a.prompt_result_id in (select rid from answers)
+    group by a.prompt_result_id
+  )
+  select a.rid, a.prompt_id, p.text, a.platform, a.model_used, a.region,
+         a.created_at, a.sentiment, a.mentioned, a.cited, a.rnk,
+         coalesce(s.total, a.cited)
+  from answers a
+  left join sizes s on s.rid = a.rid
+  left join public.prompts p on p.id = a.prompt_id
+  order by a.created_at desc;
+$$;
+
+revoke all on function public.citation_url_candidates(uuid, text) from public;
+revoke all on function public.citation_url_occurrences(uuid, bigint[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+
+grant execute on function public.citation_url_candidates(uuid, text) to authenticated, service_role;
+grant execute on function public.citation_url_occurrences(uuid, bigint[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+
+comment on function public.citation_url_candidates(uuid, text) is
+  'URLs on one domain that a brand has cited (#732), for the detail page to normalize and match in the app tier.';
+comment on function public.citation_url_occurrences(uuid, bigint[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Answers citing any of the given URL ids (#732) — the per-URL citation detail table, one row per answer.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7560,3 +7560,243 @@ as $$
   left join prompt_daily pd on pd.day = bd.day;
 $$;
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00067_citation_url_detail_rpcs.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Read the per-URL citation detail page from prompt_result_citations (#732),
+-- phase 3.
+--
+-- Phase 2 moved the Citations overview onto the citation rows and left the
+-- detail page behind. It still pages every answer in the window out to the app
+-- tier and looks for one URL in JavaScript: 60,442 rows carrying 75 MB of
+-- jsonb across 61 sequential requests on the largest brand, to render a page
+-- about a URL cited in 2,084 of them.
+--
+-- The cost is the visible half of the problem. The scan stops at 50,000 rows
+-- and walks the window oldest-first, so that brand's detail page never reached
+-- its newest 10,442 answers — five days of citations missing from the counts
+-- and a "last seen" date five days stale, with nothing on screen to say so.
+--
+-- Matching stays in the app tier on purpose. The page aggregates by
+-- `normalizeCitationUrl`, which folds away query strings and one trailing
+-- slash, and that is not cosmetic: the largest brand's 124,134 distinct cited
+-- URLs collapse to 73,289 under it. Reimplementing those rules in SQL would
+-- make two definitions of the same identity that can drift apart. So SQL
+-- narrows to a domain and the caller normalizes the candidates itself, with
+-- the same function that renders them.
+
+-- ─── Indexes ────────────────────────────────────────────────────────────────
+-- Both replace a narrower index with the same leading column, so no query
+-- loses an access path; the narrow ones are dropped below.
+--
+-- (brand_id, created_at) carrying url_id and prompt_result_id turns the
+-- overview's scan of a brand's citations into an index-only scan: 8,296 ms of
+-- random heap access became 273 ms, and citations_urls went from 11.9 s cold
+-- (over the 8 s statement timeout for `authenticated`) to 2.0 s.
+create index if not exists prompt_result_citations_brand_created_cover_idx
+  on public.prompt_result_citations (brand_id, created_at desc)
+  include (url_id, prompt_result_id);
+
+-- (url_id, brand_id) answers "does this brand cite this URL" from the index
+-- alone. citation_url_candidates probes it once per URL on the domain — 15,736
+-- times for youtube.com — which cost 5,941 ms against the url_id-only index
+-- and 66 ms against this one.
+create index if not exists prompt_result_citations_url_brand_idx
+  on public.prompt_result_citations (url_id, brand_id);
+
+drop index if exists public.prompt_result_citations_brand_created_idx;
+drop index if exists public.prompt_result_citations_url_idx;
+
+-- ─── Domains ────────────────────────────────────────────────────────────────
+-- Unchanged in what it returns; the model list is now built from the distinct
+-- (domain, model) pairs instead of `array_agg(distinct m)` over every
+-- (domain, answer) pair. The old form sorted 580,707 rows into 21,082 groups
+-- and was the larger half of the function's runtime: 7.0 s against 2.8 s here,
+-- which brings the last of the three overview functions under the timeout.
+--
+-- `order by m` keeps the array sorted, which is what array_agg(distinct)
+-- guaranteed and what the page's own sort assumes.
+create or replace function public.citations_domains(
+  p_brand_id uuid,
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  domain text,
+  total_citations bigint,
+  results_citing bigint,
+  models text[]
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+set work_mem to '96MB'
+as $$
+  with pairs as (
+    select cu.domain as d, c.prompt_result_id as rid, count(*) as n,
+           min(coalesce(pr.model_used, pr.platform)) as m
+    from public.prompt_result_citations c
+    join public.prompt_results pr on pr.id = c.prompt_result_id
+    join public.citation_urls cu on cu.id = c.url_id
+    where c.brand_id = p_brand_id
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or (c.created_at >= p_date_from and pr.created_at >= p_date_from))
+      and (p_date_to    is null or (c.created_at <= p_date_to   and pr.created_at <= p_date_to))
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+    group by cu.domain, c.prompt_result_id
+  ),
+  counts as (
+    select d, sum(n)::bigint as tc, count(*)::bigint as rc from pairs group by d
+  ),
+  model_lists as (
+    select d, array_agg(m order by m) as ms
+    from (select distinct d, m from pairs) s
+    group by d
+  )
+  select c.d, c.tc, c.rc, m.ms
+  from counts c join model_lists m on m.d = c.d
+  order by c.tc desc;
+$$;
+
+-- ─── URL detail: candidates ─────────────────────────────────────────────────
+-- Every URL on one domain that this brand has cited, for the caller to
+-- normalize and match. Brand-scoped so an authenticated user cannot enumerate
+-- the cross-tenant URL dictionary a domain at a time.
+--
+-- Deliberately unfiltered by window: which raw URLs fold into the target is a
+-- property of the URL, not of the window, and the occurrence query applies the
+-- window anyway. Filtering here would only make the candidate set depend on
+-- the filter bar, so switching from 7d to 30d could change which variants of a
+-- URL the page considers part of it.
+create or replace function public.citation_url_candidates(
+  p_brand_id uuid,
+  p_domain text
+)
+returns table (
+  id bigint,
+  url text,
+  title text
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+as $$
+  select cu.id, cu.url, cu.title
+  from public.citation_urls cu
+  where cu.domain = p_domain
+    and exists (
+      select 1 from public.prompt_result_citations c
+      where c.url_id = cu.id and c.brand_id = p_brand_id
+    );
+$$;
+
+-- ─── URL detail: occurrences ────────────────────────────────────────────────
+-- One row per answer citing any of p_url_ids, carrying what the detail table
+-- renders. The caller passes the ids its own normalization matched.
+--
+-- `rank` is `position + 1` because `position` is the citation's index in the
+-- provider's original array, which is the ordering the page ranks by: every
+-- one of 20,000 sampled answers has its citations already in startIndex order,
+-- and position survives the entries the row writer drops as unparsable, so it
+-- stays truer to the original array than counting rows would.
+--
+-- `total_sources` counts the answer's citation rows. That is the array length
+-- except where an entry had no recoverable host — one answer in 19,176 on the
+-- largest brand.
+create or replace function public.citation_url_occurrences(
+  p_brand_id uuid,
+  p_url_ids bigint[],
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  result_id uuid,
+  prompt_id uuid,
+  prompt_text text,
+  platform text,
+  model_used text,
+  region text,
+  created_at timestamptz,
+  sentiment text,
+  brand_mentioned boolean,
+  citations_in_answer int,
+  rank int,
+  total_sources int
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+set work_mem to '96MB'
+as $$
+  with hits as (
+    select c.prompt_result_id as rid,
+           count(*)::int as cited,
+           (min(c.position) + 1)::int as rnk
+    from public.prompt_result_citations c
+    where c.brand_id = p_brand_id
+      and c.url_id = any(p_url_ids)
+      and (p_date_from is null or c.created_at >= p_date_from)
+      and (p_date_to   is null or c.created_at <= p_date_to)
+    group by c.prompt_result_id
+  ),
+  answers as (
+    select h.rid, h.cited, h.rnk, pr.prompt_id, pr.platform, pr.model_used,
+           pr.region, pr.created_at, pr.sentiment,
+           coalesce(pr.mention_count, 0) > 0 as mentioned
+    from hits h
+    join public.prompt_results pr on pr.id = h.rid
+    where pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or pr.created_at >= p_date_from)
+      and (p_date_to    is null or pr.created_at <= p_date_to)
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+  ),
+  -- Grouped once and joined, rather than counted per answer in a correlated
+  -- subselect: the subselect re-probed the index for each of the 2,084 rows
+  -- the busiest URL returns.
+  sizes as (
+    select a.prompt_result_id as rid, count(*)::int as total
+    from public.prompt_result_citations a
+    where a.prompt_result_id in (select rid from answers)
+    group by a.prompt_result_id
+  )
+  select a.rid, a.prompt_id, p.text, a.platform, a.model_used, a.region,
+         a.created_at, a.sentiment, a.mentioned, a.cited, a.rnk,
+         coalesce(s.total, a.cited)
+  from answers a
+  left join sizes s on s.rid = a.rid
+  left join public.prompts p on p.id = a.prompt_id
+  order by a.created_at desc;
+$$;
+
+revoke all on function public.citation_url_candidates(uuid, text) from public;
+revoke all on function public.citation_url_occurrences(uuid, bigint[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+
+grant execute on function public.citation_url_candidates(uuid, text) to authenticated, service_role;
+grant execute on function public.citation_url_occurrences(uuid, bigint[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+
+comment on function public.citation_url_candidates(uuid, text) is
+  'URLs on one domain that a brand has cited (#732), for the detail page to normalize and match in the app tier.';
+comment on function public.citation_url_occurrences(uuid, bigint[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Answers citing any of the given URL ids (#732) — the per-URL citation detail table, one row per answer.';
+

--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -766,11 +766,17 @@ function escapeIlike(value: string): string {
 const URL_DETAIL_TRAFFIC_MAX_ROWS = 5000;
 
 /**
- * Everything the per-URL citation detail page needs (#535): a URL-filtered
- * scan of prompt_results plus, for brand-owned URLs, the targeting and
- * traffic bridges. Uses the same scan, filters and URL bucketing as
- * getCitationsOverview so the counts here agree with the overview tables for
- * the same URL, window and filters.
+ * Everything the per-URL citation detail page needs (#535), read from the
+ * citation rows (#732) plus, for brand-owned URLs, the targeting and traffic
+ * bridges. Uses the same filters as getCitationsOverview so the counts here
+ * agree with the overview tables for the same URL, window and filters.
+ *
+ * Two calls rather than one because the URL identity this page groups by is
+ * `normalizeCitationUrl`, which lives in TypeScript: SQL narrows to the
+ * target's domain, the match itself happens here with the same function that
+ * renders the result, and only the ids it accepted go back for the
+ * occurrences. Reimplementing those rules in SQL would be a second definition
+ * of the same identity, free to drift from this one.
  */
 export async function getCitationUrlDetail(
   brandId: string,
@@ -797,94 +803,86 @@ export async function getCitationUrlDetail(
     ? classifyDomain(targetHost, { brandDomains, competitorDomains })
     : 'other';
 
-  interface DetailResultRow {
-    id: string;
+  interface CandidateRow {
+    id: number;
+    url: string;
+    title: string | null;
+  }
+
+  interface OccurrenceRow {
+    result_id: string;
     prompt_id: string;
+    prompt_text: string | null;
     platform: string | null;
     model_used: string | null;
     region: string | null;
     created_at: string;
     sentiment: string | null;
-    mention_count: number | null;
-    citations: Citation[] | null;
+    brand_mentioned: boolean;
+    citations_in_answer: number;
+    rank: number;
+    total_sources: number;
   }
 
-  interface RawOccurrence extends Omit<CitationUrlOccurrence, 'promptText'> {
-    promptText: string | null;
-  }
+  // Every URL the brand has cited on this host, folded through the page's own
+  // normalization. One target usually covers several stored URLs: query
+  // strings and a trailing slash are not part of the identity here.
+  const { data: candidateRows, error: candidateErr } = await supabase.rpc(
+    'citation_url_candidates',
+    { p_brand_id: brandId, p_domain: targetHost },
+  );
+  if (candidateErr) throw new Error(candidateErr.message);
 
-  const occurrences: RawOccurrence[] = [];
-  const models = new Set<string>();
+  const urlIds: number[] = [];
   let title = '';
+  // By id, so the title is the one recorded the first time the URL was seen
+  // rather than whichever row the database happened to return first.
+  for (const row of ((candidateRows ?? []) as CandidateRow[]).slice().sort((a, b) => a.id - b.id)) {
+    if (normalizeCitationUrl(row.url) !== targetUrl) continue;
+    urlIds.push(row.id);
+    if (!title && row.title) title = row.title;
+  }
+
+  const topicPromptIds = await resolveTopicPromptIds(supabase, filters);
+  let occurrenceRows: OccurrenceRow[] = [];
+  if (urlIds.length > 0) {
+    const { data, error } = await supabase.rpc('citation_url_occurrences', {
+      ...overviewArgs(brandId, filters, topicPromptIds),
+      p_url_ids: urlIds,
+    });
+    if (error) throw new Error(error.message);
+    occurrenceRows = (data ?? []) as OccurrenceRow[];
+  }
+
+  const models = new Set<string>();
   let totalCitations = 0;
   let firstSeen: string | null = null;
   let lastSeen: string | null = null;
 
-  await scanFilteredResults<DetailResultRow>(
-    supabase,
-    brandId,
-    filters,
-    'id, prompt_id, platform, model_used, region, created_at, sentiment, mention_count, citations',
-    (batch) => {
-      for (const result of batch) {
-        const citations = Array.isArray(result.citations) ? result.citations : [];
-        if (citations.length === 0) continue;
+  const withText: CitationUrlOccurrence[] = occurrenceRows.map((row) => {
+    totalCitations += row.citations_in_answer;
+    const modelKey = row.model_used || row.platform || '';
+    if (modelKey) models.add(modelKey);
+    if (!firstSeen || row.created_at < firstSeen) firstSeen = row.created_at;
+    if (!lastSeen || row.created_at > lastSeen) lastSeen = row.created_at;
 
-        // Rank citations by their position in the answer; find ours.
-        const ordered = [...citations].sort((a, b) => (a.startIndex ?? 0) - (b.startIndex ?? 0));
-        let rank = 0;
-        let citationsInAnswer = 0;
-        for (let i = 0; i < ordered.length; i++) {
-          if (normalizeCitationUrl(ordered[i].url) !== targetUrl) continue;
-          citationsInAnswer += 1;
-          if (rank === 0) rank = i + 1;
-          if (!title && ordered[i].title) title = ordered[i].title;
-        }
-        if (citationsInAnswer === 0) continue;
+    return {
+      resultId: row.result_id,
+      promptId: row.prompt_id,
+      promptText: row.prompt_text ?? '(deleted prompt)',
+      platform: row.platform,
+      modelUsed: row.model_used,
+      region: row.region,
+      createdAt: row.created_at,
+      sentiment: row.sentiment,
+      brandMentioned: row.brand_mentioned,
+      citationsInAnswer: row.citations_in_answer,
+      rank: row.rank,
+      totalSources: row.total_sources,
+    };
+  });
 
-        totalCitations += citationsInAnswer;
-        const modelKey = result.model_used || result.platform || '';
-        if (modelKey) models.add(modelKey);
-        if (!firstSeen || result.created_at < firstSeen) firstSeen = result.created_at;
-        if (!lastSeen || result.created_at > lastSeen) lastSeen = result.created_at;
-
-        occurrences.push({
-          resultId: result.id,
-          promptId: result.prompt_id,
-          promptText: null,
-          platform: result.platform,
-          modelUsed: result.model_used,
-          region: result.region,
-          createdAt: result.created_at,
-          sentiment: result.sentiment,
-          brandMentioned: (result.mention_count ?? 0) > 0,
-          citationsInAnswer,
-          rank,
-          totalSources: citations.length,
-        });
-      }
-    },
-  );
-
-  occurrences.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
-
-  // Resolve prompt texts for everything the scan touched.
-  const promptIds = Array.from(new Set(occurrences.map((o) => o.promptId)));
-  const promptTextById = new Map<string, string>();
-  if (promptIds.length > 0) {
-    const { data: promptRows, error: promptErr } = await supabase
-      .from('prompts')
-      .select('id, text')
-      .in('id', promptIds);
-    if (promptErr) throw new Error(promptErr.message);
-    for (const p of (promptRows ?? []) as { id: string; text: string }[]) {
-      promptTextById.set(p.id, p.text);
-    }
-  }
-  const withText: CitationUrlOccurrence[] = occurrences.map((o) => ({
-    ...o,
-    promptText: o.promptText ?? promptTextById.get(o.promptId) ?? '(deleted prompt)',
-  }));
+  const promptIds = Array.from(new Set(withText.map((o) => o.promptId)));
 
   // Prompts breakdown — the queries this page is winning.
   const groupMap = new Map<string, CitationUrlPromptGroup>();

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -2406,11 +2406,45 @@ export type Database = {
         }
         Returns: Json
       }
+      citation_url_candidates: {
+        Args: { p_brand_id: string; p_domain: string }
+        Returns: {
+          id: number
+          title: string
+          url: string
+        }[]
+      }
       citation_url_ids: {
         Args: { p_urls: Json }
         Returns: {
           id: number
           url: string
+        }[]
+      }
+      citation_url_occurrences: {
+        Args: {
+          p_brand_id: string
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_prompt_ids?: string[]
+          p_regions?: string[]
+          p_topic_ids?: string[]
+          p_url_ids: number[]
+        }
+        Returns: {
+          brand_mentioned: boolean
+          citations_in_answer: number
+          created_at: string
+          model_used: string
+          platform: string
+          prompt_id: string
+          prompt_text: string
+          rank: number
+          region: string
+          result_id: string
+          sentiment: string
+          total_sources: number
         }[]
       }
       citations_domains: {


### PR DESCRIPTION
## Summary

Opening a URL from the Citations page with the range on **All** took tens of seconds, and on the largest brand it was also showing stale numbers.

`getCitationUrlDetail` was the last reader still on the pre-#732 path: it paged *every* answer in the window out to the app tier with the full `citations` jsonb attached and looked for one URL in JavaScript. On the largest brand that is **60,442 rows / 75 MB across 61 sequential requests**, to render a page about a URL cited in 2,084 of them. The overview next to it was already reading the citation rows, which is why only the detail felt slow.

The correctness half is the more serious one: the scan stops at `CITATIONS_SCAN_MAX_ROWS = 50_000` and walks the window **oldest-first**, so that brand's detail page never reached its newest 10,442 answers. Five days of citations missing from the counts and a "last seen" five days stale, with nothing on screen to say the data was cut off.

### What changed

Two new `security definer` RPCs over the existing `prompt_result_citations` index, which is complete and current (813,000 rows against 813,157 jsonb elements, identical max `created_at`) — so no backfill:

- `citation_url_candidates(brand, domain)` — the URLs on one domain that this brand has cited. Brand-scoped so an authenticated user cannot enumerate the cross-tenant URL dictionary.
- `citation_url_occurrences(brand, url_ids, …filters)` — one row per answer citing any of those ids, with rank, per-answer count and total sources.

**URL identity deliberately stays in TypeScript.** The page groups by `normalizeCitationUrl`, which folds away query strings and one trailing slash, and that is not cosmetic — the largest brand's 124,134 distinct cited URLs collapse to 73,289 under it. SQL narrows to the domain; the match runs here with the same function that renders the result. Reimplementing those rules in SQL would create a second definition of the same identity, free to drift.

### Also: the overview was about to break the same way

While measuring I found `citations_urls` at **11.9 s cold / 5.1 s warm** and `citations_domains` at **7.0 s** on the same brand — against the 8 s `statement_timeout` for `authenticated`. Same trajectory Insights was on before #773. Two fixes, both in this migration:

- A covering index `(brand_id, created_at desc) include (url_id, prompt_result_id)` makes the citation scan index-only: **8,296 ms → 273 ms**, taking `citations_urls` to 2.0 s.
- `citations_domains` builds its model list from the distinct `(domain, model)` pairs instead of `array_agg(distinct …)` over every `(domain, answer)` pair: **7.0 s → 2.8 s**.

Two narrower indexes with the same leading columns are dropped as redundant; a third candidate index on `prompt_results` was tested, gave no measurable win, and was left out rather than paying for it on every insert.

## Verification

Everything was diffed against the path it replaces, on live data:

| Check | Result |
|---|---|
| `citations_domains` old vs new — 4 brands, unfiltered | 0 differences (10,884 / 5,396 / 717 / 6,488 rows) |
| `citations_domains` — largest brand, 7d window | 0 differences (9,341 rows) |
| `citations_domains` — largest brand, model + region filter | 0 differences (5,061 rows) |
| Occurrences old vs new — single-variant URL | 0 differences across 1,835 answers, incl. rank + total_sources |
| Occurrences old vs new — URL with 132 raw variants | 0 differences across 2,643 answers, 4,012 citations both sides |
| Rank ordering assumption | 20,000 sampled answers, all citations already in `startIndex` order, none missing |
| `total_sources` vs raw array length | differs on 1 answer in 19,176 (an entry with no recoverable host) |

Worst-case detail query (the brand's most-cited URL, 2,084 answers) now measures **622 ms returning ~200 KB**, against 62 MB before.

## Related issue

None — reported directly.

## Type of change

- [x] `fix` — Bug fix
- [x] `refactor` — Code change that neither fixes a bug nor adds a feature

## How to test

- Citations → set the range to **All** → click any URL. The detail page should open without the long wait, and "Last seen" should match the newest tracking run rather than trailing it.
- Switch the platform filter and the range on the detail page; counts should stay consistent with the overview row for the same URL and window.
- Open a URL on a domain with many query-string variants (a YouTube watch link is the interesting case — the `v` parameter is part of the identity and must not merge different videos).

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`)
- [x] Commits follow Conventional Commits
- [x] `yarn lint` passes (web)
- [x] `yarn typecheck` passes (web)
- [x] `yarn format:check` passes (web)
- [x] `yarn build` passes (web)
- [x] `schema.sql` regenerated
- [x] Changes are focused — one concern per PR

> [!IMPORTANT]
> Migration `00067` has **not** been applied to the hosted database yet — the apply step was blocked by a local permission rule. The two indexes it creates are already live (they were added while measuring); the three function definitions are not. Apply before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)