### PR TITLE
test(web): add unit tests for getActiveEngineIdsForPlan

### DIFF
--- a/web/src/lib/plan-engines.test.ts
+++ b/web/src/lib/plan-engines.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ALL_MODELS, ALL_SCRAPERS } from '@/config/prompt-options';
+import { getActiveEngineIdsForPlan } from './plan-engines';
+
+// This module also exports the Supabase-backed alignPromptsToPlanForOrg, so
+// importing it pulls in the service-role client — which throws at import time
+// when NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are unset, as they
+// are in CI. Only the pure gating helper is under test, so a stub is enough.
+vi.mock('@/lib/supabase/admin', () => ({ supabaseAdmin: {} }));
+
+const ALL_SCRAPER_IDS = ALL_SCRAPERS.map((s) => s.id);
+const ALL_MODEL_IDS = ALL_MODELS.map((m) => m.id);
+
+const STARTER_SCRAPER_IDS = ['chatgpt-web', 'perplexity-web'];
+
+/**
+ * getPlan() short-circuits to the self-hosted plan unless the instance is
+ * cloud, so every cloud expectation has to set the flag the helper reads.
+ */
+function useCloud(isCloud: boolean) {
+  vi.stubEnv('NEXT_PUBLIC_IS_CLOUD', isCloud ? 'true' : 'false');
+}
+
+describe('getActiveEngineIdsForPlan', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  /**
+   * The rule under test (#800): an absent `allowedScrapers` / `allowedModels`
+   * means every engine is allowed, while an array — even an empty one — means
+   * only the listed ids are.
+   */
+  it('gives Starter only the scrapers it lists and no API models', () => {
+    useCloud(true);
+
+    expect(getActiveEngineIdsForPlan('starter')).toEqual({
+      platforms: STARTER_SCRAPER_IDS,
+      models: [],
+    });
+  });
+
+  it('gives Growth every scraper but still no API models', () => {
+    useCloud(true);
+
+    expect(getActiveEngineIdsForPlan('growth')).toEqual({
+      platforms: ALL_SCRAPER_IDS,
+      models: [],
+    });
+  });
+
+  it('leaves Enterprise API models to plan_overrides', () => {
+    useCloud(true);
+
+    // alignPromptsToPlanForOrg layers organizations.plan_overrides.allowedModels
+    // on top of this, so the plan-level answer stays "no models".
+    expect(getActiveEngineIdsForPlan('enterprise')).toEqual({
+      platforms: ALL_SCRAPER_IDS,
+      models: [],
+    });
+  });
+
+  it('gives Self-Hosted every scraper and every model', () => {
+    useCloud(true);
+
+    expect(getActiveEngineIdsForPlan('self_hosted')).toEqual({
+      platforms: ALL_SCRAPER_IDS,
+      models: ALL_MODEL_IDS,
+    });
+  });
+
+  it('falls back to Starter for a missing, empty or unknown plan id', () => {
+    useCloud(true);
+
+    for (const planId of [undefined, null, '', 'not-a-plan']) {
+      expect(getActiveEngineIdsForPlan(planId)).toEqual({
+        platforms: STARTER_SCRAPER_IDS,
+        models: [],
+      });
+    }
+  });
+
+  it('ignores the plan id on a self-hosted instance', () => {
+    useCloud(false);
+
+    // isCloud() is false, so getPlan() returns the self-hosted plan whatever
+    // the caller asked for — even a Starter org gets every engine.
+    expect(getActiveEngineIdsForPlan('starter')).toEqual({
+      platforms: ALL_SCRAPER_IDS,
+      models: ALL_MODEL_IDS,
+    });
+  });
+
+  it('defaults to self-hosted when NEXT_PUBLIC_IS_CLOUD is unset', () => {
+    vi.unstubAllEnvs();
+
+    expect(getActiveEngineIdsForPlan('starter')).toEqual({
+      platforms: ALL_SCRAPER_IDS,
+      models: ALL_MODEL_IDS,
+    });
+  });
+
+  it('returns fresh arrays so callers cannot mutate the plan config', () => {
+    useCloud(true);
+
+    const first = getActiveEngineIdsForPlan('growth');
+    first.platforms.push('mutated');
+    first.models.push('mutated');
+
+    expect(getActiveEngineIdsForPlan('growth')).toEqual({
+      platforms: ALL_SCRAPER_IDS,
+      models: [],
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `web/src/lib/plan-engines.test.ts` covering `getActiveEngineIdsForPlan`, whose central three-way rule (`allowedScrapers` / `allowedModels` absent → everything allowed; an array, even empty → only the listed ids; unknown/missing plan id → `starter`) had no test coverage. Closes #800.

## Coverage

| Case | Expectation |
| --- | --- |
| `starter` (cloud) | `allowedModels: []` resolves to **no** models, only the two listed scrapers |
| `growth` (cloud) | every scraper, still no API models |
| `enterprise` (cloud) | every scraper, no plan-level models (`plan_overrides` are layered on downstream by `alignPromptsToPlanForOrg`) |
| `self_hosted` (cloud) | every scraper and every model |
| `undefined` / `null` / `''` / `'not-a-plan'` | same as `starter` (fallback) |
| self-hosted instance, non-self-hosted id | id is ignored, everything allowed |
| `NEXT_PUBLIC_IS_CLOUD` unset | defaults to self-hosted |
| return value | fresh arrays, so callers cannot mutate the plan config |

## Notes

- Scoped to the pure helper only, as suggested: `alignPromptsToPlanForOrg` talks to the database and deserves its own issue.
- Importing the module also pulls in the service-role Supabase client, which throws at import time when `SUPABASE_SERVICE_ROLE_KEY` is unset (as in CI). The test stubs `@/lib/supabase/admin` with `vi.mock` so only the gating logic is under test; `vi.stubEnv` drives the cloud/self-hosted branch.
- Expected ids are derived from `ALL_SCRAPERS` / `ALL_MODELS` in `@/config/prompt-options` rather than hard-coded, so the suite keeps passing when the catalog grows.

## Verification

```
npx vitest run src/lib/plan-engines.test.ts   # 8 passed
npx prettier --check src/lib/plan-engines.test.ts  # All matched files use Prettier code style!
yarn test / yarn format:check                 # green
# Note: I installed deps with `npm install`, which resolves newer supabase
# typings than web/yarn.lock and surfaces 4 unrelated errors in
# src/lib/actions/* under tsc --noEmit. CI's `yarn install --frozen-lockfile`
# path is unaffected by that drift, and none of the 4 files are touched here.
```
