### PR TITLE
perf(visibility): check brand data existence with LIMIT 1 instead of an exact COUNT

### DIFF
--- a/web/src/lib/actions/tracking.ts
+++ b/web/src/lib/actions/tracking.ts
@@ -574,18 +574,25 @@ async function getInsightsRecommendations(brandId: string): Promise<InsightsReco
   return { topics, prompts };
 }
 
-/** Cheap existence check for a brand's (non-shopping) prompt_results — counts, no rows. */
-async function getBrandResultsTotal(brandId: string): Promise<number> {
+/**
+ * Does this brand have any (non-shopping) prompt_results at all?
+ *
+ * A yes/no question, so it asks for a single row with LIMIT 1 and stops at the
+ * first match, rather than an exact COUNT that visits every matching row only
+ * to compare the total against zero.
+ */
+async function brandHasResults(brandId: string): Promise<boolean> {
   const supabase = await createClient();
-  const { count, error } = await supabase
+  const { data, error } = await supabase
     .from('prompt_results')
-    .select('id', { count: 'exact', head: true })
+    .select('id')
     .eq('brand_id', brandId)
-    .neq('platform', 'chatgpt-shopping');
-  // Throw rather than swallow: a failed count must not masquerade as "no data"
+    .neq('platform', 'chatgpt-shopping')
+    .limit(1);
+  // Throw rather than swallow: a failed check must not masquerade as "no data"
   // and silently flip the page to its empty state.
   if (error) throw new Error(error.message);
-  return count ?? 0;
+  return (data?.length ?? 0) > 0;
 }
 
 export interface InsightsData {
@@ -706,7 +713,7 @@ export async function getInsightsData(
     visibilityRate,
     filterOptions,
     recommendations,
-    unfilteredTotal,
+    unfilteredHasData,
   ] = await Promise.all([
     getInsightsSummary(brandId, filterOpts),
     getCompetitorComparison(brandId, filterOpts),
@@ -715,12 +722,12 @@ export async function getInsightsData(
     getVisibilityRateKpi(brandId, filterOpts),
     getInsightsFilterOptions(brandId),
     getInsightsRecommendations(brandId),
-    opts.checkUnfiltered ? getBrandResultsTotal(brandId) : Promise.resolve(null),
+    opts.checkUnfiltered ? brandHasResults(brandId) : Promise.resolve(null),
   ]);
 
   // insights_aggregates counts the same filtered set the summary shows, so it
   // stands in for the removed results fetch when no unfiltered check ran.
-  const hasAnyData = unfilteredTotal !== null ? unfilteredTotal > 0 : summary.totalResults > 0;
+  const hasAnyData = unfilteredHasData !== null ? unfilteredHasData : summary.totalResults > 0;
 
   return {
     summary,


### PR DESCRIPTION
## Summary

The Visibility page answered "does this brand have any data at all?" with an exact COUNT(*) over prompt_results (a ~128 MB bitmap heap scan on the largest brand) only to compare the total against zero. Since the one consumer reads it as a boolean, getBrandResultsTotal becomes brandHasResults, selecting id with .limit(1) so the planner stops at the first match (~16,500 buffers → 2). hasAnyData stays a boolean and the "no data for this filter" vs "no data at all" distinction is unchanged.

## Related issue

Closes #729 

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [x] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`)
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
