### PR TITLE
perf(citations): read Competitor Gaps from the citation rows

### DIFF
--- a/supabase/migrations/00068_citation_gap_rpcs.sql
+++ b/supabase/migrations/00068_citation_gap_rpcs.sql
@@ -1,0 +1,276 @@
+-- Read Competitor Gaps from prompt_result_citations (#777), phase 4 of #732.
+--
+-- getCitationGaps was the last reader paging raw answers to the app tier:
+-- every answer in the window with its `citations` AND `competitor_mentions`
+-- jsonb attached — 77 MB + 52 MB across 62,285 rows on the largest brand —
+-- and, like the detail page before #776, capped at 50,000 rows oldest-first,
+-- so the newest answers were silently missing from the gap analysis.
+--
+-- Domain identity comes from `citation_urls.domain`, written by the same
+-- hostname extraction the page used to run per read (verified: 135,040
+-- (answer, domain) pairs computed both ways on a full brand, zero different).
+-- The you/competitor split cannot be precomputed there, because it depends on
+-- the brand's CURRENT domain lists — so the caller passes those lists in and
+-- the suffix rule (`d = entry or d ends with ".entry"`) runs here, on the
+-- distinct domains only. The rest of classification (forum/social/editorial…)
+-- stays in the app tier; it is display-only for this page.
+--
+-- Both functions carry the membership guard from report_citation_evidence:
+-- they are security definer (citation_urls has no select policy of its own),
+-- so without the guard any authenticated user could read any brand's gap
+-- data by uuid. The `allowed` CTE pins execution to members of the brand's
+-- organization; service_role clients get empty results, which no current
+-- caller minds — both are called from user-session server actions.
+--
+-- `jsonb_path_exists` instead of expanding competitor_mentions: the answer
+-- "does this answer mention any competitor" does not need rows, and the
+-- expansion was the single largest cost of the naive shape (3.8 s of the
+-- 8.6 s total on the largest brand; this shape measures 3.8 s end to end).
+-- Full expansion happens only where entries are actually needed: names on
+-- gap-qualifying answers, per-competitor rows in citation_competitor_sources.
+
+-- ─── Gap domains ────────────────────────────────────────────────────────────
+-- One row per third-party domain the window cites, with the co-occurrence
+-- counts the Competitor Gaps tab aggregates today, plus one summary row
+-- (domain null) so the answer totals survive even when no domain qualifies.
+--
+-- Semantics mirror the page exactly:
+--   * an answer's weight is 1 / its distinct cited domains;
+--   * "we are present" = brand mentioned OR any own-domain cited;
+--   * a domain's gap counters only grow from answers where a competitor is
+--     mentioned and we are absent; appears_in_ours records the opposite side;
+--   * domains on the brand's or a competitor's own sites are excluded — only
+--     third-party publications are actionable.
+create or replace function public.citation_gap_domains(
+  p_brand_id uuid,
+  p_brand_domains text[],
+  p_competitor_domains text[],
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  domain text,
+  competitor_answers bigint,
+  appears_in_ours boolean,
+  strength double precision,
+  competitor_names text[],
+  our_answer_count bigint,
+  total_answers bigint
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+set work_mem to '96MB'
+as $$
+  with allowed as (
+    select 1 from brands b
+    join profiles pf on pf.organization_id = b.organization_id
+    where b.id = p_brand_id and pf.id = auth.uid()
+  ),
+  answers as materialized (
+    select pr.id as rid,
+           coalesce(pr.mention_count, 0) > 0 as we_mention,
+           coalesce(
+             jsonb_path_exists(pr.competitor_mentions, '$[*] ? (@.mention_count > 0)'),
+             false
+           ) as comp_present,
+           pr.competitor_mentions
+    from prompt_results pr
+    where exists (select 1 from allowed)
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or pr.created_at >= p_date_from)
+      and (p_date_to    is null or pr.created_at <= p_date_to)
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+  ),
+  adomains as materialized (
+    select distinct c.prompt_result_id as rid, cu.domain as d
+    from prompt_result_citations c
+    join citation_urls cu on cu.id = c.url_id
+    where c.brand_id = p_brand_id
+      and c.prompt_result_id in (select rid from answers)
+  ),
+  -- The suffix match runs once per distinct domain, not once per pair.
+  dtags as materialized (
+    select s.d,
+      exists (select 1 from unnest(p_brand_domains) e
+              where s.d = e or right(s.d, length(e) + 1) = '.' || e) as is_you,
+      exists (select 1 from unnest(p_competitor_domains) e
+              where s.d = e or right(s.d, length(e) + 1) = '.' || e) as is_comp
+    from (select distinct ad.d from adomains ad) s
+  ),
+  per_answer as (
+    select ad.rid, 1.0 / count(*) as w, bool_or(t.is_you) as you_cited
+    from adomains ad join dtags t on t.d = ad.d
+    group by ad.rid
+  ),
+  flags as materialized (
+    select a.rid,
+           a.we_mention or coalesce(pa.you_cited, false) as we_present,
+           a.comp_present,
+           coalesce(pa.w, 0) as w
+    from answers a
+    left join per_answer pa on pa.rid = a.rid
+  ),
+  domain_rows as (
+    select ad.d,
+      count(*) filter (where f.comp_present and not f.we_present) as competitor_answers,
+      bool_or(f.we_present) as appears,
+      coalesce(sum(f.w) filter (where f.comp_present and not f.we_present), 0) as strength
+    from adomains ad
+    join dtags t on t.d = ad.d and not t.is_you and not t.is_comp
+    join flags f on f.rid = ad.rid
+    group by ad.d
+  ),
+  -- Competitor names only exist on gap-qualifying answers, so the jsonb
+  -- expansion is bounded by those instead of the whole window. A mention of
+  -- a still-live competitor renders under its current name; a deleted one
+  -- keeps the name recorded in the answer.
+  qualifying as (
+    select f.rid from flags f where f.comp_present and not f.we_present
+  ),
+  mention_names as (
+    select q.rid,
+      case when co.id is not null
+           then coalesce(nullif(trim(co.name), ''), 'Competitor')
+           else coalesce(nullif(trim(x.e ->> 'name'), ''), 'Competitor')
+      end as cname
+    from qualifying q
+    join answers a on a.rid = q.rid,
+    lateral jsonb_array_elements(a.competitor_mentions) x(e)
+    left join competitors co
+      on co.brand_id = p_brand_id and co.id::text = x.e ->> 'competitor_id'
+    where coalesce((x.e ->> 'mention_count')::numeric, 0) > 0
+  ),
+  domain_names as (
+    select ad.d, array_agg(distinct mn.cname order by mn.cname) as names
+    from adomains ad
+    join dtags t on t.d = ad.d and not t.is_you and not t.is_comp
+    join mention_names mn on mn.rid = ad.rid
+    group by ad.d
+  ),
+  totals as (
+    select count(*)::bigint as total_answers,
+           (count(*) filter (where f.we_present))::bigint as our_answer_count
+    from flags f
+  )
+  select dr.d, dr.competitor_answers::bigint, dr.appears, dr.strength::float8,
+         coalesce(dn.names, '{}'::text[]), t.our_answer_count, t.total_answers
+  from domain_rows dr
+  left join domain_names dn on dn.d = dr.d
+  cross join totals t
+  where dr.competitor_answers > 0 or dr.appears
+  union all
+  select null, 0, false, 0, '{}'::text[], t.our_answer_count, t.total_answers
+  from totals t;
+$$;
+
+-- ─── Per-competitor source domains ──────────────────────────────────────────
+-- (competitor, third-party domain) rows for the per-competitor source map.
+-- Unlike the gap counters these accumulate from every answer mentioning the
+-- competitor, whether or not we are present — alsoCitesUs comes from joining
+-- the gap rows in the app tier. Keyed by the mention's competitor_id as
+-- recorded (text), so mentions of since-deleted competitors keep counting,
+-- exactly as the page behaves today.
+create or replace function public.citation_competitor_sources(
+  p_brand_id uuid,
+  p_brand_domains text[],
+  p_competitor_domains text[],
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  competitor_id text,
+  domain text,
+  answers_feeding bigint,
+  strength double precision
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+set work_mem to '96MB'
+as $$
+  with allowed as (
+    select 1 from brands b
+    join profiles pf on pf.organization_id = b.organization_id
+    where b.id = p_brand_id and pf.id = auth.uid()
+  ),
+  answers as materialized (
+    select pr.id as rid, pr.competitor_mentions
+    from prompt_results pr
+    where exists (select 1 from allowed)
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or pr.created_at >= p_date_from)
+      and (p_date_to    is null or pr.created_at <= p_date_to)
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+  ),
+  adomains as materialized (
+    select distinct c.prompt_result_id as rid, cu.domain as d
+    from prompt_result_citations c
+    join citation_urls cu on cu.id = c.url_id
+    where c.brand_id = p_brand_id
+      and c.prompt_result_id in (select rid from answers)
+  ),
+  dtags as materialized (
+    select s.d,
+      exists (select 1 from unnest(p_brand_domains) e
+              where s.d = e or right(s.d, length(e) + 1) = '.' || e) as is_you,
+      exists (select 1 from unnest(p_competitor_domains) e
+              where s.d = e or right(s.d, length(e) + 1) = '.' || e) as is_comp
+    from (select distinct ad.d from adomains ad) s
+  ),
+  per_answer as (
+    select ad.rid, 1.0 / count(*) as w
+    from adomains ad group by ad.rid
+  ),
+  -- Expansion bounded to answers that actually mention someone; the jsonpath
+  -- probe is far cheaper than expanding every answer's array.
+  mentions as materialized (
+    select a.rid, x.e ->> 'competitor_id' as competitor_id
+    from answers a,
+    lateral jsonb_array_elements(a.competitor_mentions) x(e)
+    where coalesce(
+            jsonb_path_exists(a.competitor_mentions, '$[*] ? (@.mention_count > 0)'),
+            false
+          )
+      and coalesce((x.e ->> 'mention_count')::numeric, 0) > 0
+  )
+  select m.competitor_id, ad.d,
+         count(distinct m.rid)::bigint as answers_feeding,
+         sum(pa.w)::float8 as strength
+  from mentions m
+  join adomains ad on ad.rid = m.rid
+  join dtags t on t.d = ad.d and not t.is_you and not t.is_comp
+  join per_answer pa on pa.rid = m.rid
+  group by m.competitor_id, ad.d;
+$$;
+
+revoke all on function public.citation_gap_domains(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+revoke all on function public.citation_competitor_sources(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+
+grant execute on function public.citation_gap_domains(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+grant execute on function public.citation_competitor_sources(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+
+comment on function public.citation_gap_domains(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Per-domain competitor co-occurrence for the Competitor Gaps tab (#777). Third-party domains only; one null-domain summary row carries the answer totals.';
+comment on function public.citation_competitor_sources(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Per-competitor source domains for the Competitor Gaps tab (#777), keyed by the competitor id recorded in the mention.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7800,3 +7800,283 @@ comment on function public.citation_url_candidates(uuid, text) is
 comment on function public.citation_url_occurrences(uuid, bigint[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
   'Answers citing any of the given URL ids (#732) — the per-URL citation detail table, one row per answer.';
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- migrations/00068_citation_gap_rpcs.sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Read Competitor Gaps from prompt_result_citations (#777), phase 4 of #732.
+--
+-- getCitationGaps was the last reader paging raw answers to the app tier:
+-- every answer in the window with its `citations` AND `competitor_mentions`
+-- jsonb attached — 77 MB + 52 MB across 62,285 rows on the largest brand —
+-- and, like the detail page before #776, capped at 50,000 rows oldest-first,
+-- so the newest answers were silently missing from the gap analysis.
+--
+-- Domain identity comes from `citation_urls.domain`, written by the same
+-- hostname extraction the page used to run per read (verified: 135,040
+-- (answer, domain) pairs computed both ways on a full brand, zero different).
+-- The you/competitor split cannot be precomputed there, because it depends on
+-- the brand's CURRENT domain lists — so the caller passes those lists in and
+-- the suffix rule (`d = entry or d ends with ".entry"`) runs here, on the
+-- distinct domains only. The rest of classification (forum/social/editorial…)
+-- stays in the app tier; it is display-only for this page.
+--
+-- Both functions carry the membership guard from report_citation_evidence:
+-- they are security definer (citation_urls has no select policy of its own),
+-- so without the guard any authenticated user could read any brand's gap
+-- data by uuid. The `allowed` CTE pins execution to members of the brand's
+-- organization; service_role clients get empty results, which no current
+-- caller minds — both are called from user-session server actions.
+--
+-- `jsonb_path_exists` instead of expanding competitor_mentions: the answer
+-- "does this answer mention any competitor" does not need rows, and the
+-- expansion was the single largest cost of the naive shape (3.8 s of the
+-- 8.6 s total on the largest brand; this shape measures 3.8 s end to end).
+-- Full expansion happens only where entries are actually needed: names on
+-- gap-qualifying answers, per-competitor rows in citation_competitor_sources.
+
+-- ─── Gap domains ────────────────────────────────────────────────────────────
+-- One row per third-party domain the window cites, with the co-occurrence
+-- counts the Competitor Gaps tab aggregates today, plus one summary row
+-- (domain null) so the answer totals survive even when no domain qualifies.
+--
+-- Semantics mirror the page exactly:
+--   * an answer's weight is 1 / its distinct cited domains;
+--   * "we are present" = brand mentioned OR any own-domain cited;
+--   * a domain's gap counters only grow from answers where a competitor is
+--     mentioned and we are absent; appears_in_ours records the opposite side;
+--   * domains on the brand's or a competitor's own sites are excluded — only
+--     third-party publications are actionable.
+create or replace function public.citation_gap_domains(
+  p_brand_id uuid,
+  p_brand_domains text[],
+  p_competitor_domains text[],
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  domain text,
+  competitor_answers bigint,
+  appears_in_ours boolean,
+  strength double precision,
+  competitor_names text[],
+  our_answer_count bigint,
+  total_answers bigint
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+set work_mem to '96MB'
+as $$
+  with allowed as (
+    select 1 from brands b
+    join profiles pf on pf.organization_id = b.organization_id
+    where b.id = p_brand_id and pf.id = auth.uid()
+  ),
+  answers as materialized (
+    select pr.id as rid,
+           coalesce(pr.mention_count, 0) > 0 as we_mention,
+           coalesce(
+             jsonb_path_exists(pr.competitor_mentions, '$[*] ? (@.mention_count > 0)'),
+             false
+           ) as comp_present,
+           pr.competitor_mentions
+    from prompt_results pr
+    where exists (select 1 from allowed)
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or pr.created_at >= p_date_from)
+      and (p_date_to    is null or pr.created_at <= p_date_to)
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+  ),
+  adomains as materialized (
+    select distinct c.prompt_result_id as rid, cu.domain as d
+    from prompt_result_citations c
+    join citation_urls cu on cu.id = c.url_id
+    where c.brand_id = p_brand_id
+      and c.prompt_result_id in (select rid from answers)
+  ),
+  -- The suffix match runs once per distinct domain, not once per pair.
+  dtags as materialized (
+    select s.d,
+      exists (select 1 from unnest(p_brand_domains) e
+              where s.d = e or right(s.d, length(e) + 1) = '.' || e) as is_you,
+      exists (select 1 from unnest(p_competitor_domains) e
+              where s.d = e or right(s.d, length(e) + 1) = '.' || e) as is_comp
+    from (select distinct ad.d from adomains ad) s
+  ),
+  per_answer as (
+    select ad.rid, 1.0 / count(*) as w, bool_or(t.is_you) as you_cited
+    from adomains ad join dtags t on t.d = ad.d
+    group by ad.rid
+  ),
+  flags as materialized (
+    select a.rid,
+           a.we_mention or coalesce(pa.you_cited, false) as we_present,
+           a.comp_present,
+           coalesce(pa.w, 0) as w
+    from answers a
+    left join per_answer pa on pa.rid = a.rid
+  ),
+  domain_rows as (
+    select ad.d,
+      count(*) filter (where f.comp_present and not f.we_present) as competitor_answers,
+      bool_or(f.we_present) as appears,
+      coalesce(sum(f.w) filter (where f.comp_present and not f.we_present), 0) as strength
+    from adomains ad
+    join dtags t on t.d = ad.d and not t.is_you and not t.is_comp
+    join flags f on f.rid = ad.rid
+    group by ad.d
+  ),
+  -- Competitor names only exist on gap-qualifying answers, so the jsonb
+  -- expansion is bounded by those instead of the whole window. A mention of
+  -- a still-live competitor renders under its current name; a deleted one
+  -- keeps the name recorded in the answer.
+  qualifying as (
+    select f.rid from flags f where f.comp_present and not f.we_present
+  ),
+  mention_names as (
+    select q.rid,
+      case when co.id is not null
+           then coalesce(nullif(trim(co.name), ''), 'Competitor')
+           else coalesce(nullif(trim(x.e ->> 'name'), ''), 'Competitor')
+      end as cname
+    from qualifying q
+    join answers a on a.rid = q.rid,
+    lateral jsonb_array_elements(a.competitor_mentions) x(e)
+    left join competitors co
+      on co.brand_id = p_brand_id and co.id::text = x.e ->> 'competitor_id'
+    where coalesce((x.e ->> 'mention_count')::numeric, 0) > 0
+  ),
+  domain_names as (
+    select ad.d, array_agg(distinct mn.cname order by mn.cname) as names
+    from adomains ad
+    join dtags t on t.d = ad.d and not t.is_you and not t.is_comp
+    join mention_names mn on mn.rid = ad.rid
+    group by ad.d
+  ),
+  totals as (
+    select count(*)::bigint as total_answers,
+           (count(*) filter (where f.we_present))::bigint as our_answer_count
+    from flags f
+  )
+  select dr.d, dr.competitor_answers::bigint, dr.appears, dr.strength::float8,
+         coalesce(dn.names, '{}'::text[]), t.our_answer_count, t.total_answers
+  from domain_rows dr
+  left join domain_names dn on dn.d = dr.d
+  cross join totals t
+  where dr.competitor_answers > 0 or dr.appears
+  union all
+  select null, 0, false, 0, '{}'::text[], t.our_answer_count, t.total_answers
+  from totals t;
+$$;
+
+-- ─── Per-competitor source domains ──────────────────────────────────────────
+-- (competitor, third-party domain) rows for the per-competitor source map.
+-- Unlike the gap counters these accumulate from every answer mentioning the
+-- competitor, whether or not we are present — alsoCitesUs comes from joining
+-- the gap rows in the app tier. Keyed by the mention's competitor_id as
+-- recorded (text), so mentions of since-deleted competitors keep counting,
+-- exactly as the page behaves today.
+create or replace function public.citation_competitor_sources(
+  p_brand_id uuid,
+  p_brand_domains text[],
+  p_competitor_domains text[],
+  p_date_from timestamptz default null,
+  p_date_to timestamptz default null,
+  p_models text[] default null,
+  p_regions text[] default null,
+  p_prompt_ids uuid[] default null,
+  p_topic_ids uuid[] default null
+)
+returns table (
+  competitor_id text,
+  domain text,
+  answers_feeding bigint,
+  strength double precision
+)
+language sql
+stable
+security definer
+set search_path to 'public'
+set work_mem to '96MB'
+as $$
+  with allowed as (
+    select 1 from brands b
+    join profiles pf on pf.organization_id = b.organization_id
+    where b.id = p_brand_id and pf.id = auth.uid()
+  ),
+  answers as materialized (
+    select pr.id as rid, pr.competitor_mentions
+    from prompt_results pr
+    where exists (select 1 from allowed)
+      and pr.brand_id = p_brand_id
+      and pr.platform <> 'chatgpt-shopping'
+      and (p_date_from  is null or pr.created_at >= p_date_from)
+      and (p_date_to    is null or pr.created_at <= p_date_to)
+      and (p_models     is null or pr.model_used = any(p_models))
+      and (p_regions    is null or pr.region = any(p_regions))
+      and (p_prompt_ids is null or pr.prompt_id = any(p_prompt_ids))
+      and (p_topic_ids  is null or pr.prompt_id in (
+            select pp.id from public.prompts pp where pp.topic_id = any(p_topic_ids)))
+  ),
+  adomains as materialized (
+    select distinct c.prompt_result_id as rid, cu.domain as d
+    from prompt_result_citations c
+    join citation_urls cu on cu.id = c.url_id
+    where c.brand_id = p_brand_id
+      and c.prompt_result_id in (select rid from answers)
+  ),
+  dtags as materialized (
+    select s.d,
+      exists (select 1 from unnest(p_brand_domains) e
+              where s.d = e or right(s.d, length(e) + 1) = '.' || e) as is_you,
+      exists (select 1 from unnest(p_competitor_domains) e
+              where s.d = e or right(s.d, length(e) + 1) = '.' || e) as is_comp
+    from (select distinct ad.d from adomains ad) s
+  ),
+  per_answer as (
+    select ad.rid, 1.0 / count(*) as w
+    from adomains ad group by ad.rid
+  ),
+  -- Expansion bounded to answers that actually mention someone; the jsonpath
+  -- probe is far cheaper than expanding every answer's array.
+  mentions as materialized (
+    select a.rid, x.e ->> 'competitor_id' as competitor_id
+    from answers a,
+    lateral jsonb_array_elements(a.competitor_mentions) x(e)
+    where coalesce(
+            jsonb_path_exists(a.competitor_mentions, '$[*] ? (@.mention_count > 0)'),
+            false
+          )
+      and coalesce((x.e ->> 'mention_count')::numeric, 0) > 0
+  )
+  select m.competitor_id, ad.d,
+         count(distinct m.rid)::bigint as answers_feeding,
+         sum(pa.w)::float8 as strength
+  from mentions m
+  join adomains ad on ad.rid = m.rid
+  join dtags t on t.d = ad.d and not t.is_you and not t.is_comp
+  join per_answer pa on pa.rid = m.rid
+  group by m.competitor_id, ad.d;
+$$;
+
+revoke all on function public.citation_gap_domains(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+revoke all on function public.citation_competitor_sources(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) from public;
+
+grant execute on function public.citation_gap_domains(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+grant execute on function public.citation_competitor_sources(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) to authenticated, service_role;
+
+comment on function public.citation_gap_domains(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Per-domain competitor co-occurrence for the Competitor Gaps tab (#777). Third-party domains only; one null-domain summary row carries the answer totals.';
+comment on function public.citation_competitor_sources(uuid, text[], text[], timestamptz, timestamptz, text[], text[], uuid[], uuid[]) is
+  'Per-competitor source domains for the Competitor Gaps tab (#777), keyed by the competitor id recorded in the mention.';
+

--- a/web/src/lib/actions/citations.ts
+++ b/web/src/lib/actions/citations.ts
@@ -2,7 +2,6 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { expandDateToEndOfDay } from '@/lib/dates';
-import type { Citation, CompetitorMention } from '@/types';
 import {
   classifyDomain,
   extractHostname,
@@ -105,109 +104,6 @@ function resolveDateRange(filters: CitationsFilters): { from?: string; to?: stri
 }
 
 // ─── Main action ──────────────────────────────────────────────────────────────
-
-/**
- * Apply the platform/model filter to `prompt_results.model_used`.
- *
- * Supports both a single slug (`gpt-5-5`) and a comma-joined family
- * (`gpt-5-3-mini,gpt-5-5`) so the UI can filter an entire provider family
- * from one dropdown option.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function applyModelFilter<T extends { eq: any; in: any }>(
-  query: T,
-  models: string[] | undefined,
-): T {
-  if (!models || models.length === 0) return query;
-
-  const list = Array.from(
-    new Set(
-      models.flatMap((model) =>
-        model
-          .split(',')
-          .map((slug) => slug.trim())
-          .filter(Boolean),
-      ),
-    ),
-  );
-
-  if (list.length <= 1) return query.eq('model_used', list[0] ?? models[0]);
-  return query.in('model_used', list);
-}
-
-/**
- * PostgREST silently caps un-paginated selects at 1000 rows, which quietly
- * truncated every citations aggregation on brands with more than 1000 results
- * in the selected window (the overview literally reported `results: 1000`).
- * Page through the filtered window instead, feeding each batch to `onBatch` so
- * full citation payloads never accumulate in memory. Returns the total rows
- * scanned. The hard row ceiling bounds the `all` preset on huge brands.
- */
-const CITATIONS_SCAN_PAGE_SIZE = 1000;
-const CITATIONS_SCAN_MAX_ROWS = 50_000;
-
-async function scanFilteredResults<T>(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  brandId: string,
-  filters: CitationsFilters,
-  select: string,
-  onBatch: (batch: T[]) => void,
-): Promise<number> {
-  // Resolve topic → prompt ids once, not per page.
-  let topicPromptIds: string[] | null = null;
-  if (filters.topicIds && filters.topicIds.length > 0) {
-    const { data: topicPrompts } = await supabase
-      .from('prompts')
-      .select('id')
-      .in('topic_id', filters.topicIds);
-    topicPromptIds = ((topicPrompts ?? []) as { id: string }[]).map((p) => p.id);
-  }
-
-  const { from, to } = resolveDateRange(filters);
-  const expandedTo = expandDateToEndOfDay(to);
-
-  let total = 0;
-  for (let offset = 0; offset < CITATIONS_SCAN_MAX_ROWS; offset += CITATIONS_SCAN_PAGE_SIZE) {
-    let query = supabase
-      .from('prompt_results')
-      .select(select)
-      .eq('brand_id', brandId)
-      // #155 — chatgpt-shopping rows are isolated from analytical aggregates.
-      // The insights KPIs already exclude them; without this, the Citations
-      // page counted a superset of what the KPI counts.
-      .neq('platform', 'chatgpt-shopping');
-    if (from) query = query.gte('created_at', from);
-    if (expandedTo) query = query.lte('created_at', expandedTo);
-    if (filters.platforms && filters.platforms.length > 0) {
-      query = applyModelFilter(query, filters.platforms);
-    }
-    if (filters.regions && filters.regions.length > 0) {
-      query = query.in('region', filters.regions);
-    }
-    if (filters.promptIds && filters.promptIds.length > 0) {
-      query = query.in('prompt_id', filters.promptIds);
-    }
-    if (topicPromptIds) {
-      query = query.in(
-        'prompt_id',
-        topicPromptIds.length > 0 ? topicPromptIds : ['00000000-0000-0000-0000-000000000000'],
-      );
-    }
-
-    const { data, error } = await query
-      // Deterministic order so .range() pages don't shuffle between requests.
-      .order('created_at', { ascending: true })
-      .order('id', { ascending: true })
-      .range(offset, offset + CITATIONS_SCAN_PAGE_SIZE - 1);
-    if (error) throw new Error(error.message);
-
-    const batch = (data ?? []) as unknown as T[];
-    total += batch.length;
-    if (batch.length > 0) onBatch(batch);
-    if (batch.length < CITATIONS_SCAN_PAGE_SIZE) break;
-  }
-  return total;
-}
 
 /** URL rows the overview asks for. The table paginates a hundred at a time. */
 const CITATIONS_URL_LIMIT = 2000;
@@ -486,18 +382,14 @@ export async function getCitationGaps(
 ): Promise<CitationGaps> {
   const supabase = await createClient();
 
-  const { data: brandDomainRows } = await supabase
-    .from('brand_domains')
-    .select('domain')
-    .eq('brand_id', brandId);
+  const [{ data: brandDomainRows }, { data: competitorRows }, topicPromptIds] = await Promise.all([
+    supabase.from('brand_domains').select('domain').eq('brand_id', brandId),
+    supabase.from('competitors').select('id, name, domain').eq('brand_id', brandId),
+    resolveTopicPromptIds(supabase, filters),
+  ]);
   const brandDomains = (brandDomainRows ?? [])
     .map((r) => normalizeDomain((r as { domain: string }).domain))
     .filter(Boolean);
-
-  const { data: competitorRows } = await supabase
-    .from('competitors')
-    .select('id, name, domain')
-    .eq('brand_id', brandId);
   const competitorList = (competitorRows ?? []) as Array<{
     id: string;
     name: string;
@@ -510,141 +402,91 @@ export async function getCitationGaps(
 
   const classifyCtx = { brandDomains, competitorDomains };
 
-  interface GapResultRow {
-    id: string;
-    citations: Citation[] | null;
-    competitor_mentions: CompetitorMention[] | null;
-    mention_count: number | null;
-  }
-
-  interface DomainAgg {
-    domain: string;
-    category: SourceCategory;
-    competitorAnswers: Set<string>;
-    appearsInOurAnswers: boolean;
+  // The co-occurrence counting lives in SQL (#777) over the citation rows —
+  // the raw-answer scan it replaces moved 129 MB of jsonb for the largest
+  // brand and silently stopped at 50,000 answers, oldest first. The brand and
+  // competitor domain lists ride along because the you/competitor split
+  // depends on their CURRENT state; category labels for display are still
+  // computed here, with the same classifier as the rest of the page.
+  interface GapDomainRow {
+    domain: string | null;
+    competitor_answers: number;
+    appears_in_ours: boolean;
     strength: number;
-    competitorNames: Set<string>;
+    competitor_names: string[] | null;
+    our_answer_count: number;
+    total_answers: number;
   }
-  interface CompDomainAgg {
+  interface CompSourceRow {
+    competitor_id: string;
     domain: string;
-    category: SourceCategory;
-    answersFeeding: Set<string>;
+    answers_feeding: number;
     strength: number;
   }
 
-  const domainMap = new Map<string, DomainAgg>();
-  const byCompMap = new Map<string, Map<string, CompDomainAgg>>();
-  let ourAnswerCount = 0;
-  const domainClassificationCache = new Map<string, SourceCategory>();
-
-  const aggregateAnswer = (r: GapResultRow) => {
-    const citations = Array.isArray(r.citations) ? r.citations : [];
-    const domainCat = new Map<string, SourceCategory>();
-
-    for (const cite of citations) {
-      const host = extractHostname(cite.url);
-      if (!host || domainCat.has(host)) continue;
-
-      let category = domainClassificationCache.get(host);
-
-      if (category === undefined) {
-        category = classifyDomain(host, classifyCtx);
-        domainClassificationCache.set(host, category);
-      }
-
-      domainCat.set(host, category);
-    }
-    // Weight each answer's co-occurrences by 1 / distinct sources so a focused
-    // answer counts more per domain than a sprawling multi-source one.
-    const weight = domainCat.size > 0 ? 1 / domainCat.size : 0;
-
-    const ourDomainCited = Array.from(domainCat.values()).some((cat) => cat === 'you');
-    const wePresent = (r.mention_count ?? 0) > 0 || ourDomainCited;
-    if (wePresent) ourAnswerCount += 1;
-
-    const mentions = Array.isArray(r.competitor_mentions) ? r.competitor_mentions : [];
-    const mentionedCompetitors = mentions.filter((m) => (m.mention_count ?? 0) > 0);
-    const competitorPresent = mentionedCompetitors.length > 0;
-    const competitorNamesInAnswer = mentionedCompetitors.map(
-      (m) => competitorNameById.get(m.competitor_id) ?? ((m.name || '').trim() || 'Competitor'),
-    );
-
-    for (const [domain, category] of domainCat) {
-      // Only third-party publications are actionable — skip our and competitor sites.
-      if (category === 'you' || category === 'competitor') continue;
-
-      const agg = domainMap.get(domain) ?? {
-        domain,
-        category,
-        competitorAnswers: new Set<string>(),
-        appearsInOurAnswers: false,
-        strength: 0,
-        competitorNames: new Set<string>(),
-      };
-      if (wePresent) agg.appearsInOurAnswers = true;
-      if (competitorPresent && !wePresent) {
-        agg.competitorAnswers.add(r.id);
-        agg.strength += weight;
-        for (const name of competitorNamesInAnswer) agg.competitorNames.add(name);
-      }
-      domainMap.set(domain, agg);
-
-      if (competitorPresent) {
-        for (const m of mentionedCompetitors) {
-          let perDomain = byCompMap.get(m.competitor_id);
-          if (!perDomain) {
-            perDomain = new Map<string, CompDomainAgg>();
-            byCompMap.set(m.competitor_id, perDomain);
-          }
-          const cd = perDomain.get(domain) ?? {
-            domain,
-            category,
-            answersFeeding: new Set<string>(),
-            strength: 0,
-          };
-          cd.answersFeeding.add(r.id);
-          cd.strength += weight;
-          perDomain.set(domain, cd);
-        }
-      }
-    }
+  const rpcArgs = {
+    ...overviewArgs(brandId, filters, topicPromptIds),
+    p_brand_domains: brandDomains,
+    p_competitor_domains: competitorDomains,
   };
+  const [gapRes, compRes] = await Promise.all([
+    supabase.rpc('citation_gap_domains', rpcArgs),
+    supabase.rpc('citation_competitor_sources', rpcArgs),
+  ]);
+  if (gapRes.error) throw new Error(gapRes.error.message);
+  if (compRes.error) throw new Error(compRes.error.message);
 
-  const totalAnswers = await scanFilteredResults<GapResultRow>(
-    supabase,
-    brandId,
-    filters,
-    'id, citations, competitor_mentions, mention_count',
-    (batch) => {
-      for (const r of batch) aggregateAnswer(r);
-    },
-  );
+  const gapRows = (gapRes.data as GapDomainRow[] | null) ?? [];
+  // The null-domain summary row is always present, so the totals survive
+  // windows where no third-party domain qualifies.
+  const summary = gapRows.find((r) => r.domain === null);
+  const totalAnswers = Number(summary?.total_answers ?? 0);
+  const ourAnswerCount = Number(summary?.our_answer_count ?? 0);
+  const domainRows = gapRows.filter((r): r is GapDomainRow & { domain: string } => !!r.domain);
 
-  const gapDomains: CitationGapDomain[] = Array.from(domainMap.values())
-    .filter((g) => !g.appearsInOurAnswers && g.competitorAnswers.size >= GAP_MIN_COMPETITOR_ANSWERS)
-    .map((g) => ({
-      domain: g.domain,
-      category: g.category,
-      competitorAnswers: g.competitorAnswers.size,
-      competitors: Array.from(g.competitorNames).sort().slice(0, GAP_MAX_COMPETITOR_CHIPS),
-      strength: Math.round(g.strength * 1000) / 1000,
+  const domainClassificationCache = new Map<string, SourceCategory>();
+  const categoryOf = (domain: string): SourceCategory => {
+    let category = domainClassificationCache.get(domain);
+    if (category === undefined) {
+      category = classifyDomain(domain, classifyCtx);
+      domainClassificationCache.set(domain, category);
+    }
+    return category;
+  };
+  const appearsInOurs = new Map(domainRows.map((r) => [r.domain, r.appears_in_ours]));
+
+  const gapDomains: CitationGapDomain[] = domainRows
+    .filter((r) => !r.appears_in_ours && Number(r.competitor_answers) >= GAP_MIN_COMPETITOR_ANSWERS)
+    .map((r) => ({
+      domain: r.domain,
+      category: categoryOf(r.domain),
+      competitorAnswers: Number(r.competitor_answers),
+      competitors: (r.competitor_names ?? []).slice(0, GAP_MAX_COMPETITOR_CHIPS),
+      strength: Math.round(Number(r.strength) * 1000) / 1000,
     }))
     .sort((a, b) => b.strength - a.strength || b.competitorAnswers - a.competitorAnswers)
     .slice(0, GAP_MAX_ROWS);
 
+  const byCompMap = new Map<string, CompetitorSourceDomain[]>();
+  for (const row of (compRes.data as CompSourceRow[] | null) ?? []) {
+    let list = byCompMap.get(row.competitor_id);
+    if (!list) {
+      list = [];
+      byCompMap.set(row.competitor_id, list);
+    }
+    list.push({
+      domain: row.domain,
+      category: categoryOf(row.domain),
+      answersFeeding: Number(row.answers_feeding),
+      alsoCitesUs: appearsInOurs.get(row.domain) ?? false,
+      strength: Math.round(Number(row.strength) * 1000) / 1000,
+    });
+  }
   const byCompetitor: Record<string, CompetitorSourceDomain[]> = {};
-  for (const [competitorId, perDomain] of byCompMap) {
-    const list = Array.from(perDomain.values())
-      .map((cd) => ({
-        domain: cd.domain,
-        category: cd.category,
-        answersFeeding: cd.answersFeeding.size,
-        alsoCitesUs: domainMap.get(cd.domain)?.appearsInOurAnswers ?? false,
-        strength: Math.round(cd.strength * 1000) / 1000,
-      }))
+  for (const [competitorId, list] of byCompMap) {
+    byCompetitor[competitorId] = list
       .sort((a, b) => b.strength - a.strength || b.answersFeeding - a.answersFeeding)
       .slice(0, GAP_MAX_ROWS);
-    if (list.length > 0) byCompetitor[competitorId] = list;
   }
 
   const competitors: CitationGapCompetitor[] = competitorList

--- a/web/src/types/supabase.ts
+++ b/web/src/types/supabase.ts
@@ -2406,6 +2406,47 @@ export type Database = {
         }
         Returns: Json
       }
+      citation_competitor_sources: {
+        Args: {
+          p_brand_domains: string[]
+          p_brand_id: string
+          p_competitor_domains: string[]
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_prompt_ids?: string[]
+          p_regions?: string[]
+          p_topic_ids?: string[]
+        }
+        Returns: {
+          answers_feeding: number
+          competitor_id: string
+          domain: string
+          strength: number
+        }[]
+      }
+      citation_gap_domains: {
+        Args: {
+          p_brand_domains: string[]
+          p_brand_id: string
+          p_competitor_domains: string[]
+          p_date_from?: string
+          p_date_to?: string
+          p_models?: string[]
+          p_prompt_ids?: string[]
+          p_regions?: string[]
+          p_topic_ids?: string[]
+        }
+        Returns: {
+          appears_in_ours: boolean
+          competitor_answers: number
+          competitor_names: string[]
+          domain: string
+          our_answer_count: number
+          strength: number
+          total_answers: number
+        }[]
+      }
       citation_url_candidates: {
         Args: { p_brand_id: string; p_domain: string }
         Returns: {


### PR DESCRIPTION
## Summary

Closes #777.

`getCitationGaps` was the last reader on the pre-#732 path. It paged every answer in the window out to the app tier with both jsonb columns attached — **77 MB of `citations` + 52 MB of `competitor_mentions` across 62,285 rows** on the largest brand — and did all co-occurrence counting in JavaScript. Like the detail page before #776, the scan stopped at 50,000 rows **oldest-first**, so on any brand past the ceiling the newest answers were silently missing from the gap analysis.

### What changed

Two new RPCs over `prompt_result_citations` + `citation_urls`:

- `citation_gap_domains` — one row per third-party domain with the gap counters (competitor answers, appears-in-ours, weighted strength, competitor names), plus a null-domain summary row carrying the answer totals so they survive empty windows.
- `citation_competitor_sources` — (competitor, domain) rows for the per-competitor source map, keyed by the competitor id recorded in the mention so since-deleted competitors keep counting, exactly as today.

Aggregation semantics are unchanged: 1/distinct-domains weighting, "we are present" = brand mentioned OR own domain cited, gap counters only from answers where a competitor is present and we are absent, third-party domains only.

**What crosses the boundary and why.** The you/competitor split depends on the brand's *current* domain lists, so the caller passes those in and the two-line suffix rule runs in SQL, once per distinct domain. Display categories (forum/social/editorial/…) stay in the app tier with the same classifier as the rest of the page. Domain identity itself comes from `citation_urls.domain`, which is written by the same hostname extraction the page used to run per read.

**Security.** Both functions are `security definer` but carry the org-membership `allowed` guard from `report_citation_evidence` — they do not extend the unguarded pattern of the older five citation RPCs (that retrofit is a separate discussion). Verified: without a JWT the functions return only the zero-valued summary row.

**Performance.** The naive translation measured 8.6 s on the largest brand's all-time window — over the 8 s `authenticated` ceiling. Two changes brought it to **3.8 s**: `jsonb_path_exists` answers "does this answer mention any competitor" without expanding 52 MB of arrays (full expansion now runs only where entries are needed), and the domain suffix-match runs once per distinct domain (21k) instead of once per (answer, domain) pair (581k).

## Verification

All diffs on live data, full brand, zero tolerance:

| Check | Result |
|---|---|
| Base layer: (answer, domain) pairs, jsonb hosts vs `citation_urls.domain` | 135,040 vs 135,040, **0 different** |
| `citation_gap_domains` vs old-path replica (counts, flags, strength to 9 decimals, name arrays) | 2,440 vs 2,440 rows, **0 different** |
| `citation_competitor_sources` vs old-path replica | 3,397 vs 3,397 rows, **0 different** |
| `competitor_mentions` shape assumptions | 217,586 rows: all arrays, zero string-typed `mention_count` |
| Membership guard, no JWT | only the zero summary row |

Migration `00068` is **already applied** to the hosted database. `scanFilteredResults` and `applyModelFilter` had no callers left and are deleted.

## Type of change

- [x] `fix` — Bug fix
- [x] `refactor` — Code change that neither fixes a bug nor adds a feature

## How to test

- Citations → **Competitor Gaps** tab, range on **All**: should load in a few seconds and, on large brands, now includes the newest answers.
- Compare a smaller brand's gap list before/after deploy — rows and ordering should be unchanged.
- Platform/region/topic filters on the tab should behave exactly as before.

## Checklist

- [x] Branch follows the naming convention
- [x] Commits follow Conventional Commits
- [x] `yarn lint` / `yarn typecheck` / `yarn format:check` / `yarn build` pass (web)
- [x] `schema.sql` regenerated
- [x] Changes are focused — one concern per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)