### PR TITLE
fix(prompts): keep examples within schema bounds

### DIFF
--- a/server/src/routes/prompts.js
+++ b/server/src/routes/prompts.js
@@ -630,7 +630,7 @@ router.post('/from-topics', async (req, res) => {
 
 RULES:
 - Keep prompts SHORT and concise — between 30 and 100 characters. Aim for 40-80 characters.
-- Write them like real quick searches, e.g. "best CRM for small business" or "top email marketing tools ${new Date().getFullYear()}".
+- Write them like real quick searches, e.g. "best CRM software for growing small businesses" or "top email marketing tools for startups in ${new Date().getFullYear()}".
 - Do NOT use the brand name "${brandName}" in the prompts.
 - Each prompt should be relevant to the specific topic it belongs to.
 - Focus on queries where the brand could organically appear in AI-generated answers.

--- a/server/src/routes/prompts.test.js
+++ b/server/src/routes/prompts.test.js
@@ -9,8 +9,11 @@ describe('topic prompt examples', () => {
     const schema = source.match(
       /const topicPromptSchema[\s\S]*?prompts: z\.array\(z\.string\(\)\.min\((\d+)\)\.max\((\d+)\)/,
     );
+    expect(schema).not.toBeNull();
     const bounds = { min: Number(schema[1]), max: Number(schema[2]) };
-    const examples = source.match(/e\.g\. "([^"]+)" or "([^"]+)"/).slice(1);
+    const rule = source.match(/- Write them like real quick searches, e\.g\. ([^\n]+)$/m);
+    expect(rule).not.toBeNull();
+    const examples = [...rule[1].matchAll(/"([^"]+)"/g)].map(([, example]) => example);
     const currentYear = String(new Date().getFullYear());
     const resolvedExamples = examples.map((example) =>
       example.replace('${new Date().getFullYear()}', currentYear),

--- a/server/src/routes/prompts.test.js
+++ b/server/src/routes/prompts.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const source = readFileSync(fileURLToPath(new URL('./prompts.js', import.meta.url)), 'utf8');
+
+describe('topic prompt examples', () => {
+  it('keeps every documented example within the prompt schema bounds', () => {
+    const schema = source.match(
+      /const topicPromptSchema[\s\S]*?prompts: z\.array\(z\.string\(\)\.min\((\d+)\)\.max\((\d+)\)/,
+    );
+    const bounds = { min: Number(schema[1]), max: Number(schema[2]) };
+    const examples = source.match(/e\.g\. "([^"]+)" or "([^"]+)"/).slice(1);
+    const currentYear = String(new Date().getFullYear());
+    const resolvedExamples = examples.map((example) =>
+      example.replace('${new Date().getFullYear()}', currentYear),
+    );
+
+    for (const example of resolvedExamples) {
+      expect(example.length).toBeGreaterThanOrEqual(bounds.min);
+      expect(example.length).toBeLessThanOrEqual(bounds.max);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The `/api/prompts/from-topics` schema requires every generated prompt to contain 30–100 characters, but its first example was only 27 characters. A model following that example could therefore produce an otherwise valid response that Zod rejects and the route retries.

## Approach

- Replace both examples with natural 46-character queries that sit comfortably inside the existing bounds.
- Add a focused regression test that reads the examples and the schema bounds from the route source, resolves the dynamic year, and checks every example against those bounds.

## Tests

- `vitest run src/routes/prompts.test.js`
- `vitest run` — 29 files, 405 tests passed
- `eslint .`
- Prettier verification for both changed files
- `git diff --check upstream/main...HEAD`

## Risk

Low. This changes only instructional example text; the schema, API response, retry behavior, dependencies, authentication, and database behavior are unchanged.

## Exclusions

- No schema-bound changes
- No retry or provider changes
- No unrelated prompt cleanup

Closes #797
