### PR TITLE
fix(onboarding): reach the API server through this origin, not the visitor's network

### DIFF
--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/[id]/prompts/page.tsx
@@ -50,7 +50,7 @@ import {
 } from '@/components/ui/dialog';
 import { Checkbox } from '@/components/ui/checkbox';
 import type { Brand, Prompt, PromptSet, Topic } from '@/types';
-import { API_BASE_URL } from '@/config/api';
+import { BROWSER_API_BASE_URL } from '@/config/api';
 
 interface UnanalyzedPrompt {
   id: string;
@@ -58,7 +58,7 @@ interface UnanalyzedPrompt {
   category: string;
 }
 
-const AEO_SERVER_URL = API_BASE_URL;
+const AEO_SERVER_URL = BROWSER_API_BASE_URL;
 
 interface SuggestedPrompt {
   text: string;

--- a/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
+++ b/web/src/app/[locale]/(dashboard)/dashboard/brands/new/page.tsx
@@ -48,9 +48,9 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { API_BASE_URL } from '@/config/api';
+import { BROWSER_API_BASE_URL } from '@/config/api';
 
-const AEO_SERVER_URL = API_BASE_URL;
+const AEO_SERVER_URL = BROWSER_API_BASE_URL;
 
 // ── Step indicator ─────────────────────────────────────────────────────────────
 

--- a/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
+++ b/web/src/app/[locale]/(onboarding)/dashboard/onboarding/page.tsx
@@ -59,9 +59,9 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { API_BASE_URL } from '@/config/api';
+import { BROWSER_API_BASE_URL } from '@/config/api';
 
-const AEO_SERVER_URL = API_BASE_URL;
+const AEO_SERVER_URL = BROWSER_API_BASE_URL;
 
 // ── Step indicator ─────────────────────────────────────────────────────────────
 

--- a/web/src/app/api/aeo/[...path]/route.ts
+++ b/web/src/app/api/aeo/[...path]/route.ts
@@ -1,0 +1,124 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { API_BASE_URL } from '@/config/api';
+
+/**
+ * Same-origin proxy to the AEO API server.
+ *
+ * A handful of client components call the API server directly from the
+ * browser (topic/prompt/competitor suggestions, tracking re-analysis). That
+ * made every visitor's own network a dependency of the signup funnel: the
+ * API host has to resolve *and* be routable from wherever they are. On
+ * 2026-08-28 the CDN range it sits on stopped accepting TCP from a Turkish
+ * ISP, and onboarding died with "Couldn't fetch topic suggestions right now"
+ * for anyone on that network — with no trace in the API server's logs or
+ * Supabase's, because the request never left the browser.
+ *
+ * Routing those calls through this handler means the only host a visitor
+ * connects to is the one already serving them the page. The hop to
+ * API_BASE_URL happens from our infrastructure instead, where reachability
+ * is ours to guarantee.
+ *
+ * The upstream path is forwarded verbatim, so `/api/aeo/api/topics/suggest`
+ * reaches `${API_BASE_URL}/api/topics/suggest` and server routes still line
+ * up one-to-one with what the browser asked for.
+ *
+ * Auth is unchanged: the caller's Supabase bearer token rides through and
+ * the API server authorizes it exactly as before. This handler adds no
+ * authority of its own — it forwards, it does not authenticate.
+ */
+
+/**
+ * The suggestion endpoints run two LLM calls back to back (web research, then
+ * structured extraction) — measured at ~12s for topics and longer for prompts
+ * on a whole topic set. The platform default would cut them off.
+ */
+export const maxDuration = 300;
+
+/** Never cache a proxied call: every one of these is per-brand and mutating-ish. */
+export const dynamic = 'force-dynamic';
+
+/**
+ * Headers that describe *this* connection rather than the request, and so
+ * must not be replayed upstream — `host` would misroute virtual hosts, and a
+ * stale `content-length` contradicts the body we re-send.
+ */
+const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+async function forward(request: NextRequest, params: Promise<{ path: string[] }>) {
+  const { path } = await params;
+
+  if (!/^https?:\/\//.test(API_BASE_URL)) {
+    return NextResponse.json({ error: 'API server is not configured' }, { status: 500 });
+  }
+
+  const upstream = new URL(`${API_BASE_URL}/${(path ?? []).join('/')}`);
+  upstream.search = request.nextUrl.search;
+
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_REQUEST_HEADERS.has(key.toLowerCase())) headers.set(key, value);
+  });
+
+  const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
+
+  let response: Response;
+  try {
+    response = await fetch(upstream, {
+      method: request.method,
+      headers,
+      body: hasBody ? await request.arrayBuffer() : undefined,
+      cache: 'no-store',
+    });
+  } catch (err) {
+    // The upstream being unreachable used to surface as an opaque browser
+    // network error. Name it, so the next outage is one log line away.
+    console.error('[aeo-proxy] upstream unreachable', upstream.pathname, err);
+    return NextResponse.json({ error: 'API server is unreachable' }, { status: 502 });
+  }
+
+  // Only content-type is copied. `fetch` has already decoded the body, so
+  // replaying content-encoding or content-length would describe bytes that no
+  // longer exist and the browser would fail to parse the response.
+  const responseHeaders = new Headers();
+  const contentType = response.headers.get('content-type');
+  if (contentType) responseHeaders.set('content-type', contentType);
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+}
+
+type Context = { params: Promise<{ path: string[] }> };
+
+export async function GET(request: NextRequest, { params }: Context) {
+  return forward(request, params);
+}
+
+export async function POST(request: NextRequest, { params }: Context) {
+  return forward(request, params);
+}
+
+export async function PUT(request: NextRequest, { params }: Context) {
+  return forward(request, params);
+}
+
+export async function PATCH(request: NextRequest, { params }: Context) {
+  return forward(request, params);
+}
+
+export async function DELETE(request: NextRequest, { params }: Context) {
+  return forward(request, params);
+}

--- a/web/src/config/api.ts
+++ b/web/src/config/api.ts
@@ -1,5 +1,28 @@
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:80';
 
+/**
+ * Base the *browser* uses to reach the API server.
+ *
+ * Deliberately same-origin and relative: a fetch from the visitor's machine
+ * to another host makes their network a dependency of ours, and when that
+ * fails there is nothing in any of our logs to see. Requests to this prefix
+ * land on the proxy route handler, which forwards them to API_BASE_URL from
+ * our own infrastructure. See `app/api/aeo/[...path]/route.ts`.
+ *
+ * Code that already runs on our side — server actions in `lib/actions/*`,
+ * route handlers, cron — should keep using API_BASE_URL and call the server
+ * directly rather than looping back through this.
+ */
+export const BROWSER_API_BASE_URL = '/api/aeo';
+
+/**
+ * Absolute, public origin of the API server.
+ *
+ * Only for URLs that are rendered for somewhere *outside* this app — today
+ * that is the tracking snippet the customer pastes into their own site, whose
+ * `<script src>` has to name a real host. Anything fetched by our own pages
+ * belongs on BROWSER_API_BASE_URL instead.
+ */
 export function getPublicApiBaseUrl(): string {
   const isCloud = process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
 


### PR DESCRIPTION
## Summary

Onboarding fails with `Couldn't fetch topic suggestions right now — add your own below.` for any visitor whose network cannot route to the API host, and nothing in our logs records it.

Ten `fetch` calls across three client components name the API server directly, which makes every visitor's own network a dependency of the signup funnel:

| File | Endpoints called from the browser |
|---|---|
| `(onboarding)/dashboard/onboarding/page.tsx` | `topics/suggest`, `prompts/from-topics`, `competitors/suggest` |
| `(dashboard)/dashboard/brands/new/page.tsx` | `topics/suggest`, `prompts/from-topics`, `competitors/suggest` |
| `(dashboard)/dashboard/brands/[id]/prompts/page.tsx` | `tracking/unanalyzed`, `prompts/from-topics`, `tracking/analyze-new` |

Everything else already goes through server actions in `lib/actions/*`, which runs on our infrastructure — that is exactly why only the signup funnel broke while the rest of the app kept working.

### What happened

The CDN range the API host resolves to stopped accepting TCP from one ISP. Measured from an affected machine:

```
API host :443 / :80 / :8080     connection refused
ICMP to that IP                 reaches it, 3 hops, 33 ms
another IP in the same /20:443  refused
a different CDN range :443      open
same host via an outside relay  200 — the API server answers normally
```

The server was healthy throughout; the browser simply could not open a socket. Because the request never left the machine, the API server's logs and Supabase's were both silent. The database shows the break plainly: a brand created at 10:42 UTC got 8 topics and 40 prompts, the one created at 15:56 UTC got zero of each.

### The change

Add a proxy route handler at `/api/aeo/[...path]` and point the three client components at it via a new `BROWSER_API_BASE_URL`. The browser now connects only to the origin already serving it the page; the hop to `API_BASE_URL` happens from our infrastructure, where reachability is ours to guarantee.

- The upstream path is forwarded verbatim, so `/api/aeo/api/topics/suggest` reaches `${API_BASE_URL}/api/topics/suggest` and server routes still line up one-to-one with what the browser asked for. No call sites were rewritten — only the base constant.
- The caller's Supabase bearer token rides through unchanged. The handler forwards; it does not authenticate, and it adds no authority of its own.
- `maxDuration = 300`, because these endpoints run two LLM calls back to back (~12 s for topics, longer for a full prompt set).
- An unreachable upstream now returns a logged `502` instead of an opaque browser network error, so the next occurrence is one log line away.
- Only `content-type` is copied from the upstream response: `fetch` has already decoded the body, so replaying `content-encoding`/`content-length` would describe bytes that no longer exist.

`API_BASE_URL` stays for server-side callers. `getPublicApiBaseUrl()` stays absolute and is now documented as such — it builds the tracking snippet customers paste into their own sites, where a relative URL would be wrong.

This does not work around the ISP block. The block stands; the fix is that a visitor's network no longer has to reach that host at all.

## Related issue

No existing issue — found while reproducing a failed signup.

## Type of change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance / dependencies
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `test` — Adding or updating tests

## How to test

Verified against a production build (`yarn build` + `yarn start`) pointed at a running API server:

1. `POST /api/aeo/api/topics/suggest` with no auth returns the upstream's own `401 {"message":"Missing authorization token"}` — status and JSON body forwarded intact.
2. The same call with a bogus `Authorization: Bearer` header returns `401 {"message":"Unauthorized API Request"}`. The message changing proves the header reaches the upstream rather than being dropped.
3. A query string on a `GET` is forwarded (`?x=1` reaches the upstream route).
4. In the built client bundle, `API_BASE_URL` is gone entirely — no chunk contains the fallback `localhost:80`, and the only remaining mention of the API host is inside `getPublicApiBaseUrl`.

After deploy, the end-to-end check is onboarding itself: create a brand and confirm topic suggestions arrive, including from a network that cannot reach the API host directly.

## Checklist

- [x] Branch follows the naming convention (`feature/`, `fix/`, `chore/`, `docs/`) — see [CONTRIBUTING.md](https://github.com/ansvisor/ansvisor/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `yarn lint` passes (run from `web/`) — 0 errors
- [x] `yarn typecheck` passes (run from `web/`)
- [x] `yarn format:check` passes (run from `web/`)
- [x] Changes are focused — one concern per PR
